### PR TITLE
Adicionado modificações para o uso de multithread na classe ConfiguracaoServico

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,36 @@ $RECYCLE.BIN/
 .Spotlight-V100
 .Trashes
 
+# Build results
+[Dd]ebug/
+[Dd]ebugPublic/
+[Rr]elease/
+[Rr]eleases/
+[Xx]64/
+[Xx]86/
+[Bb]uild/
+bld/
+[Bb]in/
+[Oo]bj/
+
+# MSTest test Results
+[Tt]est[Rr]esult*/
+[Bb]uild[Ll]og.*
+
+# Build Results of an ATL Project
+[Dd]ebugPS/
+[Rr]eleasePS/
+dlldata.c
+
+# User-specific files
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
+
+# User-specific files (MonoDevelop/Xamarin Studio)
+*.userprefs
+
 # Directories potentially created on remote AFP share
 .AppleDB
 .AppleDesktop

--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,18 @@ dlldata.c
 *.userosscache
 *.sln.docstates
 
+# NuGet Packages
+*.nupkg
+# The packages folder can be ignored because of Package Restore
+**/packages/*
+# except build/, which is used as an MSBuild target.
+!**/packages/build/
+# Uncomment if necessary however generally it will be regenerated when needed
+#!**/packages/repositories.config
+# NuGet v3's project.json files produces more ignoreable files
+*.nuget.props
+*.nuget.targets
+
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs
 

--- a/NFe.Servicos/ServicosNFe.cs
+++ b/NFe.Servicos/ServicosNFe.cs
@@ -98,7 +98,7 @@ namespace NFe.Servicos
         public ServicosNFe(ConfiguracaoServico cFgServico)
         {
             _cFgServico = cFgServico;
-            _certificado = CertificadoDigital.ObterCertificado(ConfiguracaoServico.Instancia.Certificado);
+            _certificado = CertificadoDigital.ObterCertificado(cFgServico.Certificado);
             _path = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
 
             //Define a versão do protocolo de segurança

--- a/NFe.Servicos/ServicosNFe.cs
+++ b/NFe.Servicos/ServicosNFe.cs
@@ -247,7 +247,7 @@ namespace NFe.Servicos
             #region Valida, Envia os dados e obtém a resposta
 
             var xmlStatus = pedStatus.ObterXmlString();
-            Validador.Valida(ServicoNFe.NfeStatusServico, _cFgServico.VersaoNfeStatusServico, xmlStatus);
+            Validador.Valida(ServicoNFe.NfeStatusServico, _cFgServico.VersaoNfeStatusServico, xmlStatus, cfgServico: _cFgServico);
             var dadosStatus = new XmlDocument();
             dadosStatus.LoadXml(xmlStatus);
 
@@ -309,7 +309,7 @@ namespace NFe.Servicos
             #region Valida, Envia os dados e obtém a resposta
 
             var xmlConsulta = pedConsulta.ObterXmlString();
-            Validador.Valida(ServicoNFe.NfeConsultaProtocolo, _cFgServico.VersaoNfeConsultaProtocolo, xmlConsulta);
+            Validador.Valida(ServicoNFe.NfeConsultaProtocolo, _cFgServico.VersaoNfeConsultaProtocolo, xmlConsulta, cfgServico: _cFgServico);
             var dadosConsulta = new XmlDocument();
             dadosConsulta.LoadXml(xmlConsulta);
 
@@ -397,7 +397,7 @@ namespace NFe.Servicos
             #region Valida, Envia os dados e obtém a resposta
 
             var xmlInutilizacao = pedInutilizacao.ObterXmlString();
-            Validador.Valida(ServicoNFe.NfeInutilizacao, _cFgServico.VersaoNfeInutilizacao, xmlInutilizacao);
+            Validador.Valida(ServicoNFe.NfeInutilizacao, _cFgServico.VersaoNfeInutilizacao, xmlInutilizacao, cfgServico: _cFgServico);
             var dadosInutilizacao = new XmlDocument();
             dadosInutilizacao.LoadXml(xmlInutilizacao);
 
@@ -481,7 +481,7 @@ namespace NFe.Servicos
             #region Valida, Envia os dados e obtém a resposta
 
             var xmlEvento = pedEvento.ObterXmlString();
-            Validador.Valida(servicoEvento, _cFgServico.VersaoRecepcaoEventoCceCancelamento, xmlEvento);
+            Validador.Valida(servicoEvento, _cFgServico.VersaoRecepcaoEventoCceCancelamento, xmlEvento, cfgServico: _cFgServico);
             var dadosEvento = new XmlDocument();
             dadosEvento.LoadXml(xmlEvento);
 
@@ -770,7 +770,7 @@ namespace NFe.Servicos
             #region Valida, Envia os dados e obtém a resposta
 
             var xmlConsulta = pedConsulta.ObterXmlString();
-            Validador.Valida(ServicoNFe.NfeConsultaCadastro, _cFgServico.VersaoNfeConsultaCadastro, xmlConsulta);
+            Validador.Valida(ServicoNFe.NfeConsultaCadastro, _cFgServico.VersaoNfeConsultaCadastro, xmlConsulta, cfgServico: _cFgServico);
             var dadosConsulta = new XmlDocument();
             dadosConsulta.LoadXml(xmlConsulta);
 
@@ -857,7 +857,7 @@ namespace NFe.Servicos
             #region Valida, Envia os dados e obtém a resposta
 
             var xmlConsulta = pedDistDFeInt.ObterXmlString();
-            Validador.Valida(ServicoNFe.NFeDistribuicaoDFe, _cFgServico.VersaoNFeDistribuicaoDFe, xmlConsulta);
+            Validador.Valida(ServicoNFe.NFeDistribuicaoDFe, _cFgServico.VersaoNFeDistribuicaoDFe, xmlConsulta, cfgServico: _cFgServico);
             var dadosConsulta = new XmlDocument();
             dadosConsulta.LoadXml(xmlConsulta);
 
@@ -959,7 +959,7 @@ namespace NFe.Servicos
                 //Caso o lote seja enviado para o PR, colocar o namespace nos elementos <NFe> do lote, pois o serviço do PR o exige, conforme https://github.com/adeniltonbs/Zeus.Net.NFe.NFCe/issues/33
                 xmlEnvio = xmlEnvio.Replace("<NFe>", "<NFe xmlns=\"http://www.portalfiscal.inf.br/nfe\">");
 
-            Validador.Valida(ServicoNFe.NfeRecepcao, _cFgServico.VersaoNfeRecepcao, xmlEnvio);
+            Validador.Valida(ServicoNFe.NfeRecepcao, _cFgServico.VersaoNfeRecepcao, xmlEnvio, cfgServico: _cFgServico);
             var dadosEnvio = new XmlDocument();
             dadosEnvio.LoadXml(xmlEnvio);
 
@@ -1089,7 +1089,7 @@ namespace NFe.Servicos
                 //Caso o lote seja enviado para o PR, colocar o namespace nos elementos <NFe> do lote, pois o serviço do PR o exige, conforme https://github.com/adeniltonbs/Zeus.Net.NFe.NFCe/issues/33
                 xmlEnvio = xmlEnvio.Replace("<NFe>", "<NFe xmlns=\"http://www.portalfiscal.inf.br/nfe\">");
 
-            Validador.Valida(ServicoNFe.NFeAutorizacao, _cFgServico.VersaoNFeAutorizacao, xmlEnvio);
+            Validador.Valida(ServicoNFe.NFeAutorizacao, _cFgServico.VersaoNFeAutorizacao, xmlEnvio, cfgServico: _cFgServico);
             var dadosEnvio = new XmlDocument();
             dadosEnvio.LoadXml(xmlEnvio);
 
@@ -1222,7 +1222,7 @@ namespace NFe.Servicos
             #region Valida, Envia os dados e obtém a resposta
 
             var xmlDownload = pedDownload.ObterXmlString();
-            Validador.Valida(ServicoNFe.NfeDownloadNF, _cFgServico.VersaoNfeDownloadNF, xmlDownload);
+            Validador.Valida(ServicoNFe.NfeDownloadNF, _cFgServico.VersaoNfeDownloadNF, xmlDownload, cfgServico: _cFgServico);
             var dadosDownload = new XmlDocument();
             dadosDownload.LoadXml(xmlDownload);
 

--- a/NFe.Testes/NFe.Testes.csproj
+++ b/NFe.Testes/NFe.Testes.csproj
@@ -1,0 +1,77 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{3E44EA28-96AE-4FAC-9E38-ADC2E12930F1}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>NFe.Testes</RootNamespace>
+    <AssemblyName>NFe.Testes</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.1.1.11\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.1.1.11\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="NFeTestes.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\DFe.Classes\DFe.Classes.csproj">
+      <Project>{9984EC15-18E1-4A87-B4DB-18AC913DC4E8}</Project>
+      <Name>DFe.Classes</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\NFe.Utils\NFe.Utils.csproj">
+      <Project>{E35E7C4A-5690-4979-8B43-002975B48EAA}</Project>
+      <Name>NFe.Utils</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.targets'))" />
+  </Target>
+  <Import Project="..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.targets')" />
+</Project>

--- a/NFe.Testes/NFeTestes.cs
+++ b/NFe.Testes/NFeTestes.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Threading.Tasks;
+using DFe.Classes.Entidades;
+using NFe.Utils;
+using System.Threading;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NFe.Testes
+{
+    [TestClass]
+    public class NFeTestes
+    {
+
+        /// <summary>
+        /// Foram criados dois testes para análise do uso de multithread. 
+        /// O teste baseia-se em verificar o uso da classe ConfiguracaoServico em Multithread, atribuindo um Estado e um Tempo de espera diferentes (simulando tempo de resposta). 
+        /// Verifica-se no final a quantidade de Estados diferentes que foram atribuidos nas ConfiguracoesServico 
+        /// 
+        /// Primeiro método: A cada Task é criado uma nova instância
+        /// Segundo método: Uso da forma estática
+        /// 
+        /// <result>
+        /// Ao fazer uma soma de Estados distintos atribuídos, a forma estática não consegue usar diferentes Estados ao mesmo tempo (o que aconteceria com qualquer atributo).
+        /// Já o primeiro teste, como cada instância é referente a sua thread, ela não possui influência nas demais.
+        /// </result>
+        /// </summary>
+
+        [TestMethod]
+        public void NFeConfiguracaoServico_WhenTryCallAsynchronously_ReturnsCorrectStateDistinctNumbers()
+        {
+            // Arrange
+            var config1 = new { State = Estado.AC, SleepTime = TimeSpan.FromSeconds(10) };
+            var config2 = new { State = Estado.AM, SleepTime = TimeSpan.FromSeconds(2) };
+            var config3 = new { State = Estado.AP, SleepTime = TimeSpan.FromSeconds(0) };
+            var config4 = new { State = Estado.SP, SleepTime = TimeSpan.FromSeconds(3) };
+
+            var configurations = new[] { config1, config2, config3, config4 };
+
+            var result = new List<Estado>();
+
+            // Act
+            foreach (var config in configurations)
+            {
+                Task.Run(() =>
+                {
+                    var service = new ConfiguracaoServico();
+                    service.cUF = config.State;
+
+                    Thread.Sleep(config.SleepTime);
+
+                    result.Add(service.cUF);
+                }
+                );
+            }
+
+            // Assert
+            Thread.Sleep(TimeSpan.FromSeconds(12));
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(result.Distinct().Count(), 4);
+        }
+
+
+        [TestMethod()]
+        public void NFeConfiguracaoServico_WhenTryCallAsynchronously_ReturnsWrongStateDistinctNumbers()
+        {
+
+            // Arrange
+            var config1 = new { State = Estado.AC, SleepTime = TimeSpan.FromSeconds(10) };
+            var config2 = new { State = Estado.AM, SleepTime = TimeSpan.FromSeconds(2) };
+            var config3 = new { State = Estado.AP, SleepTime = TimeSpan.FromSeconds(0) };
+            var config4 = new { State = Estado.SP, SleepTime = TimeSpan.FromSeconds(3) };
+
+            var configurations = new[] { config1, config2, config3, config4 };
+
+            var result = new List<Estado>();
+
+            // Act
+            foreach (var config in configurations)
+            {
+                Task.Run(() =>
+                {
+                    ConfiguracaoServico.Instancia.cUF = config.State;
+
+                    Thread.Sleep(config.SleepTime);
+
+                    result.Add(ConfiguracaoServico.Instancia.cUF);
+                }
+                );
+            }
+
+            Thread.Sleep(TimeSpan.FromSeconds(12));
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.IsTrue(result.Distinct().Count() < 4);
+        }
+    }
+}

--- a/NFe.Testes/Properties/AssemblyInfo.cs
+++ b/NFe.Testes/Properties/AssemblyInfo.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("NFe.Testes")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("NFe.Testes")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+
+[assembly: Guid("3e44ea28-96ae-4fac-9e38-adc2e12930f1")]
+
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/NFe.Testes/packages.config
+++ b/NFe.Testes/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="MSTest.TestAdapter" version="1.1.11" targetFramework="net461" />
+  <package id="MSTest.TestFramework" version="1.1.11" targetFramework="net461" />
+</packages>

--- a/NFe.Utils/Assinatura/Assinador.cs
+++ b/NFe.Utils/Assinatura/Assinador.cs
@@ -49,19 +49,35 @@ namespace NFe.Utils.Assinatura
         /// <param name="objeto"></param>
         /// <param name="id"></param>
         /// <param name="certificadoDigital">Informe o certificado digital, se já possuir esse em cache, evitando novo acesso ao certificado</param>
+        /// <returns>Retorna um objeto do tipo Classes.Assinatura.Signature, contendo a assinatura do objeto passado como parâmetro</retu
+        public static Signature ObterAssinatura<T>(T objeto, string id, ConfiguracaoServico cfgServico = null) where T : class
+        {
+            if (cfgServico == null)
+                cfgServico = ConfiguracaoServico.Instancia;
+
+            return ObterAssinatura<T>(objeto, id, CertificadoDigital.ObterCertificado(cfgServico.Certificado), cfgServico.Certificado.ManterDadosEmCache);
+        }
+
+        /// <summary>
+        ///     Obtém a assinatura de um objeto serializável
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="objeto"></param>
+        /// <param name="id"></param>
+        /// <param name="certificadoDigital">Informe o certificado digital</param>
+        /// <param name="manterDadosEmCache">Validador para manter o certificado em cache</param>
         /// <returns>Retorna um objeto do tipo Classes.Assinatura.Signature, contendo a assinatura do objeto passado como parâmetro</returns>
-        public static Signature ObterAssinatura<T>(T objeto, string id, X509Certificate2 certificadoDigital = null) where T : class
+        public static Signature ObterAssinatura<T>(T objeto, string id, X509Certificate2 certificadoDigital, bool manterDadosEmCache = true) where T : class
         {
             var objetoLocal = objeto;
             if (id == null)
                 throw new Exception("Não é possível assinar um objeto evento sem sua respectiva Id!");
 
-            var certificado = certificadoDigital ?? CertificadoDigital.ObterCertificado(ConfiguracaoServico.Instancia.Certificado);
             try
             {
                 var documento = new XmlDocument { PreserveWhitespace = true };
                 documento.LoadXml(FuncoesXml.ClasseParaXmlString(objetoLocal));
-                var docXml = new SignedXml(documento) { SigningKey = certificado.PrivateKey };
+                var docXml = new SignedXml(documento) { SigningKey = certificadoDigital.PrivateKey };
                 var reference = new Reference { Uri = "#" + id };
 
                 // adicionando EnvelopedSignatureTransform a referencia
@@ -75,7 +91,7 @@ namespace NFe.Utils.Assinatura
 
                 // carrega o certificado em KeyInfoX509Data para adicionar a KeyInfo
                 var keyInfo = new KeyInfo();
-                keyInfo.AddClause(new KeyInfoX509Data(certificado));
+                keyInfo.AddClause(new KeyInfoX509Data(certificadoDigital));
 
                 docXml.KeyInfo = keyInfo;
                 docXml.ComputeSignature();
@@ -89,10 +105,10 @@ namespace NFe.Utils.Assinatura
             {
                 //Se não mantém os dados do certificado em cache e o certificado não foi passado por parâmetro(isto é, ele foi criado dentro deste método), 
                 //então libera o certificado, chamando o método reset.
-                if (!ConfiguracaoServico.Instancia.Certificado.ManterDadosEmCache & certificadoDigital == null)
-                    certificado.Reset();
+                if (!manterDadosEmCache & certificadoDigital == null)
+                    certificadoDigital.Reset();
             }
-           
+
         }
     }
 }

--- a/NFe.Utils/Assinatura/Assinador.cs
+++ b/NFe.Utils/Assinatura/Assinador.cs
@@ -49,7 +49,7 @@ namespace NFe.Utils.Assinatura
         /// <param name="objeto"></param>
         /// <param name="id"></param>
         /// <param name="certificadoDigital">Informe o certificado digital, se já possuir esse em cache, evitando novo acesso ao certificado</param>
-        /// <returns>Retorna um objeto do tipo Classes.Assinatura.Signature, contendo a assinatura do objeto passado como parâmetro</retu
+        /// <returns>Retorna um objeto do tipo Classes.Assinatura.Signature, contendo a assinatura do objeto passado como parâmetro</returns>
         public static Signature ObterAssinatura<T>(T objeto, string id, ConfiguracaoServico cfgServico = null) where T : class
         {
             if (cfgServico == null)

--- a/NFe.Utils/ConfiguracaoServico.cs
+++ b/NFe.Utils/ConfiguracaoServico.cs
@@ -49,9 +49,13 @@ namespace NFe.Utils
         private string _diretorioSchemas;
         private bool _salvarXmlServicos;
 
-        private ConfiguracaoServico()
+        public ConfiguracaoServico()
         {
             Certificado = new ConfiguracaoCertificado();
+        }
+
+        static ConfiguracaoServico()
+        {
         }
 
         /// <summary>

--- a/NFe.Utils/NFe/ExtNFe.cs
+++ b/NFe.Utils/NFe/ExtNFe.cs
@@ -99,9 +99,9 @@ namespace NFe.Utils.NFe
             var xmlNfe = nfe.ObterXmlString();
             var cfgServico = ConfiguracaoServico.Instancia;
             if (versao < 3)
-                Validador.Valida(ServicoNFe.NfeRecepcao, cfgServico.VersaoNfeRecepcao, xmlNfe, false);
+                Validador.Valida(ServicoNFe.NfeRecepcao, cfgServico.VersaoNfeRecepcao, xmlNfe, false, cfgServico);
             if (versao >= 3)
-                Validador.Valida(ServicoNFe.NFeAutorizacao, cfgServico.VersaoNFeAutorizacao, xmlNfe, false);
+                Validador.Valida(ServicoNFe.NFeAutorizacao, cfgServico.VersaoNFeAutorizacao, xmlNfe, false, cfgServico);
 
             return nfe; //Para uso no formato fluent
         }
@@ -110,8 +110,9 @@ namespace NFe.Utils.NFe
         ///     Assina um objeto NFe
         /// </summary>
         /// <param name="nfe"></param>
+        /// <param name="cfgServico">ConfiguracaoServico para uso na classe Assinador</param>
         /// <returns>Retorna um objeto do tipo NFe assinado</returns>
-        public static Classes.NFe Assina(this Classes.NFe nfe)
+        public static Classes.NFe Assina(this Classes.NFe nfe, ConfiguracaoServico cfgServico = null)
         {
             var nfeLocal = nfe;
             if (nfeLocal == null) throw new ArgumentNullException("nfe");
@@ -139,7 +140,7 @@ namespace NFe.Utils.NFe
             nfeLocal.infNFe.Id = "NFe" + dadosChave.Chave;
             nfeLocal.infNFe.ide.cDV = Convert.ToInt16(dadosChave.DigitoVerificador);
 
-            var assinatura = Assinador.ObterAssinatura(nfeLocal, nfeLocal.infNFe.Id);
+            var assinatura = Assinador.ObterAssinatura(nfeLocal, nfeLocal.infNFe.Id, cfgServico);
             nfeLocal.Signature = assinatura;
             return nfeLocal;
         }

--- a/NFe.Utils/Validacao/Validador.cs
+++ b/NFe.Utils/Validacao/Validador.cs
@@ -94,17 +94,27 @@ namespace NFe.Utils.Validacao
             return null;
         }
 
-        public static void Valida(ServicoNFe servicoNFe, VersaoServico versaoServico, string stringXml, bool loteNfe = true)
+        public static void Valida(ServicoNFe servicoNFe, VersaoServico versaoServico, string stringXml, bool loteNfe = true, ConfiguracaoServico cfgServico = null)
         {
-            var pathSchema = ConfiguracaoServico.Instancia.DiretorioSchemas;
+            var pathSchema = String.Empty;
 
+            if (cfgServico == null || (cfgServico != null && string.IsNullOrWhiteSpace(cfgServico.DiretorioSchemas)))
+                pathSchema = ConfiguracaoServico.Instancia.DiretorioSchemas;
+            else
+                pathSchema = cfgServico.DiretorioSchemas;
+
+            Valida(servicoNFe, versaoServico, stringXml, loteNfe, pathSchema);
+        }
+
+        public static void Valida(ServicoNFe servicoNFe, VersaoServico versaoServico, string stringXml, bool loteNfe = true, string pathSchema = null)
+        {
             if (!Directory.Exists(pathSchema))
                 throw new Exception("Diretório de Schemas não encontrado: \n" + pathSchema);
 
             var arquivoSchema = pathSchema + @"\" + ObterArquivoSchema(servicoNFe, versaoServico, loteNfe);
 
             // Define o tipo de validação
-            var cfg = new XmlReaderSettings {ValidationType = ValidationType.Schema};
+            var cfg = new XmlReaderSettings { ValidationType = ValidationType.Schema };
 
             // Carrega o arquivo de esquema
             var schemas = new XmlSchemaSet();

--- a/Zeus NFe.sln
+++ b/Zeus NFe.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26430.16
+VisualStudioVersion = 15.0.26430.14
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NFe.Classes", "NFe.Classes\NFe.Classes.csproj", "{29CA1DA2-440D-484B-951A-CF1B2EB27984}"
 EndProject
@@ -69,6 +69,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CTe.Dacte.Fast", "CTe.Dacte.Fast\CTe.Dacte.Fast.csproj", "{1D58CBBD-56A5-4A10-8DAB-F795D35150EE}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CTe.Dacte.AppTeste", "CTe.Dacte.AppTeste\CTe.Dacte.AppTeste.csproj", "{827FA496-0F49-4E93-8CE9-2246CCD353B8}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "testes", "testes", "{164EF13E-7F27-4BC8-92A4-A82B1696B279}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NFe.Testes", "NFe.Testes\NFe.Testes.csproj", "{3E44EA28-96AE-4FAC-9E38-ADC2E12930F1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -192,6 +196,10 @@ Global
 		{827FA496-0F49-4E93-8CE9-2246CCD353B8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{827FA496-0F49-4E93-8CE9-2246CCD353B8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{827FA496-0F49-4E93-8CE9-2246CCD353B8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3E44EA28-96AE-4FAC-9E38-ADC2E12930F1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3E44EA28-96AE-4FAC-9E38-ADC2E12930F1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3E44EA28-96AE-4FAC-9E38-ADC2E12930F1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3E44EA28-96AE-4FAC-9E38-ADC2E12930F1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -213,5 +221,6 @@ Global
 		{E46ECA77-8732-4D99-9460-FA5E2CD90266} = {FE769B0F-5C0F-4A54-81F6-CF878ACCAB3D}
 		{1D58CBBD-56A5-4A10-8DAB-F795D35150EE} = {FE769B0F-5C0F-4A54-81F6-CF878ACCAB3D}
 		{827FA496-0F49-4E93-8CE9-2246CCD353B8} = {FE769B0F-5C0F-4A54-81F6-CF878ACCAB3D}
+		{3E44EA28-96AE-4FAC-9E38-ADC2E12930F1} = {164EF13E-7F27-4BC8-92A4-A82B1696B279}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Issue #515 
Adicionado funcionalidade de criação de múltiplos objetos ConfiguracaoServico, possibilitando o uso de multithreads e multiempresas. 

Foi modificado para aceitar o uso de multithreads, mas ainda sim, não impede o uso da forma estática.