### PR TITLE
Implementação para receber o certificado por um array de bytes

### DIFF
--- a/NFe.Servicos/ServicosNFe.cs
+++ b/NFe.Servicos/ServicosNFe.cs
@@ -93,9 +93,7 @@ namespace NFe.Servicos
         public ServicosNFe(ConfiguracaoServico cFgServico)
         {
             _cFgServico = cFgServico;
-            _certificado = string.IsNullOrEmpty(_cFgServico.Certificado.Arquivo)
-                ? CertificadoDigital.ObterDoRepositorio(_cFgServico.Certificado.Serial, _cFgServico.Certificado.Senha)
-                : CertificadoDigital.ObterDeArquivo(_cFgServico.Certificado.Arquivo, _cFgServico.Certificado.Senha);
+            _certificado = CertificadoDigital.ObterCertificado();
             _path = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
         }
 
@@ -949,7 +947,7 @@ namespace NFe.Servicos
             }
             catch (Exception ex)
             {
-                throw new ExecutionException(ex.Message);
+                throw new ExecutionException(ex.Message, ex);
             }
 
             var retornoXmlString = retorno.OuterXml;

--- a/NFe.Utils/Assinatura/Assinador.cs
+++ b/NFe.Utils/Assinatura/Assinador.cs
@@ -52,9 +52,7 @@ namespace NFe.Utils.Assinatura
             if (id == null)
                 throw new Exception("Não é possível assinar um objeto evento sem sua respectiva Id!");
 
-            var certificado = string.IsNullOrEmpty(ConfiguracaoServico.Instancia.Certificado.Arquivo)
-                ? CertificadoDigital.ObterDoRepositorio(ConfiguracaoServico.Instancia.Certificado.Serial, ConfiguracaoServico.Instancia.Certificado.Senha)
-                : CertificadoDigital.ObterDeArquivo(ConfiguracaoServico.Instancia.Certificado.Arquivo, ConfiguracaoServico.Instancia.Certificado.Senha);
+            var certificado = CertificadoDigital.ObterCertificado();
 
             var documento = new XmlDocument {PreserveWhitespace = true};
             documento.LoadXml(FuncoesXml.ClasseParaXmlString(objetoLocal));

--- a/NFe.Utils/Assinatura/CertificadoDigital.cs
+++ b/NFe.Utils/Assinatura/CertificadoDigital.cs
@@ -40,6 +40,49 @@ namespace NFe.Utils.Assinatura
 {
     public static class CertificadoDigital
     {
+        /// <summary> 
+        /// Prioriza o certificado a partir do array de bytes / depois avalia se  ConfiguracaoServico.Instancia.Certificado.Arquivo esta preenchido para buscar do ObterDoRepositorio ou ObterDeArquivo
+        /// </summary>
+        /// <returns></returns>
+        public static X509Certificate2 ObterCertificado()
+        {
+            //TODO: Talvez mudar para um enum para escolher o retorno
+            if (ConfiguracaoServico.Instancia.Certificado.ArrayBytesArquivo != null)
+            {
+                return ObterDoArrayBytes(ConfiguracaoServico.Instancia.Certificado.ArrayBytesArquivo,
+                                            ConfiguracaoServico.Instancia.Certificado.Senha);
+            }
+            else if (string.IsNullOrEmpty(ConfiguracaoServico.Instancia.Certificado.Arquivo))
+            {
+                return ObterDoRepositorio(ConfiguracaoServico.Instancia.Certificado.Serial,
+                                                                    ConfiguracaoServico.Instancia.Certificado.Senha);
+            }
+            else
+            {
+                return ObterDeArquivo(ConfiguracaoServico.Instancia.Certificado.Arquivo,
+                                                                ConfiguracaoServico.Instancia.Certificado.Senha);
+            }
+        }
+
+        /// <summary>
+        /// Obtém um certificado a partir do arquivo e da senha passados nos parâmetros
+        /// </summary>
+        /// <param name="arquivo">Arquivo do certificado digital</param>
+        /// <param name="senha">Senha do certificado digital</param>
+        /// <returns></returns>
+        private static X509Certificate2 ObterDoArrayBytes(byte[] arrayBytes, string senha)
+        {
+            try
+            {
+                var certificado = new X509Certificate2(arrayBytes, senha, X509KeyStorageFlags.MachineKeySet);
+                return certificado;
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("Não foi possivel converter o stream para o certificado.", ex);
+            }
+        }
+        
 
         /// <summary>
         /// Exibe a lista de certificados instalados no PC e devolve o certificado selecionado
@@ -70,7 +113,7 @@ namespace NFe.Utils.Assinatura
         /// <param name="numeroSerial">Serial do certificado</param>
         /// <param name="senha">Informe a senha se desejar que o usuário não precise digitá-la toda vez que for iniciada uma nova instância da aplicação. Não informe a senha para certificado A1!</param>
         /// <returns></returns>
-        public static X509Certificate2 ObterDoRepositorio(string numeroSerial, string senha = null)
+        private static X509Certificate2 ObterDoRepositorio(string numeroSerial, string senha = null)
         {
             if (string.IsNullOrEmpty(numeroSerial))
                 throw new Exception("O nº de série do certificado não foi informado para a função ObterDoRepositorio!");
@@ -125,7 +168,7 @@ namespace NFe.Utils.Assinatura
         /// <param name="arquivo">Arquivo do certificado digital</param>
         /// <param name="senha">Senha do certificado digital</param>
         /// <returns></returns>
-        public static X509Certificate2 ObterDeArquivo(string arquivo, string senha)
+        private static X509Certificate2 ObterDeArquivo(string arquivo, string senha)
         {
             if (!File.Exists(arquivo))
             {

--- a/NFe.Utils/ConfiguracaoCertificado.cs
+++ b/NFe.Utils/ConfiguracaoCertificado.cs
@@ -53,7 +53,7 @@ namespace NFe.Utils
             {
                 if (value == _base64Arquivo) return;
                 _base64Arquivo = value;
-                _arrayBytesArquivo = System.Convert.FromBase64String(value);
+                ArrayBytesArquivo = System.Convert.FromBase64String(value);
                 OnPropertyChanged("ArrayBytesArquivo");
             }
         }

--- a/NFe.Utils/ConfiguracaoCertificado.cs
+++ b/NFe.Utils/ConfiguracaoCertificado.cs
@@ -40,7 +40,23 @@ namespace NFe.Utils
         private string _serial;
         private string _arquivo;
         private byte[] _arrayBytesArquivo;
+        private string _base64Arquivo;
 
+
+        /// <summary>
+        /// Base64 de bytes do certificado
+        /// </summary>
+        public string Base64Arquivo
+        {
+            get { return _base64Arquivo; }
+            set
+            {
+                if (value == _base64Arquivo) return;
+                _base64Arquivo = value;
+                _arrayBytesArquivo = System.Convert.FromBase64String(value);
+                OnPropertyChanged("ArrayBytesArquivo");
+            }
+        }
 
         /// <summary>
         /// Array de bytes do certificado

--- a/NFe.Utils/ConfiguracaoCertificado.cs
+++ b/NFe.Utils/ConfiguracaoCertificado.cs
@@ -39,6 +39,21 @@ namespace NFe.Utils
     {
         private string _serial;
         private string _arquivo;
+        private byte[] _arrayBytesArquivo;
+
+
+        /// <summary>
+        /// Array de bytes do certificado
+        /// </summary>
+        public byte[] ArrayBytesArquivo
+        {
+            get { return _arrayBytesArquivo; }
+            set
+            {
+                if (value == _arrayBytesArquivo) return;
+                _arrayBytesArquivo = value;
+            }
+        }
 
         /// <summary>
         ///     Nº de série do certificado digital

--- a/NFe.Utils/Exceptions/ExecutionException.cs
+++ b/NFe.Utils/Exceptions/ExecutionException.cs
@@ -14,10 +14,13 @@ namespace NFe.Utils.Exceptions
             return "Falha na rede internet: " + this.message;
         }
 
-        public ExecutionException(string msg)
+        public ExecutionException(string msg):base(msg)
         {
             this.message = msg;
-            new Exception();
+        }
+        public ExecutionException(string msg, Exception innerException):base(msg, innerException)
+        {
+            this.message = msg;
         }
     }
 }

--- a/NFe.Utils/Exceptions/ValidationException.cs
+++ b/NFe.Utils/Exceptions/ValidationException.cs
@@ -14,10 +14,14 @@ namespace NFe.Utils.Exceptions
             return "Erros da validação: " + this.message;
         }
 
-        public ValidationException(string msg)
+        public ValidationException(string msg):base(msg)
         {
             this.message = msg;
-            new Exception();
+        }
+
+        public ValidationException(string msg , Exception innerException):base(msg, innerException)
+        {
+            this.message = msg;
         }
     }
 }

--- a/NFe.Utils/Validacao/Validador.cs
+++ b/NFe.Utils/Validacao/Validador.cs
@@ -127,7 +127,7 @@ namespace NFe.Utils.Validacao
             {
                 // Um erro ocorre se o documento XML inclui caracteres ilegais
                 // ou tags que não estão aninhadas corretamente
-                throw new Exception("Ocorreu o seguinte erro durante a validação XML:" + "\n" + err.Message);
+                throw new Exception("Ocorreu o seguinte erro durante a validação XML:" + "\n" + err.Message, err);
             }
             finally
             {
@@ -137,7 +137,7 @@ namespace NFe.Utils.Validacao
 
         internal static void ValidationEventHandler(object sender, ValidationEventArgs args)
         {
-            throw new ValidationException(args.Message);
+            throw new  ValidationException(args.Message,args.Exception);
         }
     }
 }


### PR DESCRIPTION
Implementação para receber o certificado por um array de bytes /
Implementação das exceptions (NFe.Utils.Exceptions) para receberem
innerException , para ajudar no debug/tests ( correção principalmente no método NFeAutorizacao da classe ServicosNFe )
Adicionado propriedade Base64Arquivo para receber o certificado por base64 e já converter para o array de bytes