### PR TITLE
Limpar instancia NFe

### DIFF
--- a/NFe.Utils/ConfiguracaoServico.cs
+++ b/NFe.Utils/ConfiguracaoServico.cs
@@ -214,5 +214,13 @@ namespace NFe.Utils
                 return _instancia;
             }
         }
+
+        /// <summary>
+        ///     Limpa a instancia atual caso exista
+        /// </summary>
+        public static void LimparIntancia()
+        {
+            _instancia = null;
+        }
     }
 }


### PR DESCRIPTION
Em alguns clientes acontece o erro de envio com o SSL/TLS e o mesmo só é sanado ao fechar o sistema e entrar novamente e após varios testes era somente a instancia que ficava em memória.

Não existe a certeza de que limpar a instancia resolveria esse problema, mas ao atualizar um cliente em específico não tive mais o problema durante as horas em que acompanhei o processo e como a chamada do método não ocasionou nenhum efeito colateral não vejo mal em sua existência.