### PR TITLE
CORREÇÕES nas classes Exceções e removendo 'else' perdido.

### DIFF
--- a/NFe.Servicos/ServicosNFe.cs
+++ b/NFe.Servicos/ServicosNFe.cs
@@ -77,6 +77,7 @@ using System.Net;
 using System.Reflection;
 using System.Security.Cryptography.X509Certificates;
 using System.Xml;
+using NFe.Utils.Excecoes;
 
 namespace NFe.Servicos
 {
@@ -1027,9 +1028,6 @@ namespace NFe.Servicos
             {
                 throw new ExecucaoException(ex.Message);
             }
-            else
-                retorno = ws.Execute(dadosEnvio);
-
 
             var retornoXmlString = retorno.OuterXml;
             var retEnvio = new retEnviNFe().CarregarDeXmlString(retornoXmlString);

--- a/NFe.Utils/Excecoes/ExecucaoException.cs
+++ b/NFe.Utils/Excecoes/ExecucaoException.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
-namespace NFe.Utils.Exceptions
+namespace NFe.Utils.Excecoes
 {
     public class ExecucaoException : Exception
     {

--- a/NFe.Utils/Excecoes/ValidacaoException.cs
+++ b/NFe.Utils/Excecoes/ValidacaoException.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
-namespace NFe.Utils.Exceptions
+namespace NFe.Utils.Excecoes
 {
     public class ValidacaoException : Exception
     {


### PR DESCRIPTION
1. O nome das classes foi alterado para o português nas referências, porém as classes foram mantidas em ingles. (correção: alterando os nomes das classes para o portugues);

2. Faltou uma referencia à uma das classes das exceções; (correção: inserido a referencia faltante);

3. 'else' perdido com trecho duplicado: (correção: remoção do código já existente na lógica).