### PR TITLE
[CTe e MDFe -Reset() no X509Certificate2]

### DIFF
--- a/CTe.Classes/ConfiguracaoServico.cs
+++ b/CTe.Classes/ConfiguracaoServico.cs
@@ -58,7 +58,18 @@ namespace CTe.Classes
         /// </summary>
         public ConfiguracaoCertificado ConfiguracaoCertificado { get; set; }
 
-        public X509Certificate2 X509Certificate2 { get { return ObterCertificado(); } }
+        private X509Certificate2 _certificado = null;
+        public X509Certificate2 X509Certificate2
+        {
+            get
+            {
+                if (this._certificado != null)
+                    if (!this.ConfiguracaoCertificado.ManterDadosEmCache)
+                        this._certificado.Reset();
+                _certificado = ObterCertificado();
+                return _certificado;
+            }
+        }
 
         private X509Certificate2 ObterCertificado()
         {

--- a/MDFe.Utils/Configuracoes/MDFeConfiguracao.cs
+++ b/MDFe.Utils/Configuracoes/MDFeConfiguracao.cs
@@ -69,8 +69,18 @@ namespace MDFe.Utils.Configuracoes
             return _versaoWebService;
         }
 
-        public static X509Certificate2 X509Certificate2 { get { return ObterCertificado(); } }
-
+        private static X509Certificate2 _certificado = null;
+        public static X509Certificate2 X509Certificate2
+        {
+            get
+            {
+                if (_certificado != null)
+                    if (!ConfiguracaoCertificado.ManterDadosEmCache)
+                        _certificado.Reset();
+                _certificado = ObterCertificado();
+                return _certificado;
+            }
+        }
 
         public static bool NaoSalvarXml()
         {


### PR DESCRIPTION
Este commit tem como objetivo tentar corrigir o problema de SSL/TLS que ocorre com vários usuários quando vão emitir o segundo documento fiscal.

Estudando melhor o fonte notei que o servicoNFe implementa a interface IDisposable e quando o método Dispose() era chamado o certificado chamava o método Reset(), mas quando o objeto era destruido de outra forma este reset não era chamado e como na minha implementaçaõ eu não implementava esta funcionalidade, acredito que o certificado ficava preso de alguma forma, e que quando o sistema era fechado eu este objeto era liberado e no primeiro uso funcionaria corretamente.

Pensando nisso implementei a mesma habilidade do Reset nos projetos do CTe e MDFe além de ajustar meu projeto proprio utilizando o dispose nos serviços da NFe.

https://github.com/adeniltonbs/Zeus.Net.NFe.NFCe/issues/428