### PR TITLE
Cache de certificado digital alterado para aceitar mais de um, quando…

### DIFF
--- a/DFe.Utils/ConfiguracaoCertificado.cs
+++ b/DFe.Utils/ConfiguracaoCertificado.cs
@@ -55,6 +55,7 @@ namespace DFe.Utils
         private string _arquivo;
         private string _senha;
         private TipoCertificado _tipoCertificado;
+        private string _cacheId;
 
         /// <summary>
         /// Tipo de certificado a ser usado
@@ -124,6 +125,20 @@ namespace DFe.Utils
                 if (value == _senha) return;
                 _senha = value;
                 OnPropertyChanged(this.ObterPropriedadeInfo(c => c.Senha).Name);
+            }
+        }
+
+        /// <summary>
+        /// Id do certificado no cache do Zeus
+        /// </summary>
+        public string CacheId
+        {
+            get { return _cacheId; }
+            set
+            {
+                if (value == _cacheId) return;
+                _cacheId = value;
+                OnPropertyChanged("CacheId");
             }
         }
 

--- a/NFe.AppTeste/MainWindow.xaml.cs
+++ b/NFe.AppTeste/MainWindow.xaml.cs
@@ -126,6 +126,8 @@ namespace NFe.AppTeste
 
                 //Exemplo com using para chamar o método Dispose da classe.
                 //Usar dessa forma, especialmente, quando for usar certificado A3 com a senha salva.
+                // se usar cache você pode por um id no certificado e salvar mais de um certificado digital também na memoria com o zeus
+                //_configuracoes.CfgServico.Certificado.CacheId = "1";
                 using (var servicoNFe = new ServicosNFe(_configuracoes.CfgServico))
                 {
                     var retornoStatus = servicoNFe.NfeStatusServico();


### PR DESCRIPTION
… um sistema for multiempresa você tem a possibilidade de ter mais de um certificado digital em cache no Zeus.

Por padrão o zeus pega o SerialNumber do certificado e adiciona numa lista. Isso somente serve para uso de um unico certificado digital. Para usar mais de um você deve setar na classe ConfiguracaoCertificado.CacheId = id de sua preferência.