### PR TITLE
Ajustes Danfe NFe

### DIFF
--- a/NFe.Danfe.Fast/NFe/NFeRetrato.frx
+++ b/NFe.Danfe.Fast/NFe/NFeRetrato.frx
@@ -1,5 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Report ScriptLanguage="CSharp" ReferencedAssemblies="System.dll&#13;&#10;System.Drawing.dll&#13;&#10;System.Windows.Forms.dll&#13;&#10;System.Data.dll&#13;&#10;System.Xml.dll&#13;&#10;NFe.Classes.dll&#13;&#10;NFe.Utils.dll&#13;&#10;NFe.Danfe.Fast.dll" ReportInfo.Created="10/22/2015 14:20:37" ReportInfo.Modified="01/02/2017 15:33:43" ReportInfo.CreatorVersion="2016.3.22.0">
+<?xml version="1.0" encoding="utf-8"?>
+<Report ScriptLanguage="CSharp" ReferencedAssemblies="System.dll&#13;&#10;System.Drawing.dll&#13;&#10;System.Windows.Forms.dll&#13;&#10;System.Data.dll&#13;&#10;System.Xml.dll&#13;&#10;NFe.Classes.dll&#13;&#10;NFe.Utils.dll&#13;&#10;NFe.Danfe.Fast.dll" ReportInfo.Created="10/22/2015 14:20:37" ReportInfo.Modified="01/07/2017 13:49:27" ReportInfo.CreatorVersion="2016.4.0.0">
   <ScriptText>using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -78,6 +78,35 @@ namespace FastReport
       
       Text49.Text = FormatarCampo(((Nullable&lt;Int64&gt;)Report.GetColumnValue(&quot;NFe.NFe.infNFe.dest.enderDest.fone&quot;)).ToString(),'f');
       
+      var vol = Report.GetDataSource(&quot;NFe.NFe.infNFe.transp.vol&quot;);
+      vol.Init();
+      int qtdeVol = 0; 
+       
+      int volumes = 0;
+      decimal pesoL = 0;
+      decimal pesoB = 0;
+      while (vol.HasMoreRows)
+      {      
+        if (((Nullable&lt;Int32&gt;)Report.GetColumnValue(&quot;NFe.NFe.infNFe.transp.vol.qVol&quot;)) != null)
+          volumes += (Int32) ((Nullable&lt;Int32&gt;)Report.GetColumnValue(&quot;NFe.NFe.infNFe.transp.vol.qVol&quot;));
+        if (((Nullable&lt;Decimal&gt;)Report.GetColumnValue(&quot;NFe.NFe.infNFe.transp.vol.pesoL&quot;)) != null)
+          pesoL += (Decimal) ((Nullable&lt;Decimal&gt;)Report.GetColumnValue(&quot;NFe.NFe.infNFe.transp.vol.pesoL&quot;));
+        if (((Nullable&lt;Decimal&gt;)Report.GetColumnValue(&quot;NFe.NFe.infNFe.transp.vol.pesoB&quot;)) != null)
+          pesoB += (Decimal) ((Nullable&lt;Decimal&gt;)Report.GetColumnValue(&quot;NFe.NFe.infNFe.transp.vol.pesoB&quot;));   
+        qtdeVol++; 
+        vol.Next();
+      }
+           
+      if (qtdeVol &gt; 1)
+      {
+        Text122.Text = volumes.ToString();
+        Text123.Text = &quot;VOLUMES&quot;;
+        Text124.Text = &quot;&quot;;
+        Text125.Text = &quot;&quot;;
+        Text126.Text = FormatNumber(pesoB,3) + &quot; KG&quot;;
+        Text127.Text = FormatNumber(pesoL,3) + &quot; KG&quot;;
+      }        
+      
       //Formato a data de emissão
       string dtEntradaSaida = &quot;&quot;;
       string hrEntradaSaida = &quot;&quot;;
@@ -114,8 +143,10 @@ namespace FastReport
         Child5.Visible=true;
         if ((int)Report.GetColumnValue(&quot;NFe.NFe.infNFe.ide.indPag&quot;) == 0) 
           Text169.Text=&quot;PAGAMENTO A VISTA&quot;;
-        else
+        else if ((int)Report.GetColumnValue(&quot;NFe.NFe.infNFe.ide.indPag&quot;) == 1) 
           Text169.Text=&quot;PAGAMENTO A PRAZO&quot;;
+        else 
+          Text169.Text=&quot;FORMA DE PAGAMENTO: OUTROS&quot;;
       }                                                                                      
       
       if ((CRT)(Report.GetColumnValue(&quot;NFe.NFe.infNFe.emit.CRT&quot;)) == CRT.SimplesNacional)
@@ -141,56 +172,78 @@ namespace FastReport
       if (!((Boolean)Report.GetParameterValue(&quot;DuasLinhas&quot;)))
       {             
         Text143.Text = &quot;[NFe.NFe.infNFe.det.prod.xProd]&quot;;
-        Text142.Height = 10.5f;
-        Text143.Height = Text142.Height;
-        Text144.Height = Text142.Height;
-        lblCst.Height = Text142.Height;       
-        Text147.Height = Text142.Height;
-        Text148.Height = Text142.Height;
-        Text149.Height = Text142.Height;
-        Text150.Height = Text142.Height;
-        Text151.Height = Text142.Height;
-        Text152.Height = Text142.Height;
-        Text153.Height = Text142.Height;
-        Text154.Height = Text142.Height;
-        Text166.Height = Text142.Height;
-        Text165.Height = Text142.Height;
-        
-        Line17.Height = Text142.Height;
-        Line3.Height = Text142.Height;
-        Line4.Height = Text142.Height;
-        Line5.Height = Text142.Height;
-        Line6.Height = Text142.Height;
-        Line7.Height = Text142.Height;
-        Line8.Height = Text142.Height;
-        Line9.Height = Text142.Height;
-        Line10.Height = Text142.Height;
-        Line11.Height = Text142.Height;
-        Line12.Height = Text142.Height;
-        Line13.Height = Text142.Height;
-        Line14.Height = Text142.Height;
-        Line15.Height = Text142.Height;
-        Line16.Height = Text142.Height;
-        
-        Line2.Top = Text142.Height;
-        
-        dbProdutos.Height = Text142.Height;        
-        
-        Text142.VertAlign = FastReport.VertAlign.Top;
-        Text143.VertAlign = FastReport.VertAlign.Top;
-        Text144.VertAlign = FastReport.VertAlign.Top;
-        lblCst.VertAlign = FastReport.VertAlign.Top;
-        Text147.VertAlign = FastReport.VertAlign.Top;
-        Text148.VertAlign = FastReport.VertAlign.Top;
-        Text149.VertAlign = FastReport.VertAlign.Top;
-        Text150.VertAlign = FastReport.VertAlign.Top;
-        Text151.VertAlign = FastReport.VertAlign.Top;
-        Text152.VertAlign = FastReport.VertAlign.Top;
-        Text153.VertAlign = FastReport.VertAlign.Top;
-        Text154.VertAlign = FastReport.VertAlign.Top;
-        Text166.VertAlign = FastReport.VertAlign.Top;
-        Text165.VertAlign = FastReport.VertAlign.Top;
+        if ( ((String)Report.GetColumnValue(&quot;NFe.NFe.infNFe.det.prod.xProd&quot;)).Length &gt; 45 )
+        {
+          Text142.Height = 18f;
+          
+          Text142.VertAlign = FastReport.VertAlign.Center;
+          Text143.VertAlign = FastReport.VertAlign.Center;
+          Text144.VertAlign = FastReport.VertAlign.Center;
+          lblCst.VertAlign = FastReport.VertAlign.Center;
+          Text147.VertAlign = FastReport.VertAlign.Center;
+          Text148.VertAlign = FastReport.VertAlign.Center;
+          Text149.VertAlign = FastReport.VertAlign.Center;
+          Text150.VertAlign = FastReport.VertAlign.Center;
+          Text151.VertAlign = FastReport.VertAlign.Center;
+          Text152.VertAlign = FastReport.VertAlign.Center;
+          Text153.VertAlign = FastReport.VertAlign.Center;
+          Text154.VertAlign = FastReport.VertAlign.Center;
+          Text166.VertAlign = FastReport.VertAlign.Center;
+          Text165.VertAlign = FastReport.VertAlign.Center;
+        }
+        else
+        {
+          Text142.Height = 10.5f;
+          Text142.VertAlign = FastReport.VertAlign.Top;
+          Text143.VertAlign = FastReport.VertAlign.Top;
+          Text144.VertAlign = FastReport.VertAlign.Top;
+          lblCst.VertAlign = FastReport.VertAlign.Top;
+          Text147.VertAlign = FastReport.VertAlign.Top;
+          Text148.VertAlign = FastReport.VertAlign.Top;
+          Text149.VertAlign = FastReport.VertAlign.Top;
+          Text150.VertAlign = FastReport.VertAlign.Top;
+          Text151.VertAlign = FastReport.VertAlign.Top;
+          Text152.VertAlign = FastReport.VertAlign.Top;
+          Text153.VertAlign = FastReport.VertAlign.Top;
+          Text154.VertAlign = FastReport.VertAlign.Top;
+          Text166.VertAlign = FastReport.VertAlign.Top;
+          Text165.VertAlign = FastReport.VertAlign.Top;
+        }
       }
+      
+      Text143.Height = Text142.Height;
+      Text144.Height = Text142.Height;
+      lblCst.Height = Text142.Height;       
+      Text147.Height = Text142.Height;
+      Text148.Height = Text142.Height;
+      Text149.Height = Text142.Height;
+      Text150.Height = Text142.Height;
+      Text151.Height = Text142.Height;
+      Text152.Height = Text142.Height;
+      Text153.Height = Text142.Height;
+      Text154.Height = Text142.Height;
+      Text166.Height = Text142.Height;
+      Text165.Height = Text142.Height;
+      
+      Line17.Height = Text142.Height;
+      Line3.Height = Text142.Height;
+      Line4.Height = Text142.Height;
+      Line5.Height = Text142.Height;
+      Line6.Height = Text142.Height;
+      Line7.Height = Text142.Height;
+      Line8.Height = Text142.Height;
+      Line9.Height = Text142.Height;
+      Line10.Height = Text142.Height;
+      Line11.Height = Text142.Height;
+      Line12.Height = Text142.Height;
+      Line13.Height = Text142.Height;
+      Line14.Height = Text142.Height;
+      Line15.Height = Text142.Height;
+      Line16.Height = Text142.Height;
+      
+      Line2.Top = Text142.Height;     
+      dbProdutos.Height = Text142.Height;        
+            
       //Converto para INT o campo do CST
       ICMSBasico icmsBasico = (ICMSBasico) (Report.GetColumnValue(&quot;NFe.NFe.infNFe.det.imposto.ICMS.TipoICMS&quot;));
       ICMSGeral icmsGeral = new ICMSGeral(icmsBasico);  


### PR DESCRIPTION
- Forma de pagamento só estava A Vista ou A Prazo, adicionado "Outros".
- Produtos com mais de 45 caracteres estava cortando a descrição, agora adiciona uma segunda linhas mas somente para este produto.
- Quando tiver mais de um volume na nota, soma os volumes na quantidade, os pesos bruto e liquido, fixa a espécie em "VOLUMES", deixa a marca em branco e a numeração em branco. https://github.com/adeniltonbs/Zeus.Net.NFe.NFCe/issues/325
