### PR TITLE
Atualização urls QrCode

### DIFF
--- a/NFe.Utils/InformacoesSuplementares/ExtinfNFeSupl.cs
+++ b/NFe.Utils/InformacoesSuplementares/ExtinfNFeSupl.cs
@@ -73,15 +73,25 @@ namespace NFe.Utils.InformacoesSuplementares
         {
             var endQrCodeNfce = new List<EnderecoConsultaPublicaNfce>
             {
-                new EnderecoConsultaPublicaNfce(Estado.AC, TipoAmbiente.taProducao, TipoUrlConsultaPublica.UrlQrCode, "http://www.sefaznet.ac.gov.br/nfce/qrcode"),
+                new EnderecoConsultaPublicaNfce(Estado.AC, TipoAmbiente.taProducao, TipoUrlConsultaPublica.UrlQrCode, "http://hml.sefaznet.ac.gov.br/nfce/qrcode"),
                 new EnderecoConsultaPublicaNfce(Estado.AC, TipoAmbiente.taProducao, TipoUrlConsultaPublica.UrlConsulta, "http://www.sefaznet.ac.gov.br/nfce/"),
                 new EnderecoConsultaPublicaNfce(Estado.AC, TipoAmbiente.taHomologacao, TipoUrlConsultaPublica.UrlQrCode, "http://hml.sefaznet.ac.gov.br/nfce/qrcode"),
                 new EnderecoConsultaPublicaNfce(Estado.AC, TipoAmbiente.taHomologacao, TipoUrlConsultaPublica.UrlConsulta, "http://hml.sefaznet.ac.gov.br/nfce/"),
+
+                new EnderecoConsultaPublicaNfce(Estado.AL, TipoAmbiente.taProducao, TipoUrlConsultaPublica.UrlQrCode, "http://nfce.sefaz.al.gov.br/QRCode/consultarNFCe.jsp"),
+                new EnderecoConsultaPublicaNfce(Estado.AL, TipoAmbiente.taProducao, TipoUrlConsultaPublica.UrlConsulta, "http://nfce.sefaz.al.gov.br/consultaNFCe.htm"),
+                new EnderecoConsultaPublicaNfce(Estado.AL, TipoAmbiente.taHomologacao, TipoUrlConsultaPublica.UrlQrCode, "http://nfce.sefaz.al.gov.br/QRCode/consultarNFCe.jsp"),
+                new EnderecoConsultaPublicaNfce(Estado.AL, TipoAmbiente.taHomologacao, TipoUrlConsultaPublica.UrlConsulta, "http://nfce.sefaz.al.gov.br/consultaNFCe.htm"),
 
                 new EnderecoConsultaPublicaNfce(Estado.AM, TipoAmbiente.taProducao, TipoUrlConsultaPublica.UrlQrCode, "http://sistemas.sefaz.am.gov.br/nfceweb/consultarNFCe.jsp"),
                 new EnderecoConsultaPublicaNfce(Estado.AM, TipoAmbiente.taProducao, TipoUrlConsultaPublica.UrlConsulta, "http://sistemas.sefaz.am.gov.br/nfceweb/formConsulta.do"),
                 new EnderecoConsultaPublicaNfce(Estado.AM, TipoAmbiente.taHomologacao, TipoUrlConsultaPublica.UrlQrCode, "http://homnfce.sefaz.am.gov.br/nfceweb/consultarNFCe.jsp"),
                 new EnderecoConsultaPublicaNfce(Estado.AM, TipoAmbiente.taHomologacao, TipoUrlConsultaPublica.UrlConsulta, "http://homnfce.sefaz.am.gov.br/nfceweb/formConsulta.do"),
+
+                new EnderecoConsultaPublicaNfce(Estado.AP, TipoAmbiente.taProducao, TipoUrlConsultaPublica.UrlQrCode, "https://www.sefaz.ap.gov.br/nfce/nfcep.php"),
+                new EnderecoConsultaPublicaNfce(Estado.AP, TipoAmbiente.taProducao, TipoUrlConsultaPublica.UrlConsulta, "https://www.sefaz.ap.gov.br/sate/seg/SEGf_AcessarFuncao.jsp?cdFuncao=FIS_1261"),
+                new EnderecoConsultaPublicaNfce(Estado.AP, TipoAmbiente.taHomologacao, TipoUrlConsultaPublica.UrlQrCode, "https://www.sefaz.ap.gov.br/nfcehml/nfce.php"),
+                new EnderecoConsultaPublicaNfce(Estado.AP, TipoAmbiente.taHomologacao, TipoUrlConsultaPublica.UrlConsulta, "https://www.sefaz.ap.gov.br/sate1/seg/SEGf_AcessarFuncao.jsp?cdFuncao=FIS_1261"),
 
                 new EnderecoConsultaPublicaNfce(Estado.BA, TipoAmbiente.taProducao, TipoUrlConsultaPublica.UrlQrCode, "http://nfe.sefaz.ba.gov.br/servicos/nfce/modulos/geral/NFCEC_consulta_chave_acesso.aspx"),
                 new EnderecoConsultaPublicaNfce(Estado.BA, TipoAmbiente.taProducao, TipoUrlConsultaPublica.UrlConsulta, "http://nfe.sefaz.ba.gov.br/servicos/nfce/default.aspx"),
@@ -93,15 +103,25 @@ namespace NFe.Utils.InformacoesSuplementares
                 new EnderecoConsultaPublicaNfce(Estado.DF, TipoAmbiente.taHomologacao, TipoUrlConsultaPublica.UrlQrCode, "http://dec.fazenda.df.gov.br/ConsultarNFCe.aspx"),
                 new EnderecoConsultaPublicaNfce(Estado.DF, TipoAmbiente.taHomologacao, TipoUrlConsultaPublica.UrlConsulta, "http://dec.fazenda.df.gov.br/nfce"),
 
-                new EnderecoConsultaPublicaNfce(Estado.GO, TipoAmbiente.taProducao, TipoUrlConsultaPublica.UrlQrCode, "http://nfe.sefaz.go.gov.br/nfeweb/jsp/ConsultaDANFENFCe.jsf"),
-                new EnderecoConsultaPublicaNfce(Estado.GO, TipoAmbiente.taProducao, TipoUrlConsultaPublica.UrlConsulta, "http://nfe.sefaz.go.gov.br/nfeweb/jsp/ConsultaDANFENFCe.jsf"),
-                new EnderecoConsultaPublicaNfce(Estado.GO, TipoAmbiente.taHomologacao, TipoUrlConsultaPublica.UrlQrCode, "http://homolog.sefaz.go.gov.br/nfeweb/jsp/ConsultaDANFENFCe.jsf​​"),
-                new EnderecoConsultaPublicaNfce(Estado.GO, TipoAmbiente.taHomologacao, TipoUrlConsultaPublica.UrlConsulta, "http://homolog.sefaz.go.gov.br/nfeweb/jsp/ConsultaDANFENFCe.jsf​​"),
+                new EnderecoConsultaPublicaNfce(Estado.GO, TipoAmbiente.taProducao, TipoUrlConsultaPublica.UrlQrCode, "http://nfe.sefaz.go.gov.br/nfeweb/sites/nfce/danfeNFCe"),
+                new EnderecoConsultaPublicaNfce(Estado.GO, TipoAmbiente.taProducao, TipoUrlConsultaPublica.UrlConsulta, "http://nfe.sefaz.go.gov.br/nfeweb/sites/nfce/ConsultaDANFENFCe"),
+                new EnderecoConsultaPublicaNfce(Estado.GO, TipoAmbiente.taHomologacao, TipoUrlConsultaPublica.UrlQrCode, "http://homolog.sefaz.go.gov.br/nfeweb/sites/nfce/danfeNFCe"),
+                new EnderecoConsultaPublicaNfce(Estado.GO, TipoAmbiente.taHomologacao, TipoUrlConsultaPublica.UrlConsulta, "http://homolog.sefaz.go.gov.br/nfeweb/sites/nfce/ConsultaDANFENFCe"),
+
+                new EnderecoConsultaPublicaNfce(Estado.ES, TipoAmbiente.taProducao, TipoUrlConsultaPublica.UrlQrCode, "http://app.sefaz.es.gov.br/ConsultaNFCe/qrcode.aspx"),
+                new EnderecoConsultaPublicaNfce(Estado.ES, TipoAmbiente.taProducao, TipoUrlConsultaPublica.UrlConsulta, "http://app.sefaz.es.gov.br/ConsultaNFCe"),
+                new EnderecoConsultaPublicaNfce(Estado.ES, TipoAmbiente.taHomologacao, TipoUrlConsultaPublica.UrlQrCode, "http://homologacao.sefaz.es.gov.br/ConsultaNFCe/qrcode.aspx"),
+                new EnderecoConsultaPublicaNfce(Estado.ES, TipoAmbiente.taHomologacao, TipoUrlConsultaPublica.UrlConsulta, "http://homologacao.sefaz.es.gov.br/ConsultaNFCe"),
 
                 new EnderecoConsultaPublicaNfce(Estado.MA, TipoAmbiente.taProducao, TipoUrlConsultaPublica.UrlQrCode, "http://www.nfce.sefaz.ma.gov.br/portal/consultarNFCe.jsp"),
                 new EnderecoConsultaPublicaNfce(Estado.MA, TipoAmbiente.taProducao, TipoUrlConsultaPublica.UrlConsulta, "http://www.nfce.sefaz.ma.gov.br/portal/consultaNFe.do"),
                 new EnderecoConsultaPublicaNfce(Estado.MA, TipoAmbiente.taHomologacao, TipoUrlConsultaPublica.UrlQrCode, "http://www.hom.nfce.sefaz.ma.gov.br/portal/consultarNFCe.jsp"),
                 new EnderecoConsultaPublicaNfce(Estado.MA, TipoAmbiente.taHomologacao, TipoUrlConsultaPublica.UrlConsulta, "http://www.hom.nfce.sefaz.ma.gov.br/portal/consultaNFe.do"),
+
+                new EnderecoConsultaPublicaNfce(Estado.MS, TipoAmbiente.taProducao, TipoUrlConsultaPublica.UrlQrCode, "http://www.dfe.ms.gov.br/nfce/qrcode"),
+                new EnderecoConsultaPublicaNfce(Estado.MS, TipoAmbiente.taProducao, TipoUrlConsultaPublica.UrlConsulta, "http://www.dfe.ms.gov.br/nfce/chavedeacesso"),
+                new EnderecoConsultaPublicaNfce(Estado.MS, TipoAmbiente.taHomologacao, TipoUrlConsultaPublica.UrlQrCode, "http://www.dfe.ms.gov.br/nfce/qrcode"),
+                new EnderecoConsultaPublicaNfce(Estado.MS, TipoAmbiente.taHomologacao, TipoUrlConsultaPublica.UrlConsulta, "http://www.dfe.ms.gov.br/nfce/chavedeacesso"),
 
                 new EnderecoConsultaPublicaNfce(Estado.MT, TipoAmbiente.taProducao, TipoUrlConsultaPublica.UrlQrCode, "http://www.sefaz.mt.gov.br/nfce/consultanfce"),
                 new EnderecoConsultaPublicaNfce(Estado.MT, TipoAmbiente.taProducao, TipoUrlConsultaPublica.UrlConsulta, "http://www.sefaz.mt.gov.br/nfce/consultanfce"),
@@ -118,14 +138,19 @@ namespace NFe.Utils.InformacoesSuplementares
                 new EnderecoConsultaPublicaNfce(Estado.PB, TipoAmbiente.taHomologacao, TipoUrlConsultaPublica.UrlQrCode, "https://www6.receita.pb.gov.br/atf/seg/SEGf_AcessarFuncao.jsp?cdFuncao=FIS_1410"),
                 new EnderecoConsultaPublicaNfce(Estado.PB, TipoAmbiente.taHomologacao, TipoUrlConsultaPublica.UrlConsulta, "https://www6.receita.pb.gov.br/atf/seg/SEGf_AcessarFuncao.jsp?cdFuncao=FIS_1410"),
 
+                new EnderecoConsultaPublicaNfce(Estado.PE, TipoAmbiente.taProducao, TipoUrlConsultaPublica.UrlQrCode, "http://nfce.sefaz.pe.gov.br/nfce-web/consultarNFCe"),
+                new EnderecoConsultaPublicaNfce(Estado.PE, TipoAmbiente.taProducao, TipoUrlConsultaPublica.UrlConsulta, "http://nfce.sefaz.pe.gov.br/nfce-web/entradaConsNfce"),
+                new EnderecoConsultaPublicaNfce(Estado.PE, TipoAmbiente.taHomologacao, TipoUrlConsultaPublica.UrlQrCode, "http://nfcehomolog.sefaz.pe.gov.br/nfce-web/consultarNFCe"),
+                new EnderecoConsultaPublicaNfce(Estado.PE, TipoAmbiente.taHomologacao, TipoUrlConsultaPublica.UrlConsulta, "http://nfcehomolog.sefaz.pe.gov.br/nfce-web/entradaConsNfce"),
+
                 new EnderecoConsultaPublicaNfce(Estado.PI, TipoAmbiente.taProducao, TipoUrlConsultaPublica.UrlQrCode, "http://webas.sefaz.pi.gov.br/nfceweb/consultarNFCe.jsf"),
                 new EnderecoConsultaPublicaNfce(Estado.PI, TipoAmbiente.taProducao, TipoUrlConsultaPublica.UrlConsulta, "http://webas.sefaz.pi.gov.br/nfceweb/consultarNFCe.jsf"),
                 new EnderecoConsultaPublicaNfce(Estado.PI, TipoAmbiente.taHomologacao, TipoUrlConsultaPublica.UrlQrCode, "http://webas.sefaz.pi.gov.br/nfceweb-homologacao/consultarNFCe.jsf"),
                 new EnderecoConsultaPublicaNfce(Estado.PI, TipoAmbiente.taHomologacao, TipoUrlConsultaPublica.UrlConsulta, "http://webas.sefaz.pi.gov.br/nfceweb-homologacao/consultarNFCe.jsf"),
 
-                new EnderecoConsultaPublicaNfce(Estado.PR, TipoAmbiente.taProducao, TipoUrlConsultaPublica.UrlQrCode, "www.dfeportal.fazenda.pr.gov.br/dfe-portal/rest/servico/consultaNFCe"),
+                new EnderecoConsultaPublicaNfce(Estado.PR, TipoAmbiente.taProducao, TipoUrlConsultaPublica.UrlQrCode, "http://www.dfeportal.fazenda.pr.gov.br/dfe-portal/rest/servico/consultaNFCe"),
                 new EnderecoConsultaPublicaNfce(Estado.PR, TipoAmbiente.taProducao, TipoUrlConsultaPublica.UrlConsulta, "http://www.fazenda.pr.gov.br/"),
-                new EnderecoConsultaPublicaNfce(Estado.PR, TipoAmbiente.taHomologacao, TipoUrlConsultaPublica.UrlQrCode, "www.dfeportal.fazenda.pr.gov.br/dfe-portal/rest/servico/consultaNFCe"),
+                new EnderecoConsultaPublicaNfce(Estado.PR, TipoAmbiente.taHomologacao, TipoUrlConsultaPublica.UrlQrCode, "http://www.dfeportal.fazenda.pr.gov.br/dfe-portal/rest/servico/consultaNFCe"),
                 new EnderecoConsultaPublicaNfce(Estado.PR, TipoAmbiente.taHomologacao, TipoUrlConsultaPublica.UrlConsulta, "http://www.fazenda.pr.gov.br/"),
 
                 new EnderecoConsultaPublicaNfce(Estado.RJ, TipoAmbiente.taProducao, TipoUrlConsultaPublica.UrlQrCode, "http://www4.fazenda.rj.gov.br/consultaNFCe/QRCode"),
@@ -134,22 +159,24 @@ namespace NFe.Utils.InformacoesSuplementares
                 new EnderecoConsultaPublicaNfce(Estado.RJ, TipoAmbiente.taHomologacao, TipoUrlConsultaPublica.UrlConsulta, "http://nfce.fazenda.rj.gov.br/consulta"),
 
                 new EnderecoConsultaPublicaNfce(Estado.RN, TipoAmbiente.taProducao, TipoUrlConsultaPublica.UrlQrCode, "http://nfce.set.rn.gov.br/consultarNFCe.aspx"),
-                new EnderecoConsultaPublicaNfce(Estado.RN, TipoAmbiente.taProducao, TipoUrlConsultaPublica.UrlConsulta, "http://nfce.set.rn.gov.br/consultarNFCe.aspx"),
                 new EnderecoConsultaPublicaNfce(Estado.RN, TipoAmbiente.taProducao, TipoUrlConsultaPublica.UrlConsulta, "http://nfce.set.rn.gov.br/portalDFE/NFCe/ConsultaNFCe.aspx"),
-                new EnderecoConsultaPublicaNfce(Estado.RN, TipoAmbiente.taHomologacao, TipoUrlConsultaPublica.UrlQrCode, "http://nfce.set.rn.gov.br/consultarNFCe.aspx"),
+                new EnderecoConsultaPublicaNfce(Estado.RN, TipoAmbiente.taHomologacao, TipoUrlConsultaPublica.UrlQrCode, "http://hom.nfce.set.rn.gov.br/consultarNFCe.aspx"),
+                new EnderecoConsultaPublicaNfce(Estado.RN, TipoAmbiente.taHomologacao, TipoUrlConsultaPublica.UrlConsulta, "http://nfce.set.rn.gov.br/portalDFE/NFCe/ConsultaNFCe.aspx"),
 
                 new EnderecoConsultaPublicaNfce(Estado.RO, TipoAmbiente.taProducao, TipoUrlConsultaPublica.UrlQrCode, "http://www.nfce.sefin.ro.gov.br/consultanfce/consulta.jsp"),
                 new EnderecoConsultaPublicaNfce(Estado.RO, TipoAmbiente.taProducao, TipoUrlConsultaPublica.UrlConsulta, "http://www.nfce.sefin.ro.gov.br"),
                 new EnderecoConsultaPublicaNfce(Estado.RO, TipoAmbiente.taHomologacao, TipoUrlConsultaPublica.UrlQrCode, "http://www.nfce.sefin.ro.gov.br/consultanfce/consulta.jsp"),
                 new EnderecoConsultaPublicaNfce(Estado.RO, TipoAmbiente.taHomologacao, TipoUrlConsultaPublica.UrlConsulta, "http://www.nfce.sefin.ro.gov.br/consultaAmbHomologacao.jsp"),
 
+                new EnderecoConsultaPublicaNfce(Estado.RR, TipoAmbiente.taProducao, TipoUrlConsultaPublica.UrlQrCode, "https://www.sefaz.rr.gov.br/nfce/servlet/qrcode"),
+                new EnderecoConsultaPublicaNfce(Estado.RR, TipoAmbiente.taProducao, TipoUrlConsultaPublica.UrlConsulta, "https://www.sefaz.rr.gov.br/nfce/servlet/wp_consulta_nfce"),
+                new EnderecoConsultaPublicaNfce(Estado.RR, TipoAmbiente.taHomologacao, TipoUrlConsultaPublica.UrlQrCode, "http://200.174.88.103:8080/nfce/servlet/qrcode"),
+                new EnderecoConsultaPublicaNfce(Estado.RR, TipoAmbiente.taHomologacao, TipoUrlConsultaPublica.UrlConsulta, "http://200.174.88.103:8080/nfce/servlet/wp_consulta_nfce"),
+
                 new EnderecoConsultaPublicaNfce(Estado.RS, TipoAmbiente.taProducao, TipoUrlConsultaPublica.UrlQrCode, "https://www.sefaz.rs.gov.br/NFCE/NFCE-COM.aspx"),
                 new EnderecoConsultaPublicaNfce(Estado.RS, TipoAmbiente.taProducao, TipoUrlConsultaPublica.UrlConsulta, "https://www.sefaz.rs.gov.br/NFE/NFE-NFC.aspx"),
                 new EnderecoConsultaPublicaNfce(Estado.RS, TipoAmbiente.taHomologacao, TipoUrlConsultaPublica.UrlQrCode, "https://www.sefaz.rs.gov.br/NFCE/NFCE-COM.aspx"),
                 new EnderecoConsultaPublicaNfce(Estado.RS, TipoAmbiente.taHomologacao, TipoUrlConsultaPublica.UrlConsulta, "https://www.sefaz.rs.gov.br/NFE/NFE-NFC.aspx"),
-
-                new EnderecoConsultaPublicaNfce(Estado.RR, TipoAmbiente.taProducao, TipoUrlConsultaPublica.UrlConsulta, "https://www.sefaz.rr.gov.br/nfce/servlet/wp_consulta_nfce"),
-                new EnderecoConsultaPublicaNfce(Estado.RR, TipoAmbiente.taHomologacao, TipoUrlConsultaPublica.UrlConsulta, "http://200.174.88.103:8080/nfce/servlet/wp_consulta_nfce"),
 
                 new EnderecoConsultaPublicaNfce(Estado.SE, TipoAmbiente.taProducao, TipoUrlConsultaPublica.UrlQrCode, "http://www.nfce.se.gov.br/portal/consultarNFCe.jsp"),
                 new EnderecoConsultaPublicaNfce(Estado.SE, TipoAmbiente.taProducao, TipoUrlConsultaPublica.UrlConsulta, "http://www.nfce.se.gov.br/portal"),


### PR DESCRIPTION
Atualização das urls para qr-code de acordo com link (http://nfce.encat.org/desenvolvedor/qrcode/) divulgado na NT 2015/002, versão 1.41, publicada em 26/08/2016;
