### PR TITLE
Ajustes dos Serviços NFC-e Estado do Pará (PA)

### DIFF
--- a/NFe.Servicos/Enderecador.cs
+++ b/NFe.Servicos/Enderecador.cs
@@ -106,6 +106,7 @@ namespace NFe.Servicos
                 Estado.DF,
                 Estado.ES,
                 Estado.MA, //Somente NFCe. MA usa o SVAN para NFe. Rev: 09/09/2015
+                Estado.PA, //Somente NFCe. MA usa o SVAN para NFe. Rev: 09/09/2015
                 Estado.PB,
                 Estado.PI, //Somente NFCe. PI usa o SVAN para NFe. Rev: 09/09/2015
                 Estado.RJ,
@@ -987,7 +988,7 @@ namespace NFe.Servicos
                 {
                     #region NFe
                     
-                    if (estado != Estado.BA & estado != Estado.MA & estado != Estado.PI)
+                    if (estado != Estado.BA & estado != Estado.MA & estado != Estado.PA & estado != Estado.PI)
                     {
                         if (emissao != TipoEmissao.teEPEC)
                             endServico.AddRange(eventoCceCanc.Select(servicoNFe => new EnderecoServico(servicoNFe, VersaoServico.ve100, TipoAmbiente.taHomologacao, emissao, estado, ModeloDocumento.NFe, "https://nfe-homologacao.svrs.rs.gov.br/ws/recepcaoevento/recepcaoevento.asmx")));
@@ -1035,7 +1036,7 @@ namespace NFe.Servicos
                     #region NFe
 
                     //Rev: 09/09/2015
-                    if (estado != Estado.BA & estado != Estado.MA & estado != Estado.PI)
+                    if (estado != Estado.BA & estado != Estado.MA & estado != Estado.PA & estado != Estado.PI)
                     {
                         if (emissao != TipoEmissao.teEPEC)
                             endServico.AddRange(eventoCceCanc.Select(servicoNFe => new EnderecoServico(servicoNFe, VersaoServico.ve100, TipoAmbiente.taProducao, emissao, estado, ModeloDocumento.NFe, "https://nfe.svrs.rs.gov.br/ws/recepcaoevento/recepcaoevento.asmx")));


### PR DESCRIPTION
Ajuste para o Estado do Pará utilizar os serviços da SVRS (Sefaz Virtual do Rio Grande de Sul) no envio e emissão da NCF-e;
