### PR TITLE
Revert "removido arredondamento "

### DIFF
--- a/CTe.Classes/Informacoes/Impostos/ICMS/ICMS00.cs
+++ b/CTe.Classes/Informacoes/Impostos/ICMS/ICMS00.cs
@@ -51,20 +51,20 @@ namespace CTe.Classes.Informacoes.Impostos.ICMS
 
         public decimal vBC
         {
-            get { return _vBc; }
-            set { _vBc = value; }
+            get { return _vBc.Arredondar(2); }
+            set { _vBc = value.Arredondar(2); }
         }
 
         public decimal pICMS
         {
-            get { return _pIcms; }
-            set { _pIcms = value; }
+            get { return _pIcms.Arredondar(2); }
+            set { _pIcms = value.Arredondar(2); }
         }
 
         public decimal vICMS
         {
-            get { return _vIcms; }
-            set { _vIcms = value; }
+            get { return _vIcms.Arredondar(2); }
+            set { _vIcms = value.Arredondar(2); }
         }
     }
 }

--- a/CTe.Classes/Informacoes/Impostos/ICMS/ICMS20.cs
+++ b/CTe.Classes/Informacoes/Impostos/ICMS/ICMS20.cs
@@ -52,26 +52,26 @@ namespace CTe.Classes.Informacoes.Impostos.ICMS
 
         public decimal pRedBC
         {
-            get { return _pRedBc; }
-            set { _pRedBc = value; }
+            get { return _pRedBc.Arredondar(2); }
+            set { _pRedBc = value.Arredondar(2); }
         }
 
         public decimal vBC
         {
-            get { return _vBc; }
-            set { _vBc = value; }
+            get { return _vBc.Arredondar(2); }
+            set { _vBc = value.Arredondar(2); }
         }
 
         public decimal pICMS
         {
-            get { return _pIcms; }
-            set { _pIcms = value; }
+            get { return _pIcms.Arredondar(2); }
+            set { _pIcms = value.Arredondar(2); }
         }
 
         public decimal vICMS
         {
-            get { return _vIcms; }
-            set { _vIcms = value; }
+            get { return _vIcms.Arredondar(2); }
+            set { _vIcms = value.Arredondar(2); }
         }
     }
 }

--- a/CTe.Classes/Informacoes/Impostos/ICMS/ICMS60.cs
+++ b/CTe.Classes/Informacoes/Impostos/ICMS/ICMS60.cs
@@ -52,26 +52,26 @@ namespace CTe.Classes.Informacoes.Impostos.ICMS
 
         public decimal vBCSTRet
         {
-            get { return _vBcstRet; }
-            set { _vBcstRet = value; }
+            get { return _vBcstRet.Arredondar(2); }
+            set { _vBcstRet = value.Arredondar(2); }
         }
 
         public decimal vICMSSTRet
         {
-            get { return _vIcmsstRet; }
-            set { _vIcmsstRet = value; }
+            get { return _vIcmsstRet.Arredondar(2); }
+            set { _vIcmsstRet = value.Arredondar(2); }
         }
 
         public decimal pICMSSTRet
         {
-            get { return _pIcmsstRet; }
-            set { _pIcmsstRet = value; }
+            get { return _pIcmsstRet.Arredondar(2); }
+            set { _pIcmsstRet = value.Arredondar(2); }
         }
 
         public decimal vCred
         {
-            get { return _vCred; }
-            set { _vCred = value; }
+            get { return _vCred.Arredondar(2); }
+            set { _vCred = value.Arredondar(2); }
         }
     }
 }

--- a/CTe.Classes/Informacoes/Impostos/ICMS/ICMS90.cs
+++ b/CTe.Classes/Informacoes/Impostos/ICMS/ICMS90.cs
@@ -53,32 +53,32 @@ namespace CTe.Classes.Informacoes.Impostos.ICMS
 
         public decimal pRedBC
         {
-            get { return _pRedBc; }
-            set { _pRedBc = value; }
+            get { return _pRedBc.Arredondar(2); }
+            set { _pRedBc = value.Arredondar(2); }
         }
 
         public decimal vBC
         {
-            get { return _vBc; }
-            set { _vBc = value; }
+            get { return _vBc.Arredondar(2); }
+            set { _vBc = value.Arredondar(2); }
         }
 
         public decimal pICMS
         {
-            get { return _pIcms; }
-            set { _pIcms = value; }
+            get { return _pIcms.Arredondar(2); }
+            set { _pIcms = value.Arredondar(2); }
         }
 
         public decimal vICMS
         {
-            get { return _vIcms; }
-            set { _vIcms = value; }
+            get { return _vIcms.Arredondar(2); }
+            set { _vIcms = value.Arredondar(2); }
         }
 
         public decimal vCred
         {
-            get { return _vCred; }
-            set { _vCred = value; }
+            get { return _vCred.Arredondar(2); }
+            set { _vCred = value.Arredondar(2); }
         }
     }
 }

--- a/CTe.Classes/Informacoes/Impostos/ICMS/ICMSOutraUF.cs
+++ b/CTe.Classes/Informacoes/Impostos/ICMS/ICMSOutraUF.cs
@@ -52,26 +52,26 @@ namespace CTe.Classes.Informacoes.Impostos.ICMS
 
         public decimal pRedBCOutraUF
         {
-            get { return _pRedBcOutraUf; }
-            set { _pRedBcOutraUf = value; }
+            get { return _pRedBcOutraUf.Arredondar(2); }
+            set { _pRedBcOutraUf = value.Arredondar(2); }
         }
 
         public decimal vBCOutraUF
         {
-            get { return _vBcOutraUf; }
-            set { _vBcOutraUf = value; }
+            get { return _vBcOutraUf.Arredondar(2); }
+            set { _vBcOutraUf = value.Arredondar(2); }
         }
 
         public decimal pICMSOutraUF
         {
-            get { return _pIcmsOutraUf; }
-            set { _pIcmsOutraUf = value; }
+            get { return _pIcmsOutraUf.Arredondar(2); }
+            set { _pIcmsOutraUf = value.Arredondar(2); }
         }
 
         public decimal vICMSOutraUF
         {
-            get { return _vIcmsOutraUf; }
-            set { _vIcmsOutraUf = value; }
+            get { return _vIcmsOutraUf.Arredondar(2); }
+            set { _vIcmsOutraUf = value.Arredondar(2); }
         }
     }
 }

--- a/CTe.Classes/Informacoes/Impostos/ICMSUFFim.cs
+++ b/CTe.Classes/Informacoes/Impostos/ICMSUFFim.cs
@@ -48,50 +48,50 @@ namespace CTe.Classes.Informacoes.Impostos
 
         public decimal vBCUFFim
         {
-            get { return _vBcufFim; }
-            set { _vBcufFim = value; }
+            get { return _vBcufFim.Arredondar(2); }
+            set { _vBcufFim = value.Arredondar(2); }
         }
 
         public decimal pFCPUFFim
         {
-            get { return _pFcpufFim; }
-            set { _pFcpufFim = value; }
+            get { return _pFcpufFim.Arredondar(2); }
+            set { _pFcpufFim = value.Arredondar(2); }
         }
 
         public decimal pICMSUFFim
         {
-            get { return _pIcmsufFim; }
-            set { _pIcmsufFim = value; }
+            get { return _pIcmsufFim.Arredondar(2); }
+            set { _pIcmsufFim = value.Arredondar(2); }
         }
 
         public decimal pICMSInter
         {
-            get { return _pIcmsInter; }
-            set { _pIcmsInter = value; }
+            get { return _pIcmsInter.Arredondar(2); }
+            set { _pIcmsInter = value.Arredondar(2); }
         }
 
         public decimal pICMSInterPart
         {
-            get { return _pIcmsInterPart; }
-            set { _pIcmsInterPart = value; }
+            get { return _pIcmsInterPart.Arredondar(2); }
+            set { _pIcmsInterPart = value.Arredondar(2); }
         }
 
         public decimal vFCPUFFim
         {
-            get { return _vFcpufFim; }
-            set { _vFcpufFim = value; }
+            get { return _vFcpufFim.Arredondar(2); }
+            set { _vFcpufFim = value.Arredondar(2); }
         }
 
         public decimal vICMSUFFim
         {
-            get { return _vIcmsufFim; }
-            set { _vIcmsufFim = value; }
+            get { return _vIcmsufFim.Arredondar(2); }
+            set { _vIcmsufFim = value.Arredondar(2); }
         }
 
         public decimal vICMSUFIni
         {
-            get { return _vIcmsufIni; }
-            set { _vIcmsufIni = value; }
+            get { return _vIcmsufIni.Arredondar(2); }
+            set { _vIcmsufIni = value.Arredondar(2); }
         }
     }
 }

--- a/CTe.Classes/Informacoes/Impostos/imp.cs
+++ b/CTe.Classes/Informacoes/Impostos/imp.cs
@@ -42,8 +42,8 @@ namespace CTe.Classes.Informacoes.Impostos
         private decimal? _vTotTrib;
         public decimal? vTotTrib
         {
-            get { return _vTotTrib; }
-            set { _vTotTrib = value; }
+            get { return _vTotTrib.Arredondar(2); }
+            set { _vTotTrib = value.Arredondar(2); }
         }
 
         public bool vTotTribSpecified { get { return vTotTrib.HasValue; } }

--- a/CTe.Classes/Informacoes/Impostos/infTribFed.cs
+++ b/CTe.Classes/Informacoes/Impostos/infTribFed.cs
@@ -45,32 +45,32 @@ namespace CTe.Classes.Informacoes.Impostos
 
         public decimal? vPIS
         {
-            get { return _vPis; }
-            set { _vPis = value; }
+            get { return _vPis.Arredondar(2); }
+            set { _vPis = value.Arredondar(2); }
         }
 
         public decimal? vCOFINS
         {
-            get { return _vCofins; }
-            set { _vCofins = value; }
+            get { return _vCofins.Arredondar(2); }
+            set { _vCofins = value.Arredondar(2); }
         }
 
         public decimal? vIR
         {
-            get { return _vIr; }
-            set { _vIr = value; }
+            get { return _vIr.Arredondar(2); }
+            set { _vIr = value.Arredondar(2); }
         }
 
         public decimal? vINSS
         {
-            get { return _vInss; }
-            set { _vInss = value; }
+            get { return _vInss.Arredondar(2); }
+            set { _vInss = value.Arredondar(2); }
         }
 
         public decimal? vCSLL
         {
-            get { return _vCsll; }
-            set { _vCsll = value; }
+            get { return _vCsll.Arredondar(2); }
+            set { _vCsll = value.Arredondar(2); }
         }
 
 

--- a/CTe.Classes/Informacoes/Valores/Comp.cs
+++ b/CTe.Classes/Informacoes/Valores/Comp.cs
@@ -42,8 +42,8 @@ namespace CTe.Classes.Informacoes.Valores
 
         public decimal vComp
         {
-            get { return _vComp; }
-            set { _vComp = value; }
+            get { return _vComp.Arredondar(2); }
+            set { _vComp = value.Arredondar(2); }
         }
     }
 }

--- a/CTe.Classes/Informacoes/Valores/vPrest.cs
+++ b/CTe.Classes/Informacoes/Valores/vPrest.cs
@@ -42,15 +42,15 @@ namespace CTe.Classes.Informacoes.Valores
         [XmlElement("vTPrest", Order = 0)]
         public decimal vTPrest
         {
-            get { return _vTPrest; }
-            set { _vTPrest = value; }
+            get { return _vTPrest.Arredondar(2); }
+            set { _vTPrest = value.Arredondar(2); }
         }
 
         [XmlElement("vRec", Order = 1)]
         public decimal vRec
         {
-            get { return _vRec; }
-            set { _vRec = value; }
+            get { return _vRec.Arredondar(2); }
+            set { _vRec = value.Arredondar(2); }
         }
 
         [XmlElement("Comp", Order = 2)]

--- a/CTe.Classes/Informacoes/infCTeNormal/cobrancas/dup.cs
+++ b/CTe.Classes/Informacoes/infCTeNormal/cobrancas/dup.cs
@@ -58,8 +58,8 @@ namespace CTe.Classes.Informacoes.infCTeNormal.cobrancas
 
         public decimal? vDup
         {
-            get { return _vDup; }
-            set { _vDup = value; }
+            get { return _vDup.Arredondar(2); }
+            set { _vDup = value.Arredondar(2); }
         }
 
         public bool vDupSpecified { get { return vDup.HasValue; } }

--- a/CTe.Classes/Informacoes/infCTeNormal/cobrancas/fat.cs
+++ b/CTe.Classes/Informacoes/infCTeNormal/cobrancas/fat.cs
@@ -44,20 +44,20 @@ namespace CTe.Classes.Informacoes.infCTeNormal.cobrancas
 
         public decimal? vOrig
         {
-            get { return _vOrig; }
-            set { _vOrig = value; }
+            get { return _vOrig.Arredondar(2); }
+            set { _vOrig = value.Arredondar(2); }
         }
 
         public decimal? vDesc
         {
-            get { return _vDesc; }
-            set { _vDesc = value; }
+            get { return _vDesc.Arredondar(2); }
+            set { _vDesc = value.Arredondar(2); }
         }
 
         public decimal? vLiq
         {
-            get { return _vLiq; }
-            set { _vLiq = value; }
+            get { return _vLiq.Arredondar(2); }
+            set { _vLiq = value.Arredondar(2); }
         }
 
 

--- a/CTe.Classes/Informacoes/infCTeNormal/infCarga.cs
+++ b/CTe.Classes/Informacoes/infCTeNormal/infCarga.cs
@@ -46,8 +46,8 @@ namespace CTe.Classes.Informacoes.infCTeNormal
         [XmlElement(Order = 1)]
         public decimal? vCarga
         {
-            get { return _vCarga; }
-            set { _vCarga = value; }
+            get { return _vCarga.Arredondar(2); }
+            set { _vCarga = value.Arredondar(2); }
         }
 
         [XmlElement(Order = 2)]
@@ -65,8 +65,8 @@ namespace CTe.Classes.Informacoes.infCTeNormal
         [XmlElement(Order = 5)]
         public decimal? vCargaAverb
         {
-            get { return _vCargaAverb; }
-            set { _vCargaAverb = value; }
+            get { return _vCargaAverb.Arredondar(2); }
+            set { _vCargaAverb = value.Arredondar(2); }
         }
 
         [XmlElement(Order = 6)]

--- a/CTe.Classes/Informacoes/infCTeNormal/infCargas/infQ.cs
+++ b/CTe.Classes/Informacoes/infCTeNormal/infCargas/infQ.cs
@@ -45,8 +45,8 @@ namespace CTe.Classes.Informacoes.infCTeNormal.infCargas
 
         public decimal qCarga
         {
-            get { return _qCarga; }
-            set { _qCarga = value; }
+            get { return _qCarga.Arredondar(4); }
+            set { _qCarga = value.Arredondar(4); }
         }
     }
 }

--- a/CTe.Classes/Informacoes/infCTeNormal/infCteSubs/refNF.cs
+++ b/CTe.Classes/Informacoes/infCTeNormal/infCteSubs/refNF.cs
@@ -61,8 +61,8 @@ namespace CTe.Classes.Informacoes.infCTeNormal.infCteSubs
 
         public decimal valor
         {
-            get { return _valor; }
-            set { _valor = value; }
+            get { return _valor.Arredondar(2); }
+            set { _valor = value.Arredondar(2); }
         }
 
         [XmlIgnore]

--- a/CTe.Classes/Informacoes/infCTeNormal/infDocRef.cs
+++ b/CTe.Classes/Informacoes/infCTeNormal/infDocRef.cs
@@ -55,8 +55,8 @@ namespace CTe.Classes.Informacoes.infCTeNormal
 
         public decimal? vDoc
         {
-            get { return _vDoc; }
-            set { _vDoc = value; }
+            get { return _vDoc.Arredondar(2); }
+            set { _vDoc = value.Arredondar(2); }
         }
 
         public bool vDocSpecified { get { return vDoc.HasValue; } }

--- a/CTe.Classes/Informacoes/infCTeNormal/infDocumentos/infNF.cs
+++ b/CTe.Classes/Informacoes/infCTeNormal/infDocumentos/infNF.cs
@@ -67,46 +67,46 @@ namespace CTe.Classes.Informacoes.infCTeNormal.infDocumentos
 
         public decimal vBC
         {
-            get { return _vBc; }
-            set { _vBc = value; }
+            get { return _vBc.Arredondar(2); }
+            set { _vBc = value.Arredondar(2); }
         }
 
         public decimal vICMS
         {
-            get { return _vIcms; }
-            set { _vIcms = value; }
+            get { return _vIcms.Arredondar(2); }
+            set { _vIcms = value.Arredondar(2); }
         }
 
         public decimal vBCST
         {
-            get { return _vBcst; }
-            set { _vBcst = value; }
+            get { return _vBcst.Arredondar(2); }
+            set { _vBcst = value.Arredondar(2); }
         }
 
         public decimal vST
         {
-            get { return _vSt; }
-            set { _vSt = value; }
+            get { return _vSt.Arredondar(2); }
+            set { _vSt = value.Arredondar(2); }
         }
 
         public decimal vProd
         {
-            get { return _vProd; }
-            set { _vProd = value; }
+            get { return _vProd.Arredondar(2); }
+            set { _vProd = value.Arredondar(2); }
         }
 
         public decimal vNF
         {
-            get { return _vNf; }
-            set { _vNf = value; }
+            get { return _vNf.Arredondar(2); }
+            set { _vNf = value.Arredondar(2); }
         }
 
         public int nCFOP { get; set; }
 
         public decimal nPeso
         {
-            get { return _nPeso; }
-            set { _nPeso = value; }
+            get { return _nPeso.Arredondar(3); }
+            set { _nPeso = value.Arredondar(3); }
         }
 
         public string PIN { get; set; }

--- a/CTe.Classes/Informacoes/infCTeNormal/infDocumentos/infOutros.cs
+++ b/CTe.Classes/Informacoes/infCTeNormal/infDocumentos/infOutros.cs
@@ -69,8 +69,8 @@ namespace CTe.Classes.Informacoes.infCTeNormal.infDocumentos
 
         public decimal? vDocFisc
         {
-            get { return _vDocFisc; }
-            set { _vDocFisc = value; }
+            get { return _vDocFisc.Arredondar(2); }
+            set { _vDocFisc = value.Arredondar(2); }
         }
 
         public bool vDocFiscSpecified { get { return vDocFisc.HasValue; } }

--- a/CTe.Classes/Informacoes/infCTeNormal/infDocumentos/infUnidCarga.cs
+++ b/CTe.Classes/Informacoes/infCTeNormal/infDocumentos/infUnidCarga.cs
@@ -50,8 +50,8 @@ namespace CTe.Classes.Informacoes.infCTeNormal.infDocumentos
 
         public decimal? qtdRat
         {
-            get { return _qtdRat; }
-            set { _qtdRat = value; }
+            get { return _qtdRat.Arredondar(3); }
+            set { _qtdRat = value.Arredondar(3); }
         }
 
         public bool qtdRatSpecified { get { return qtdRat.HasValue; } }

--- a/CTe.Classes/Informacoes/infCTeNormal/infDocumentos/infUnidTransp.cs
+++ b/CTe.Classes/Informacoes/infCTeNormal/infDocumentos/infUnidTransp.cs
@@ -53,8 +53,8 @@ namespace CTe.Classes.Informacoes.infCTeNormal.infDocumentos
 
         public decimal? qtdRat
         {
-            get { return _qtdRat; }
-            set { _qtdRat = value; }
+            get { return _qtdRat.Arredondar(3); }
+            set { _qtdRat = value.Arredondar(3); }
         }
 
         public bool qtdRatSpecified { get { return qtdRat.HasValue; } }

--- a/CTe.Classes/Informacoes/infCTeNormal/infModals/aereos/tarifa.cs
+++ b/CTe.Classes/Informacoes/infCTeNormal/infModals/aereos/tarifa.cs
@@ -45,8 +45,8 @@ namespace CTe.Classes.Informacoes.infCTeNormal.infModals.aereos
 
         public decimal vTar
         {
-            get { return _vTar; }
-            set { _vTar = value; }
+            get { return _vTar.Arredondar(2); }
+            set { _vTar = value.Arredondar(2); }
         }
     }
 }

--- a/CTe.Classes/Informacoes/infCTeNormal/infModals/aquav.cs
+++ b/CTe.Classes/Informacoes/infCTeNormal/infModals/aquav.cs
@@ -45,14 +45,14 @@ namespace CTe.Classes.Informacoes.infCTeNormal.infModals
 
         public decimal vPrest
         {
-            get { return _vPrest; }
-            set { _vPrest = value; }
+            get { return _vPrest.Arredondar(2); }
+            set { _vPrest = value.Arredondar(2); }
         }
 
         public decimal vAFRMM
         {
-            get { return _vAfrmm; }
-            set { _vAfrmm = value; }
+            get { return _vAfrmm.Arredondar(2); }
+            set { _vAfrmm = value.Arredondar(2); }
         }
 
         public string nBooking { get; set; }

--- a/CTe.Classes/Informacoes/infCTeNormal/infModals/detCont.cs
+++ b/CTe.Classes/Informacoes/infCTeNormal/infModals/detCont.cs
@@ -71,8 +71,8 @@ namespace CTe.Classes.Informacoes.infCTeNormal.infModals
 
         public decimal? unidRat
         {
-            get { return _unidRat; }
-            set { _unidRat = value; }
+            get { return _unidRat.Arredondar(2); }
+            set { _unidRat = value.Arredondar(2); }
         }
 
         public bool unidRatSpecified { get { return unidRat.HasValue; } }
@@ -85,8 +85,8 @@ namespace CTe.Classes.Informacoes.infCTeNormal.infModals
 
         public decimal? unidRat
         {
-            get { return _unidRat; }
-            set { _unidRat = value; }
+            get { return _unidRat.Arredondar(2); }
+            set { _unidRat = value.Arredondar(2); }
         }
 
         public bool unidRatSpecified { get { return unidRat.HasValue; } }

--- a/CTe.Classes/Informacoes/infCTeNormal/infModals/duto.cs
+++ b/CTe.Classes/Informacoes/infCTeNormal/infModals/duto.cs
@@ -44,8 +44,8 @@ namespace CTe.Classes.Informacoes.infCTeNormal.infModals
 
         public decimal? vTar
         {
-            get { return _vTar; }
-            set { _vTar = value; }
+            get { return _vTar.Arredondar(6); }
+            set { _vTar = value.Arredondar(6); }
         }
 
         public bool vTarSpecified { get { return vTar.HasValue; } }

--- a/CTe.Classes/Informacoes/infCTeNormal/infModals/ferrov.cs
+++ b/CTe.Classes/Informacoes/infCTeNormal/infModals/ferrov.cs
@@ -52,8 +52,8 @@ namespace CTe.Classes.Informacoes.infCTeNormal.infModals
 
         public decimal vFrete
         {
-            get { return _vFrete; }
-            set { _vFrete = value; }
+            get { return _vFrete.Arredondar(2); }
+            set { _vFrete = value.Arredondar(2); }
         }
 
         [XmlElement(ElementName = "ferroEnv")]
@@ -72,8 +72,8 @@ namespace CTe.Classes.Informacoes.infCTeNormal.infModals
 
         public decimal? vFrete
         {
-            get { return _vFrete; }
-            set { _vFrete = value; }
+            get { return _vFrete.Arredondar(2); }
+            set { _vFrete = value.Arredondar(2); }
         }
 
         public bool vFreteSpecified { get { return vFrete.HasValue; } }
@@ -137,8 +137,8 @@ namespace CTe.Classes.Informacoes.infCTeNormal.infModals
 
         public decimal? cap
         {
-            get { return _cap; }
-            set { _cap = value; }
+            get { return _cap.Arredondar(3); }
+            set { _cap = value.Arredondar(3); }
         }
 
         public bool capSpecified { get { return cap.HasValue; } }

--- a/CTe.Classes/Informacoes/infCTeNormal/infModals/infTotAP.cs
+++ b/CTe.Classes/Informacoes/infCTeNormal/infModals/infTotAP.cs
@@ -42,8 +42,8 @@ namespace CTe.Classes.Informacoes.infCTeNormal.infModals
 
         public decimal qTotProd
         {
-            get { return _qTotProd; }
-            set { _qTotProd = value; }
+            get { return _qTotProd.Arredondar(4); }
+            set { _qTotProd = value.Arredondar(4); }
         }
 
         public uniAP uniAP { get; set; }

--- a/CTe.Classes/Informacoes/infCTeNormal/infQcteOs.cs
+++ b/CTe.Classes/Informacoes/infCTeNormal/infQcteOs.cs
@@ -41,8 +41,8 @@ namespace CTe.Classes.Informacoes.infCTeNormal
 
         public decimal qCarga
         {
-            get { return _qCarga; }
-            set { _qCarga = value; }
+            get { return _qCarga.Arredondar(4); }
+            set { _qCarga = value.Arredondar(4); }
         }
     }
 }

--- a/CTe.Classes/Informacoes/infCTeNormal/seg.cs
+++ b/CTe.Classes/Informacoes/infCTeNormal/seg.cs
@@ -49,8 +49,8 @@ namespace CTe.Classes.Informacoes.infCTeNormal
 
         public decimal? vCarga
         {
-            get { return _vCarga; }
-            set { _vCarga = value; }
+            get { return _vCarga.Arredondar(2); }
+            set { _vCarga = value.Arredondar(2); }
         }
 
         public bool vCargaSpecified { get { return vCarga.HasValue; } }

--- a/CTe.Classes/Informacoes/infCTeNormal/veicNovos.cs
+++ b/CTe.Classes/Informacoes/infCTeNormal/veicNovos.cs
@@ -48,8 +48,8 @@ namespace CTe.Classes.Informacoes.infCTeNormal
 
         public decimal vUnit
         {
-            get { return _vUnit; }
-            set { _vUnit = value; }
+            get { return _vUnit.Arredondar(2); }
+            set { _vUnit = value.Arredondar(2); }
         }
 
         public decimal vFrete { get; set; }

--- a/CTe.Classes/Servicos/Evento/dest.cs
+++ b/CTe.Classes/Servicos/Evento/dest.cs
@@ -122,7 +122,7 @@ namespace CTe.Classes.Servicos.Evento
         public decimal vNF
         {
             get { return _vNf; }
-            set { _vNf = value; }
+            set { _vNf = Valor.Arredondar(value, 2); }
         }
 
         /// <summary>
@@ -131,7 +131,7 @@ namespace CTe.Classes.Servicos.Evento
         public decimal vICMS
         {
             get { return _vIcms; }
-            set { _vIcms = value; }
+            set { _vIcms = Valor.Arredondar(value, 2); }
         }
 
         /// <summary>
@@ -140,7 +140,7 @@ namespace CTe.Classes.Servicos.Evento
         public decimal vST
         {
             get { return _vSt; }
-            set { _vSt = value; }
+            set { _vSt = Valor.Arredondar(value, 2); }
         }
 
         public bool ShouldSerializeIE()

--- a/DFe.Classes/DFe.Classes.csproj
+++ b/DFe.Classes/DFe.Classes.csproj
@@ -50,6 +50,7 @@
     <Compile Include="Flags\ModeloDocumento.cs" />
     <Compile Include="Flags\TipoAmbiente.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Valor.cs" />
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/DFe.Classes/Valor.cs
+++ b/DFe.Classes/Valor.cs
@@ -1,0 +1,20 @@
+﻿using System.Globalization;
+
+namespace DFe.Classes
+{
+    public static class Valor
+    {
+        public static decimal Arredondar(this decimal valor, int casasDecimais)
+        {
+            var valorNovo = decimal.Round(valor, casasDecimais);
+            var valorNovoStr = valorNovo.ToString("F" + casasDecimais, CultureInfo.CurrentCulture);
+            return decimal.Parse(valorNovoStr);
+        }
+
+        public static decimal? Arredondar(this decimal? valor, int casasDecimais)
+        {
+            if (valor == null) return null;
+            return Arredondar(valor.Value, casasDecimais);
+        }
+    }
+}

--- a/MDFe.Classes/Informacoes/MDFeDisp.cs
+++ b/MDFe.Classes/Informacoes/MDFeDisp.cs
@@ -63,8 +63,8 @@ namespace MDFe.Classes.Informacoes
 
         public decimal vValePed
         {
-            get { return _vValePed; }
-            set { _vValePed = value; }
+            get { return _vValePed.Arredondar(2); }
+            set { _vValePed = value.Arredondar(2); }
         }
     }
 }

--- a/MDFe.Classes/Informacoes/MDFeTot.cs
+++ b/MDFe.Classes/Informacoes/MDFeTot.cs
@@ -68,7 +68,7 @@ namespace MDFe.Classes.Informacoes
         public decimal vCarga
         {
             get { return _vCarga; }
-            set { _vCarga = value; }
+            set { _vCarga = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -84,7 +84,7 @@ namespace MDFe.Classes.Informacoes
         public decimal QCarga
         {
             get { return _qCarga; }
-            set { _qCarga = value; }
+            set { _qCarga = value.Arredondar(4); }
         }
 
 

--- a/MDFe.Classes/Informacoes/MDFeVag.cs
+++ b/MDFe.Classes/Informacoes/MDFeVag.cs
@@ -45,14 +45,14 @@ namespace MDFe.Classes.Informacoes
 
         public decimal pesoBC
         {
-            get { return _pesoBc; }
-            set { _pesoBc = value; }
+            get { return _pesoBc.Arredondar(3); }
+            set { _pesoBc = value.Arredondar(3); }
         }
 
         public decimal pesoR
         {
-            get { return _pesoR; }
-            set { _pesoR = value; }
+            get { return _pesoR.Arredondar(3); }
+            set { _pesoR = value.Arredondar(3); }
         }
 
         public string tpVag { get; set; }
@@ -83,8 +83,8 @@ namespace MDFe.Classes.Informacoes
         [XmlElement(ElementName = "TU")]
         public decimal TU
         {
-            get { return _tu; }
-            set { _tu = value; }
+            get { return _tu.Arredondar(3); }
+            set { _tu = value.Arredondar(3); }
         }
     }
 }

--- a/NFe.AppTeste/MainWindow.xaml.cs
+++ b/NFe.AppTeste/MainWindow.xaml.cs
@@ -1300,7 +1300,7 @@ namespace NFe.AppTeste
 
         protected virtual cobr GetCobranca(ICMSTot icmsTot)
         {
-            var valorParcela = (icmsTot.vProd/2).Arredondar(2);
+            var valorParcela = Valor.Arredondar(icmsTot.vProd/2, 2);
             var c = new cobr
             {
                 fat = new fat {nFat = "12345678910", vLiq = icmsTot .vProd},
@@ -1316,7 +1316,7 @@ namespace NFe.AppTeste
 
         protected virtual List<pag> GetPagamento(ICMSTot icmsTot)
         {
-            var valorPagto = (icmsTot.vProd / 2).Arredondar(2);
+            var valorPagto = Valor.Arredondar(icmsTot.vProd / 2, 2);
             var p = new List<pag>
             {
                 new pag {tPag = FormaPagamento.fpDinheiro, vPag = valorPagto},

--- a/NFe.Classes/Informacoes/Cana/deduc.cs
+++ b/NFe.Classes/Informacoes/Cana/deduc.cs
@@ -30,9 +30,6 @@
 /* http://www.zeusautomacao.com.br/                                             */
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
-
-using DFe.Classes;
-
 namespace NFe.Classes.Informacoes.Cana
 {
     public class deduc
@@ -53,7 +50,7 @@ namespace NFe.Classes.Informacoes.Cana
         public decimal vDed
         {
             get { return _vDed; }
-            set { _vDed = value; }
+            set { _vDed = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -62,7 +59,7 @@ namespace NFe.Classes.Informacoes.Cana
         public decimal vFor
         {
             get { return _vFor; }
-            set { _vFor = value; }
+            set { _vFor = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -71,7 +68,7 @@ namespace NFe.Classes.Informacoes.Cana
         public decimal vTotDed
         {
             get { return _vTotDed; }
-            set { _vTotDed = value; }
+            set { _vTotDed = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -80,7 +77,7 @@ namespace NFe.Classes.Informacoes.Cana
         public decimal vLiqFor
         {
             get { return _vLiqFor; }
-            set { _vLiqFor = value; }
+            set { _vLiqFor = value.Arredondar(2); }
         }
     }
 }

--- a/NFe.Classes/Informacoes/Cana/forDia.cs
+++ b/NFe.Classes/Informacoes/Cana/forDia.cs
@@ -53,7 +53,7 @@ namespace NFe.Classes.Informacoes.Cana
         public decimal qtde
         {
             get { return _qtde; }
-            set { _qtde = value; }
+            set { _qtde = value.Arredondar(10); }
         }
 
         /// <summary>
@@ -62,7 +62,7 @@ namespace NFe.Classes.Informacoes.Cana
         public decimal qTotMes
         {
             get { return _qTotMes; }
-            set { _qTotMes = value; }
+            set { _qTotMes = value.Arredondar(10); }
         }
 
         /// <summary>
@@ -71,7 +71,7 @@ namespace NFe.Classes.Informacoes.Cana
         public decimal qTotAnt
         {
             get { return _qTotAnt; }
-            set { _qTotAnt = value; }
+            set { _qTotAnt = value.Arredondar(10); }
         }
 
         /// <summary>
@@ -80,7 +80,7 @@ namespace NFe.Classes.Informacoes.Cana
         public decimal qTotGer
         {
             get { return _qTotGer; }
-            set { _qTotGer = value; }
+            set { _qTotGer = value.Arredondar(10); }
         }
     }
 }

--- a/NFe.Classes/Informacoes/Cobranca/dup.cs
+++ b/NFe.Classes/Informacoes/Cobranca/dup.cs
@@ -52,7 +52,7 @@ namespace NFe.Classes.Informacoes.Cobranca
         public decimal vDup
         {
             get { return _vDup; }
-            set { _vDup = value; }
+            set { _vDup = value.Arredondar(2); }
         }
     }
 }

--- a/NFe.Classes/Informacoes/Cobranca/fat.cs
+++ b/NFe.Classes/Informacoes/Cobranca/fat.cs
@@ -48,8 +48,8 @@ namespace NFe.Classes.Informacoes.Cobranca
         /// </summary>
         public decimal? vOrig
         {
-            get { return _vOrig; }
-            set { _vOrig = value; }
+            get { return _vOrig.Arredondar(2); }
+            set { _vOrig = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -57,8 +57,8 @@ namespace NFe.Classes.Informacoes.Cobranca
         /// </summary>
         public decimal? vDesc
         {
-            get { return _vDesc; }
-            set { _vDesc = value; }
+            get { return _vDesc.Arredondar(2); }
+            set { _vDesc = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -66,8 +66,8 @@ namespace NFe.Classes.Informacoes.Cobranca
         /// </summary>
         public decimal? vLiq
         {
-            get { return _vLiq; }
-            set { _vLiq = value; }
+            get { return _vLiq.Arredondar(2); }
+            set { _vLiq = value.Arredondar(2); }
         }
 
         public bool ShouldSerializevOrig()

--- a/NFe.Classes/Informacoes/Detalhe/DeclaracaoImportacao/DI.cs
+++ b/NFe.Classes/Informacoes/Detalhe/DeclaracaoImportacao/DI.cs
@@ -99,8 +99,8 @@ namespace NFe.Classes.Informacoes.Detalhe.DeclaracaoImportacao
         /// </summary>
         public decimal? vAFRMM
         {
-            get { return _vAfrmm; }
-            set { _vAfrmm = value; }
+            get { return _vAfrmm.Arredondar(2); }
+            set { _vAfrmm = value.Arredondar(2); }
         }
 
         /// <summary>

--- a/NFe.Classes/Informacoes/Detalhe/DeclaracaoImportacao/adi.cs
+++ b/NFe.Classes/Informacoes/Detalhe/DeclaracaoImportacao/adi.cs
@@ -56,8 +56,8 @@ namespace NFe.Classes.Informacoes.Detalhe.DeclaracaoImportacao
         /// </summary>
         public decimal? vDescDI
         {
-            get { return _vDescDi; }
-            set { _vDescDi = value; }
+            get { return _vDescDi.Arredondar(2); }
+            set { _vDescDi = value.Arredondar(2); }
         }
 
         /// <summary>

--- a/NFe.Classes/Informacoes/Detalhe/Exportacao/exportInd.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Exportacao/exportInd.cs
@@ -52,7 +52,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Exportacao
         public decimal qExport
         {
             get { return _qExport; }
-            set { _qExport = value; }
+            set { _qExport = value.Arredondar(4); }
         }
     }
 }

--- a/NFe.Classes/Informacoes/Detalhe/IPIDevolvido.cs
+++ b/NFe.Classes/Informacoes/Detalhe/IPIDevolvido.cs
@@ -42,7 +42,7 @@ namespace NFe.Classes.Informacoes.Detalhe
         public decimal vIPIDevol
         {
             get { return _vIpiDevol; }
-            set { _vIpiDevol = value; }
+            set { _vIpiDevol = value.Arredondar(2); }
         }
     }
 }

--- a/NFe.Classes/Informacoes/Detalhe/ProdEspecifico/CIDE.cs
+++ b/NFe.Classes/Informacoes/Detalhe/ProdEspecifico/CIDE.cs
@@ -44,7 +44,7 @@ namespace NFe.Classes.Informacoes.Detalhe.ProdEspecifico
         public decimal qBCProd
         {
             get { return _qBcProd; }
-            set { _qBcProd = value; }
+            set { _qBcProd = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -53,7 +53,7 @@ namespace NFe.Classes.Informacoes.Detalhe.ProdEspecifico
         public decimal vAliqProd
         {
             get { return _vAliqProd; }
-            set { _vAliqProd = value; }
+            set { _vAliqProd = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -62,7 +62,7 @@ namespace NFe.Classes.Informacoes.Detalhe.ProdEspecifico
         public decimal vCIDE
         {
             get { return _vCide; }
-            set { _vCide = value; }
+            set { _vCide = value.Arredondar(2); }
         }
     }
 }

--- a/NFe.Classes/Informacoes/Detalhe/ProdEspecifico/comb.cs
+++ b/NFe.Classes/Informacoes/Detalhe/ProdEspecifico/comb.cs
@@ -47,8 +47,8 @@ namespace NFe.Classes.Informacoes.Detalhe.ProdEspecifico
         /// </summary>
         public decimal? pMixGN
         {
-            get { return _pMixGn; }
-            set { _pMixGn = value; }
+            get { return _pMixGn.Arredondar(4); }
+            set { _pMixGn = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -61,8 +61,8 @@ namespace NFe.Classes.Informacoes.Detalhe.ProdEspecifico
         /// </summary>
         public decimal? qTemp
         {
-            get { return _qTemp; }
-            set { _qTemp = value; }
+            get { return _qTemp.Arredondar(4); }
+            set { _qTemp = value.Arredondar(4); }
         }
 
         /// <summary>

--- a/NFe.Classes/Informacoes/Detalhe/ProdEspecifico/encerrante.cs
+++ b/NFe.Classes/Informacoes/Detalhe/ProdEspecifico/encerrante.cs
@@ -62,7 +62,7 @@ namespace NFe.Classes.Informacoes.Detalhe.ProdEspecifico
         public decimal vEncIni
         {
             get { return _vEncIni; }
-            set { _vEncIni = value; }
+            set { _vEncIni = value.Arredondar(3); }
         }
 
         /// <summary>
@@ -71,7 +71,7 @@ namespace NFe.Classes.Informacoes.Detalhe.ProdEspecifico
         public decimal vEncFin
         {
             get { return _vEncFin; }
-            set { _vEncFin = value; }
+            set { _vEncFin = value.Arredondar(3); }
         }
     }
 }

--- a/NFe.Classes/Informacoes/Detalhe/ProdEspecifico/med.cs
+++ b/NFe.Classes/Informacoes/Detalhe/ProdEspecifico/med.cs
@@ -53,7 +53,7 @@ namespace NFe.Classes.Informacoes.Detalhe.ProdEspecifico
         public decimal qLote
         {
             get { return _qLote; }
-            set { _qLote = value; }
+            set { _qLote = value.Arredondar(3); }
         }
 
         /// <summary>
@@ -94,7 +94,7 @@ namespace NFe.Classes.Informacoes.Detalhe.ProdEspecifico
         public decimal vPMC
         {
             get { return _vPmc; }
-            set { _vPmc = value; }
+            set { _vPmc = value.Arredondar(2); }
         }
     }
 }

--- a/NFe.Classes/Informacoes/Detalhe/ProdEspecifico/veicProd.cs
+++ b/NFe.Classes/Informacoes/Detalhe/ProdEspecifico/veicProd.cs
@@ -74,7 +74,7 @@ namespace NFe.Classes.Informacoes.Detalhe.ProdEspecifico
         public decimal pesoL
         {
             get { return _pesoL; }
-            set { _pesoL = value; }
+            set { _pesoL = value.Arredondar(3); }
         }
 
         /// <summary>
@@ -83,7 +83,7 @@ namespace NFe.Classes.Informacoes.Detalhe.ProdEspecifico
         public decimal pesoB
         {
             get { return _pesoB; }
-            set { _pesoB = value; }
+            set { _pesoB = value.Arredondar(3); }
         }
 
         /// <summary>
@@ -107,7 +107,7 @@ namespace NFe.Classes.Informacoes.Detalhe.ProdEspecifico
         public decimal CMT
         {
             get { return _cmt; }
-            set { _cmt = value; }
+            set { _cmt = value.Arredondar(4); }
         }
 
         /// <summary>

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS00.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS00.cs
@@ -60,8 +60,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal vBC
         {
-            get { return _vBc; }
-            set { _vBc = value; }
+            get { return _vBc.Arredondar(2); }
+            set { _vBc = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -69,8 +69,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal pICMS
         {
-            get { return _pIcms; }
-            set { _pIcms = value; }
+            get { return _pIcms.Arredondar(4); }
+            set { _pIcms = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -78,8 +78,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal vICMS
         {
-            get { return _vIcms; }
-            set { _vIcms = value; }
+            get { return _vIcms.Arredondar(2); }
+            set { _vIcms = value.Arredondar(2); }
         }
     }
 }

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS10.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS10.cs
@@ -65,8 +65,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal vBC
         {
-            get { return _vBc; }
-            set { _vBc = value; }
+            get { return _vBc.Arredondar(2); }
+            set { _vBc = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -74,8 +74,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal pICMS
         {
-            get { return _pIcms; }
-            set { _pIcms = value; }
+            get { return _pIcms.Arredondar(4); }
+            set { _pIcms = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -83,8 +83,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal vICMS
         {
-            get { return _vIcms; }
-            set { _vIcms = value; }
+            get { return _vIcms.Arredondar(2); }
+            set { _vIcms = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -97,8 +97,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal? pMVAST
         {
-            get { return _pMvast; }
-            set { _pMvast = value; }
+            get { return _pMvast.Arredondar(4); }
+            set { _pMvast = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -106,8 +106,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal? pRedBCST
         {
-            get { return _pRedBcst; }
-            set { _pRedBcst = value; }
+            get { return _pRedBcst.Arredondar(4); }
+            set { _pRedBcst = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -115,8 +115,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal vBCST
         {
-            get { return _vBcst; }
-            set { _vBcst = value; }
+            get { return _vBcst.Arredondar(2); }
+            set { _vBcst = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -124,8 +124,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal pICMSST
         {
-            get { return _pIcmsst; }
-            set { _pIcmsst = value; }
+            get { return _pIcmsst.Arredondar(4); }
+            set { _pIcmsst = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -133,8 +133,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal vICMSST
         {
-            get { return _vIcmsst; }
-            set { _vIcmsst = value; }
+            get { return _vIcmsst.Arredondar(2); }
+            set { _vIcmsst = value.Arredondar(2); }
         }
 
         public bool ShouldSerializepMVAST()

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS20.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS20.cs
@@ -62,8 +62,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal pRedBC
         {
-            get { return _pRedBc; }
-            set { _pRedBc = value; }
+            get { return _pRedBc.Arredondar(4); }
+            set { _pRedBc = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -71,8 +71,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal vBC
         {
-            get { return _vBc; }
-            set { _vBc = value; }
+            get { return _vBc.Arredondar(2); }
+            set { _vBc = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -80,8 +80,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal pICMS
         {
-            get { return _pIcms; }
-            set { _pIcms = value; }
+            get { return _pIcms.Arredondar(4); }
+            set { _pIcms = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -89,8 +89,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal vICMS
         {
-            get { return _vIcms; }
-            set { _vIcms = value; }
+            get { return _vIcms.Arredondar(2); }
+            set { _vIcms = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -98,8 +98,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal? vICMSDeson
         {
-            get { return _vIcmsDeson; }
-            set { _vIcmsDeson = value; }
+            get { return _vIcmsDeson.Arredondar(2); }
+            set { _vIcmsDeson = value.Arredondar(2); }
         }
 
         /// <summary>

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS30.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS30.cs
@@ -63,8 +63,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal? pMVAST
         {
-            get { return _pMvast; }
-            set { _pMvast = value; }
+            get { return _pMvast.Arredondar(4); }
+            set { _pMvast = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -72,8 +72,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal? pRedBCST
         {
-            get { return _pRedBcst; }
-            set { _pRedBcst = value; }
+            get { return _pRedBcst.Arredondar(4); }
+            set { _pRedBcst = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -81,8 +81,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal vBCST
         {
-            get { return _vBcst; }
-            set { _vBcst = value; }
+            get { return _vBcst.Arredondar(2); }
+            set { _vBcst = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -90,8 +90,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal pICMSST
         {
-            get { return _pIcmsst; }
-            set { _pIcmsst = value; }
+            get { return _pIcmsst.Arredondar(4); }
+            set { _pIcmsst = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -99,8 +99,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal vICMSST
         {
-            get { return _vIcmsst; }
-            set { _vIcmsst = value; }
+            get { return _vIcmsst.Arredondar(2); }
+            set { _vIcmsst = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -108,8 +108,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal? vICMSDeson
         {
-            get { return _vIcmsDeson; }
-            set { _vIcmsDeson = value; }
+            get { return _vIcmsDeson.Arredondar(2); }
+            set { _vIcmsDeson = value.Arredondar(2); }
         }
 
         /// <summary>

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS40.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS40.cs
@@ -53,8 +53,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal? vICMSDeson
         {
-            get { return _vIcmsDeson; }
-            set { _vIcmsDeson = value; }
+            get { return _vIcmsDeson.Arredondar(2); }
+            set { _vIcmsDeson = value.Arredondar(2); }
         }
 
         /// <summary>

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS51.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS51.cs
@@ -64,8 +64,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal? pRedBC
         {
-            get { return _pRedBc; }
-            set { _pRedBc = value; }
+            get { return _pRedBc.Arredondar(4); }
+            set { _pRedBc = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -73,8 +73,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal? vBC
         {
-            get { return _vBc; }
-            set { _vBc = value; }
+            get { return _vBc.Arredondar(2); }
+            set { _vBc = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -82,8 +82,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal? pICMS
         {
-            get { return _pIcms; }
-            set { _pIcms = value; }
+            get { return _pIcms.Arredondar(4); }
+            set { _pIcms = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -91,8 +91,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal? vICMSOp
         {
-            get { return _vIcmsOp; }
-            set { _vIcmsOp = value; }
+            get { return _vIcmsOp.Arredondar(2); }
+            set { _vIcmsOp = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -100,8 +100,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal? pDif
         {
-            get { return _pDif; }
-            set { _pDif = value; }
+            get { return _pDif.Arredondar(2); }
+            set { _pDif = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -109,8 +109,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal? vICMSDif
         {
-            get { return _vIcmsDif; }
-            set { _vIcmsDif = value; }
+            get { return _vIcmsDif.Arredondar(2); }
+            set { _vIcmsDif = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -118,8 +118,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal? vICMS
         {
-            get { return _vIcms; }
-            set { _vIcms = value; }
+            get { return _vIcms.Arredondar(2); }
+            set { _vIcms = value.Arredondar(2); }
         }
 
         public bool ShouldSerializemodBC()

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS60.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS60.cs
@@ -54,8 +54,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal? vBCSTRet
         {
-            get { return _vBcstRet; }
-            set { _vBcstRet = value; }
+            get { return _vBcstRet.Arredondar(2); }
+            set { _vBcstRet = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -63,8 +63,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal? vICMSSTRet
         {
-            get { return _vIcmsstRet; }
-            set { _vIcmsstRet = value; }
+            get { return _vIcmsstRet.Arredondar(2); }
+            set { _vIcmsstRet = value.Arredondar(2); }
         }
 
         public bool ShouldSerializevBCSTRet()

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS70.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS70.cs
@@ -68,7 +68,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         public decimal pRedBC
         {
             get { return _pRedBc; }
-            set { _pRedBc = value; }
+            set { _pRedBc = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -77,7 +77,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         public decimal vBC
         {
             get { return _vBc; }
-            set { _vBc = value; }
+            set { _vBc = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -86,7 +86,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         public decimal pICMS
         {
             get { return _pIcms; }
-            set { _pIcms = value; }
+            set { _pIcms = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -95,7 +95,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         public decimal vICMS
         {
             get { return _vIcms; }
-            set { _vIcms = value; }
+            set { _vIcms = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -108,8 +108,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal? pMVAST
         {
-            get { return _pMvast; }
-            set { _pMvast = value; }
+            get { return _pMvast.Arredondar(4); }
+            set { _pMvast = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -117,8 +117,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal? pRedBCST
         {
-            get { return _pRedBcst; }
-            set { _pRedBcst = value; }
+            get { return _pRedBcst.Arredondar(4); }
+            set { _pRedBcst = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -127,7 +127,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         public decimal vBCST
         {
             get { return _vBcst; }
-            set { _vBcst = value; }
+            set { _vBcst = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -136,7 +136,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         public decimal pICMSST
         {
             get { return _pIcmsst; }
-            set { _pIcmsst = value; }
+            set { _pIcmsst = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -145,7 +145,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         public decimal vICMSST
         {
             get { return _vIcmsst; }
-            set { _vIcmsst = value; }
+            set { _vIcmsst = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -153,8 +153,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal? vICMSDeson
         {
-            get { return _vIcmsDeson; }
-            set { _vIcmsDeson = value; }
+            get { return _vIcmsDeson.Arredondar(2); }
+            set { _vIcmsDeson = value.Arredondar(2); }
         }
 
         /// <summary>

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS90.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS90.cs
@@ -67,8 +67,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal? vBC
         {
-            get { return _vBc; }
-            set { _vBc = value; }
+            get { return _vBc.Arredondar(2); }
+            set { _vBc = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -76,8 +76,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal? pRedBC
         {
-            get { return _pRedBc; }
-            set { _pRedBc = value; }
+            get { return _pRedBc.Arredondar(4); }
+            set { _pRedBc = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -85,8 +85,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal? pICMS
         {
-            get { return _pIcms; }
-            set { _pIcms = value; }
+            get { return _pIcms.Arredondar(4); }
+            set { _pIcms = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -94,8 +94,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal? vICMS
         {
-            get { return _vIcms; }
-            set { _vIcms = value; }
+            get { return _vIcms.Arredondar(2); }
+            set { _vIcms = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -108,8 +108,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal? pMVAST
         {
-            get { return _pMvast; }
-            set { _pMvast = value; }
+            get { return _pMvast.Arredondar(4); }
+            set { _pMvast = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -117,8 +117,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal? pRedBCST
         {
-            get { return _pRedBcst; }
-            set { _pRedBcst = value; }
+            get { return _pRedBcst.Arredondar(4); }
+            set { _pRedBcst = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -126,8 +126,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal? vBCST
         {
-            get { return _vBcst; }
-            set { _vBcst = value; }
+            get { return _vBcst.Arredondar(2); }
+            set { _vBcst = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -135,8 +135,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal? pICMSST
         {
-            get { return _pIcmsst; }
-            set { _pIcmsst = value; }
+            get { return _pIcmsst.Arredondar(4); }
+            set { _pIcmsst = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -144,8 +144,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal? vICMSST
         {
-            get { return _vIcmsst; }
-            set { _vIcmsst = value; }
+            get { return _vIcmsst.Arredondar(2); }
+            set { _vIcmsst = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -153,8 +153,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal? vICMSDeson
         {
-            get { return _vIcmsDeson; }
-            set { _vIcmsDeson = value; }
+            get { return _vIcmsDeson.Arredondar(2); }
+            set { _vIcmsDeson = value.Arredondar(2); }
         }
 
         /// <summary>

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMSPart.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMSPart.cs
@@ -68,7 +68,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         public decimal vBC
         {
             get { return _vBc; }
-            set { _vBc = value; }
+            set { _vBc = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -76,8 +76,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal? pRedBC
         {
-            get { return _pRedBc; }
-            set { _pRedBc = value; }
+            get { return _pRedBc.Arredondar(4); }
+            set { _pRedBc = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -86,7 +86,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         public decimal pICMS
         {
             get { return _pIcms; }
-            set { _pIcms = value; }
+            set { _pIcms = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -95,7 +95,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         public decimal vICMS
         {
             get { return _vIcms; }
-            set { _vIcms = value; }
+            set { _vIcms = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -108,8 +108,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal? pMVAST
         {
-            get { return _pMvast; }
-            set { _pMvast = value; }
+            get { return _pMvast.Arredondar(4); }
+            set { _pMvast = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -117,8 +117,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal? pRedBCST
         {
-            get { return _pRedBcst; }
-            set { _pRedBcst = value; }
+            get { return _pRedBcst.Arredondar(4); }
+            set { _pRedBcst = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -127,7 +127,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         public decimal vBCST
         {
             get { return _vBcst; }
-            set { _vBcst = value; }
+            set { _vBcst = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -136,7 +136,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         public decimal pICMSST
         {
             get { return _pIcmsst; }
-            set { _pIcmsst = value; }
+            set { _pIcmsst = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -145,7 +145,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         public decimal vICMSST
         {
             get { return _vIcmsst; }
-            set { _vIcmsst = value; }
+            set { _vIcmsst = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -154,7 +154,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         public decimal pBCOp
         {
             get { return _pBcOp; }
-            set { _pBcOp = value; }
+            set { _pBcOp = value.Arredondar(4); }
         }
 
         /// <summary>

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMSSN101.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMSSN101.cs
@@ -55,7 +55,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         public decimal pCredSN
         {
             get { return _pCredSn; }
-            set { _pCredSn = value; }
+            set { _pCredSn = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -64,7 +64,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         public decimal vCredICMSSN
         {
             get { return _vCredIcmssn; }
-            set { _vCredIcmssn = value; }
+            set { _vCredIcmssn = value.Arredondar(2); }
         }
     }
 }

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMSSN201.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMSSN201.cs
@@ -64,8 +64,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal? pMVAST
         {
-            get { return _pMvast; }
-            set { _pMvast = value; }
+            get { return _pMvast.Arredondar(4); }
+            set { _pMvast = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -73,8 +73,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal? pRedBCST
         {
-            get { return _pRedBcst; }
-            set { _pRedBcst = value; }
+            get { return _pRedBcst.Arredondar(4); }
+            set { _pRedBcst = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -83,7 +83,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         public decimal vBCST
         {
             get { return _vBcst; }
-            set { _vBcst = value; }
+            set { _vBcst = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -92,7 +92,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         public decimal pICMSST
         {
             get { return _pIcmsst; }
-            set { _pIcmsst = value; }
+            set { _pIcmsst = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -101,7 +101,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         public decimal vICMSST
         {
             get { return _vIcmsst; }
-            set { _vIcmsst = value; }
+            set { _vIcmsst = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -110,7 +110,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         public decimal pCredSN
         {
             get { return _pCredSn; }
-            set { _pCredSn = value; }
+            set { _pCredSn = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -119,7 +119,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         public decimal vCredICMSSN
         {
             get { return _vCredIcmssn; }
-            set { _vCredIcmssn = value; }
+            set { _vCredIcmssn = value.Arredondar(2); }
         }
 
         public bool ShouldSerializepMVAST()

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMSSN202.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMSSN202.cs
@@ -62,8 +62,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal? pMVAST
         {
-            get { return _pMvast; }
-            set { _pMvast = value; }
+            get { return _pMvast.Arredondar(4); }
+            set { _pMvast = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -71,8 +71,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal? pRedBCST
         {
-            get { return _pRedBcst; }
-            set { _pRedBcst = value; }
+            get { return _pRedBcst.Arredondar(4); }
+            set { _pRedBcst = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -81,7 +81,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         public decimal vBCST
         {
             get { return _vBcst; }
-            set { _vBcst = value; }
+            set { _vBcst = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -90,7 +90,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         public decimal pICMSST
         {
             get { return _pIcmsst; }
-            set { _pIcmsst = value; }
+            set { _pIcmsst = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -99,7 +99,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         public decimal vICMSST
         {
             get { return _vIcmsst; }
-            set { _vIcmsst = value; }
+            set { _vIcmsst = value.Arredondar(2); }
         }
 
         public bool ShouldSerializepMVAST()

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMSSN500.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMSSN500.cs
@@ -54,8 +54,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal? vBCSTRet
         {
-            get { return _vBcstRet; }
-            set { _vBcstRet = value; }
+            get { return _vBcstRet.Arredondar(2); }
+            set { _vBcstRet = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -63,8 +63,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal? vICMSSTRet
         {
-            get { return _vIcmsstRet; }
-            set { _vIcmsstRet = value; }
+            get { return _vIcmsstRet.Arredondar(2); }
+            set { _vIcmsstRet = value.Arredondar(2); }
         }
 
         public bool ShouldSerializevBCSTRet()

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMSSN900.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMSSN900.cs
@@ -68,8 +68,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal? vBC
         {
-            get { return _vBc; }
-            set { _vBc = value; }
+            get { return _vBc.Arredondar(2); }
+            set { _vBc = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -77,8 +77,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal? pRedBC
         {
-            get { return _pRedBc; }
-            set { _pRedBc = value; }
+            get { return _pRedBc.Arredondar(4); }
+            set { _pRedBc = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -86,8 +86,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal? pICMS
         {
-            get { return _pIcms; }
-            set { _pIcms = value; }
+            get { return _pIcms.Arredondar(4); }
+            set { _pIcms = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -95,8 +95,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal? vICMS
         {
-            get { return _vIcms; }
-            set { _vIcms = value; }
+            get { return _vIcms.Arredondar(2); }
+            set { _vIcms = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -109,8 +109,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal? pMVAST
         {
-            get { return _pMvast; }
-            set { _pMvast = value; }
+            get { return _pMvast.Arredondar(4); }
+            set { _pMvast = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -118,8 +118,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal? pRedBCST
         {
-            get { return _pRedBcst; }
-            set { _pRedBcst = value; }
+            get { return _pRedBcst.Arredondar(4); }
+            set { _pRedBcst = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -127,8 +127,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal? vBCST
         {
-            get { return _vBcst; }
-            set { _vBcst = value; }
+            get { return _vBcst.Arredondar(2); }
+            set { _vBcst = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -136,8 +136,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal? pICMSST
         {
-            get { return _pIcmsst; }
-            set { _pIcmsst = value; }
+            get { return _pIcmsst.Arredondar(4); }
+            set { _pIcmsst = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -145,8 +145,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal? vICMSST
         {
-            get { return _vIcmsst; }
-            set { _vIcmsst = value; }
+            get { return _vIcmsst.Arredondar(2); }
+            set { _vIcmsst = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -154,8 +154,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal? pCredSN
         {
-            get { return _pCredSn; }
-            set { _pCredSn = value; }
+            get { return _pCredSn.Arredondar(4); }
+            set { _pCredSn = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -163,8 +163,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// </summary>
         public decimal? vCredICMSSN
         {
-            get { return _vCredIcmssn; }
-            set { _vCredIcmssn = value; }
+            get { return _vCredIcmssn.Arredondar(2); }
+            set { _vCredIcmssn = value.Arredondar(2); }
         }
 
         public bool ShouldSerializemodBC()

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMSST.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMSST.cs
@@ -57,7 +57,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         public decimal vBCSTRet
         {
             get { return _vBcstRet; }
-            set { _vBcstRet = value; }
+            set { _vBcstRet = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -66,7 +66,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         public decimal vICMSSTRet
         {
             get { return _vIcmsstRet; }
-            set { _vIcmsstRet = value; }
+            set { _vIcmsstRet = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -75,7 +75,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         public decimal vBCSTDest
         {
             get { return _vBcstDest; }
-            set { _vBcstDest = value; }
+            set { _vBcstDest = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -84,7 +84,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         public decimal vICMSSTDest
         {
             get { return _vIcmsstDest; }
-            set { _vIcmsstDest = value; }
+            set { _vIcmsstDest = value.Arredondar(2); }
         }
     }
 }

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMSUFDest.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMSUFDest.cs
@@ -44,7 +44,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         public decimal vBCUFDest
         {
             get { return _vBcufDest; }
-            set { _vBcufDest = value; }
+            set { _vBcufDest = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -55,7 +55,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
             get { return _pFcpufDest; }
             set
             {
-                _pFcpufDest = value; }
+                _pFcpufDest = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -64,7 +64,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         public decimal pICMSUFDest
         {
             get { return _pIcmsufDest; }
-            set { _pIcmsufDest = value; }
+            set { _pIcmsufDest = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -73,7 +73,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         public decimal pICMSInter
         {
             get { return _pIcmsInter; }
-            set { _pIcmsInter = value; }
+            set { _pIcmsInter = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -82,7 +82,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         public decimal pICMSInterPart
         {
             get { return _pIcmsInterPart; }
-            set { _pIcmsInterPart = value; }
+            set { _pIcmsInterPart = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -91,7 +91,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         public decimal vFCPUFDest
         {
             get { return _vFcpufDest; }
-            set { _vFcpufDest = value; }
+            set { _vFcpufDest = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -100,7 +100,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         public decimal vICMSUFDest
         {
             get { return _vIcmsufDest; }
-            set { _vIcmsufDest = value; }
+            set { _vIcmsufDest = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -109,7 +109,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         public decimal vICMSUFRemet
         {
             get { return _vIcmsufRemet; }
-            set { _vIcmsufRemet = value; }
+            set { _vIcmsufRemet = value.Arredondar(2); }
         }
     }
 }

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Federal/COFINSAliq.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Federal/COFINSAliq.cs
@@ -51,7 +51,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         public decimal vBC
         {
             get { return _vBc; }
-            set { _vBc = value; }
+            set { _vBc = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -60,7 +60,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         public decimal pCOFINS
         {
             get { return _pCofins; }
-            set { _pCofins = value; }
+            set { _pCofins = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -69,7 +69,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         public decimal vCOFINS
         {
             get { return _vCofins; }
-            set { _vCofins = value; }
+            set { _vCofins = value.Arredondar(2); }
         }
     }
 }

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Federal/COFINSOutr.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Federal/COFINSOutr.cs
@@ -52,8 +52,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// </summary>
         public decimal? vBC
         {
-            get { return _vBc; }
-            set { _vBc = value; }
+            get { return _vBc.Arredondar(2); }
+            set { _vBc = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -61,8 +61,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// </summary>
         public decimal? pCOFINS
         {
-            get { return _pCofins; }
-            set { _pCofins = value; }
+            get { return _pCofins.Arredondar(4); }
+            set { _pCofins = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -70,8 +70,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// </summary>
         public decimal? qBCProd
         {
-            get { return _qBcProd; }
-            set { _qBcProd = value; }
+            get { return _qBcProd.Arredondar(4); }
+            set { _qBcProd = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -79,8 +79,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// </summary>
         public decimal? vAliqProd
         {
-            get { return _vAliqProd; }
-            set { _vAliqProd = value; }
+            get { return _vAliqProd.Arredondar(4); }
+            set { _vAliqProd = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -88,8 +88,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// </summary>
         public decimal? vCOFINS
         {
-            get { return _vCofins; }
-            set { _vCofins = value; }
+            get { return _vCofins.Arredondar(2); }
+            set { _vCofins = value.Arredondar(2); }
         }
 
         public bool ShouldSerializevBC()

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Federal/COFINSQtde.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Federal/COFINSQtde.cs
@@ -51,7 +51,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         public decimal qBCProd
         {
             get { return _qBcProd; }
-            set { _qBcProd = value; }
+            set { _qBcProd = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -60,7 +60,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         public decimal vAliqProd
         {
             get { return _vAliqProd; }
-            set { _vAliqProd = value; }
+            set { _vAliqProd = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -69,7 +69,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         public decimal vCOFINS
         {
             get { return _vCofins; }
-            set { _vCofins = value; }
+            set { _vCofins = value.Arredondar(2); }
         }
     }
 }

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Federal/COFINSST.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Federal/COFINSST.cs
@@ -47,8 +47,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// </summary>
         public decimal? vBC
         {
-            get { return _vBc; }
-            set { _vBc = value; }
+            get { return _vBc.Arredondar(2); }
+            set { _vBc = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -56,8 +56,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// </summary>
         public decimal? pCOFINS
         {
-            get { return _pCofins; }
-            set { _pCofins = value; }
+            get { return _pCofins.Arredondar(4); }
+            set { _pCofins = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -65,8 +65,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// </summary>
         public decimal? qBCProd
         {
-            get { return _qBcProd; }
-            set { _qBcProd = value; }
+            get { return _qBcProd.Arredondar(4); }
+            set { _qBcProd = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -74,8 +74,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// </summary>
         public decimal? vAliqProd
         {
-            get { return _vAliqProd; }
-            set { _vAliqProd = value; }
+            get { return _vAliqProd.Arredondar(4); }
+            set { _vAliqProd = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -83,8 +83,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// </summary>
         public decimal? vCOFINS
         {
-            get { return _vCofins; }
-            set { _vCofins = value; }
+            get { return _vCofins.Arredondar(2); }
+            set { _vCofins = value.Arredondar(2); }
         }
 
         public bool ShouldSerializevBC()

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Federal/II.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Federal/II.cs
@@ -45,7 +45,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         public decimal vBC
         {
             get { return _vBc; }
-            set { _vBc = value; }
+            set { _vBc = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -54,7 +54,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         public decimal vDespAdu
         {
             get { return _vDespAdu; }
-            set { _vDespAdu = value; }
+            set { _vDespAdu = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -63,7 +63,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         public decimal vII
         {
             get { return _vIi; }
-            set { _vIi = value; }
+            set { _vIi = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -72,7 +72,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         public decimal vIOF
         {
             get { return _vIof; }
-            set { _vIof = value; }
+            set { _vIof = value.Arredondar(2); }
         }
     }
 }

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Federal/IPITrib.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Federal/IPITrib.cs
@@ -52,8 +52,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// </summary>
         public decimal? vBC
         {
-            get { return _vBc; }
-            set { _vBc = value; }
+            get { return _vBc.Arredondar(2); }
+            set { _vBc = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -61,8 +61,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// </summary>
         public decimal? pIPI
         {
-            get { return _pIpi; }
-            set { _pIpi = value; }
+            get { return _pIpi.Arredondar(4); }
+            set { _pIpi = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -70,8 +70,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// </summary>
         public decimal? qUnid
         {
-            get { return _qUnid; }
-            set { _qUnid = value; }
+            get { return _qUnid.Arredondar(4); }
+            set { _qUnid = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -79,8 +79,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// </summary>
         public decimal? vUnid
         {
-            get { return _vUnid; }
-            set { _vUnid = value; }
+            get { return _vUnid.Arredondar(4); }
+            set { _vUnid = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -88,8 +88,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// </summary>
         public decimal? vIPI
         {
-            get { return _vIpi; }
-            set { _vIpi = value; }
+            get { return _vIpi.Arredondar(2); }
+            set { _vIpi = value.Arredondar(2); }
         }
 
         public bool ShouldSerializevBC()

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Federal/PISAliq.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Federal/PISAliq.cs
@@ -51,7 +51,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         public decimal vBC
         {
             get { return _vBc; }
-            set { _vBc = value; }
+            set { _vBc = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -60,7 +60,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         public decimal pPIS
         {
             get { return _pPis; }
-            set { _pPis = value; }
+            set { _pPis = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -69,7 +69,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         public decimal vPIS
         {
             get { return _vPis; }
-            set { _vPis = value; }
+            set { _vPis = value.Arredondar(2); }
         }
     }
 }

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Federal/PISOutr.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Federal/PISOutr.cs
@@ -52,8 +52,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// </summary>
         public decimal? vBC
         {
-            get { return _vBc; }
-            set { _vBc = value; }
+            get { return _vBc.Arredondar(2); }
+            set { _vBc = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -61,8 +61,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// </summary>
         public decimal? pPIS
         {
-            get { return _pPis; }
-            set { _pPis = value; }
+            get { return _pPis.Arredondar(4); }
+            set { _pPis = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -70,8 +70,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// </summary>
         public decimal? qBCProd
         {
-            get { return _qBcProd; }
-            set { _qBcProd = value; }
+            get { return _qBcProd.Arredondar(4); }
+            set { _qBcProd = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -79,8 +79,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// </summary>
         public decimal? vAliqProd
         {
-            get { return _vAliqProd; }
-            set { _vAliqProd = value; }
+            get { return _vAliqProd.Arredondar(4); }
+            set { _vAliqProd = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -88,8 +88,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// </summary>
         public decimal? vPIS
         {
-            get { return _vPis; }
-            set { _vPis = value; }
+            get { return _vPis.Arredondar(2); }
+            set { _vPis = value.Arredondar(2); }
         }
 
         public bool ShouldSerializevBC()

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Federal/PISQtde.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Federal/PISQtde.cs
@@ -51,7 +51,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         public decimal qBCProd
         {
             get { return _qBcProd; }
-            set { _qBcProd = value; }
+            set { _qBcProd = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -60,7 +60,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         public decimal vAliqProd
         {
             get { return _vAliqProd; }
-            set { _vAliqProd = value; }
+            set { _vAliqProd = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -69,7 +69,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         public decimal vPIS
         {
             get { return _vPis; }
-            set { _vPis = value; }
+            set { _vPis = value.Arredondar(2); }
         }
     }
 }

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Federal/PISST.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Federal/PISST.cs
@@ -47,8 +47,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// </summary>
         public decimal? vBC
         {
-            get { return _vBc; }
-            set { _vBc = value; }
+            get { return _vBc.Arredondar(2); }
+            set { _vBc = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -56,8 +56,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// </summary>
         public decimal? pPIS
         {
-            get { return _pPis; }
-            set { _pPis = value; }
+            get { return _pPis.Arredondar(4); }
+            set { _pPis = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -65,8 +65,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// </summary>
         public decimal? qBCProd
         {
-            get { return _qBcProd; }
-            set { _qBcProd = value; }
+            get { return _qBcProd.Arredondar(4); }
+            set { _qBcProd = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -74,8 +74,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// </summary>
         public decimal? vAliqProd
         {
-            get { return _vAliqProd; }
-            set { _vAliqProd = value; }
+            get { return _vAliqProd.Arredondar(4); }
+            set { _vAliqProd = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -83,8 +83,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// </summary>
         public decimal? vPIS
         {
-            get { return _vPis; }
-            set { _vPis = value; }
+            get { return _vPis.Arredondar(2); }
+            set { _vPis = value.Arredondar(2); }
         }
 
         public bool ShouldSerializevBC()

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Municipal/ISSQN.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Municipal/ISSQN.cs
@@ -49,7 +49,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Municipal
         public decimal vBC
         {
             get { return _vBc; }
-            set { _vBc = value; }
+            set { _vBc = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -58,7 +58,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Municipal
         public decimal vAliq
         {
             get { return _vAliq; }
-            set { _vAliq = value; }
+            set { _vAliq = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -67,7 +67,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Municipal
         public decimal vISSQN
         {
             get { return _vIssqn; }
-            set { _vIssqn = value; }
+            set { _vIssqn = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -85,8 +85,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Municipal
         /// </summary>
         public decimal? vDeducao
         {
-            get { return _vDeducao; }
-            set { _vDeducao = value; }
+            get { return _vDeducao.Arredondar(2); }
+            set { _vDeducao = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -94,8 +94,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Municipal
         /// </summary>
         public decimal? vOutro
         {
-            get { return _vOutro; }
-            set { _vOutro = value; }
+            get { return _vOutro.Arredondar(2); }
+            set { _vOutro = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -103,8 +103,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Municipal
         /// </summary>
         public decimal? vDescIncond
         {
-            get { return _vDescIncond; }
-            set { _vDescIncond = value; }
+            get { return _vDescIncond.Arredondar(2); }
+            set { _vDescIncond = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -112,8 +112,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Municipal
         /// </summary>
         public decimal? vDescCond
         {
-            get { return _vDescCond; }
-            set { _vDescCond = value; }
+            get { return _vDescCond.Arredondar(2); }
+            set { _vDescCond = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -121,8 +121,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Municipal
         /// </summary>
         public decimal? vISSRet
         {
-            get { return _vIssRet; }
-            set { _vIssRet = value; }
+            get { return _vIssRet.Arredondar(2); }
+            set { _vIssRet = value.Arredondar(2); }
         }
 
         /// <summary>

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/imposto.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/imposto.cs
@@ -45,8 +45,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao
         /// </summary>
         public decimal? vTotTrib
         {
-            get { return _vTotTrib; }
-            set { _vTotTrib = value; }
+            get { return _vTotTrib.Arredondar(2); }
+            set { _vTotTrib = value.Arredondar(2); }
         }
 
         /// <summary>

--- a/NFe.Classes/Informacoes/Detalhe/impostoDevol.cs
+++ b/NFe.Classes/Informacoes/Detalhe/impostoDevol.cs
@@ -42,7 +42,7 @@ namespace NFe.Classes.Informacoes.Detalhe
         public decimal pDevol
         {
             get { return _pDevol; }
-            set { _pDevol = value; }
+            set { _pDevol = value.Arredondar(2); }
         }
 
         /// <summary>

--- a/NFe.Classes/Informacoes/Detalhe/prod.cs
+++ b/NFe.Classes/Informacoes/Detalhe/prod.cs
@@ -118,7 +118,7 @@ namespace NFe.Classes.Informacoes.Detalhe
         public decimal qCom
         {
             get { return _qcom; }
-            set { _qcom = value; }
+            set { _qcom = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -127,7 +127,7 @@ namespace NFe.Classes.Informacoes.Detalhe
         public decimal vUnCom
         {
             get { return _vUnCom; }
-            set { _vUnCom = value; }
+            set { _vUnCom = value.Arredondar(10); }
         }
 
         /// <summary>
@@ -136,7 +136,7 @@ namespace NFe.Classes.Informacoes.Detalhe
         public decimal vProd
         {
             get { return _vprod; }
-            set { _vprod = value; }
+            set { _vprod = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -159,7 +159,7 @@ namespace NFe.Classes.Informacoes.Detalhe
         public decimal qTrib
         {
             get { return _qtrib; }
-            set { _qtrib = value; }
+            set { _qtrib = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -168,7 +168,7 @@ namespace NFe.Classes.Informacoes.Detalhe
         public decimal vUnTrib
         {
             get { return _vUnTrib; }
-            set { _vUnTrib = value; }
+            set { _vUnTrib = value.Arredondar(10); }
         }
 
         /// <summary>
@@ -176,8 +176,8 @@ namespace NFe.Classes.Informacoes.Detalhe
         /// </summary>
         public decimal? vFrete
         {
-            get { return _vFrete; }
-            set { _vFrete = value; }
+            get { return _vFrete.Arredondar(2); }
+            set { _vFrete = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -185,8 +185,8 @@ namespace NFe.Classes.Informacoes.Detalhe
         /// </summary>
         public decimal? vSeg
         {
-            get { return _vSeg; }
-            set { _vSeg = value; }
+            get { return _vSeg.Arredondar(2); }
+            set { _vSeg = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -194,8 +194,8 @@ namespace NFe.Classes.Informacoes.Detalhe
         /// </summary>
         public decimal? vDesc
         {
-            get { return _vDesc; }
-            set { _vDesc = value; }
+            get { return _vDesc.Arredondar(2); }
+            set { _vDesc = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -203,8 +203,8 @@ namespace NFe.Classes.Informacoes.Detalhe
         /// </summary>
         public decimal? vOutro
         {
-            get { return _vOutro; }
-            set { _vOutro = value; }
+            get { return _vOutro.Arredondar(2); }
+            set { _vOutro = value.Arredondar(2); }
         }
 
         /// <summary>

--- a/NFe.Classes/Informacoes/Pagamento/pag.cs
+++ b/NFe.Classes/Informacoes/Pagamento/pag.cs
@@ -47,7 +47,7 @@ namespace NFe.Classes.Informacoes.Pagamento
         public decimal vPag
         {
             get { return _vPag; }
-            set { _vPag = value; }
+            set { _vPag = value.Arredondar(2); }
         }
 
         /// <summary>

--- a/NFe.Classes/Informacoes/Total/ICMSTot.cs
+++ b/NFe.Classes/Informacoes/Total/ICMSTot.cs
@@ -59,8 +59,8 @@ namespace NFe.Classes.Informacoes.Total
         /// </summary>
         public decimal vBC
         {
-            get { return _vBc; }
-            set { _vBc = value; }
+            get { return _vBc.Arredondar(2); }
+            set { _vBc = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -68,8 +68,8 @@ namespace NFe.Classes.Informacoes.Total
         /// </summary>
         public decimal vICMS
         {
-            get { return _vIcms; }
-            set { _vIcms = value; }
+            get { return _vIcms.Arredondar(2); }
+            set { _vIcms = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -77,8 +77,8 @@ namespace NFe.Classes.Informacoes.Total
         /// </summary>
         public decimal? vICMSDeson
         {
-            get { return _vIcmsDeson; }
-            set { _vIcmsDeson = value; }
+            get { return _vIcmsDeson.Arredondar(2); }
+            set { _vIcmsDeson = value.Arredondar(2); }
         } //Nulable por conta da v2.00
 
         public bool ShouldSerializevICMSDeson()
@@ -91,8 +91,8 @@ namespace NFe.Classes.Informacoes.Total
         /// </summary>
         public decimal? vFCPUFDest
         {
-            get { return _vFcpufDest; }
-            set { _vFcpufDest = value; }
+            get { return _vFcpufDest.Arredondar(2); }
+            set { _vFcpufDest = value.Arredondar(2); }
         }
 
         public bool ShouldSerializevFCPUFDest()
@@ -105,8 +105,8 @@ namespace NFe.Classes.Informacoes.Total
         /// </summary>
         public decimal? vICMSUFDest
         {
-            get { return _vIcmsufDest; }
-            set { _vIcmsufDest = value; }
+            get { return _vIcmsufDest.Arredondar(2); }
+            set { _vIcmsufDest = value.Arredondar(2); }
         }
 
         public bool ShouldSerializevICMSUFDest()
@@ -119,8 +119,8 @@ namespace NFe.Classes.Informacoes.Total
         /// </summary>
         public decimal? vICMSUFRemet
         {
-            get { return _vIcmsufRemet; }
-            set { _vIcmsufRemet = value; }
+            get { return _vIcmsufRemet.Arredondar(2); }
+            set { _vIcmsufRemet = value.Arredondar(2); }
         }
 
         public bool ShouldSerializevICMSUFRemet()
@@ -133,8 +133,8 @@ namespace NFe.Classes.Informacoes.Total
         /// </summary>
         public decimal vBCST
         {
-            get { return _vBcst; }
-            set { _vBcst = value; }
+            get { return _vBcst.Arredondar(2); }
+            set { _vBcst = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -142,8 +142,8 @@ namespace NFe.Classes.Informacoes.Total
         /// </summary>
         public decimal vST
         {
-            get { return _vSt; }
-            set { _vSt = value; }
+            get { return _vSt.Arredondar(2); }
+            set { _vSt = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -151,8 +151,8 @@ namespace NFe.Classes.Informacoes.Total
         /// </summary>
         public decimal vProd
         {
-            get { return _vProd; }
-            set { _vProd = value; }
+            get { return _vProd.Arredondar(2); }
+            set { _vProd = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -160,8 +160,8 @@ namespace NFe.Classes.Informacoes.Total
         /// </summary>
         public decimal vFrete
         {
-            get { return _vFrete; }
-            set { _vFrete = value; }
+            get { return _vFrete.Arredondar(2); }
+            set { _vFrete = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -169,8 +169,8 @@ namespace NFe.Classes.Informacoes.Total
         /// </summary>
         public decimal vSeg
         {
-            get { return _vSeg; }
-            set { _vSeg = value; }
+            get { return _vSeg.Arredondar(2); }
+            set { _vSeg = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -178,8 +178,8 @@ namespace NFe.Classes.Informacoes.Total
         /// </summary>
         public decimal vDesc
         {
-            get { return _vDesc; }
-            set { _vDesc = value; }
+            get { return _vDesc.Arredondar(2); }
+            set { _vDesc = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -187,8 +187,8 @@ namespace NFe.Classes.Informacoes.Total
         /// </summary>
         public decimal vII
         {
-            get { return _vIi; }
-            set { _vIi = value; }
+            get { return _vIi.Arredondar(2); }
+            set { _vIi = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -196,8 +196,8 @@ namespace NFe.Classes.Informacoes.Total
         /// </summary>
         public decimal vIPI
         {
-            get { return _vIpi; }
-            set { _vIpi = value; }
+            get { return _vIpi.Arredondar(2); }
+            set { _vIpi = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -205,8 +205,8 @@ namespace NFe.Classes.Informacoes.Total
         /// </summary>
         public decimal vPIS
         {
-            get { return _vPis; }
-            set { _vPis = value; }
+            get { return _vPis.Arredondar(2); }
+            set { _vPis = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -214,8 +214,8 @@ namespace NFe.Classes.Informacoes.Total
         /// </summary>
         public decimal vCOFINS
         {
-            get { return _vCofins; }
-            set { _vCofins = value; }
+            get { return _vCofins.Arredondar(2); }
+            set { _vCofins = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -223,8 +223,8 @@ namespace NFe.Classes.Informacoes.Total
         /// </summary>
         public decimal vOutro
         {
-            get { return _vOutro; }
-            set { _vOutro = value; }
+            get { return _vOutro.Arredondar(2); }
+            set { _vOutro = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -232,8 +232,8 @@ namespace NFe.Classes.Informacoes.Total
         /// </summary>
         public decimal vNF
         {
-            get { return _vNf; }
-            set { _vNf = value; }
+            get { return _vNf.Arredondar(2); }
+            set { _vNf = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -241,8 +241,8 @@ namespace NFe.Classes.Informacoes.Total
         /// </summary>
         public decimal vTotTrib
         {
-            get { return _vTotTrib; }
-            set { _vTotTrib = value; }
+            get { return _vTotTrib.Arredondar(2); }
+            set { _vTotTrib = value.Arredondar(2); }
         }
 
     }

--- a/NFe.Classes/Informacoes/Total/ISSQNtot.cs
+++ b/NFe.Classes/Informacoes/Total/ISSQNtot.cs
@@ -50,8 +50,8 @@ namespace NFe.Classes.Informacoes.Total
         /// </summary>
         public decimal? vServ
         {
-            get { return _vServ; }
-            set { _vServ = value; }
+            get { return _vServ.Arredondar(2); }
+            set { _vServ = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -59,8 +59,8 @@ namespace NFe.Classes.Informacoes.Total
         /// </summary>
         public decimal? vBC
         {
-            get { return _vBc; }
-            set { _vBc = value; }
+            get { return _vBc.Arredondar(2); }
+            set { _vBc = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -68,8 +68,8 @@ namespace NFe.Classes.Informacoes.Total
         /// </summary>
         public decimal? vISS
         {
-            get { return _vIss; }
-            set { _vIss = value; }
+            get { return _vIss.Arredondar(2); }
+            set { _vIss = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -77,8 +77,8 @@ namespace NFe.Classes.Informacoes.Total
         /// </summary>
         public decimal? vPIS
         {
-            get { return _vPis; }
-            set { _vPis = value; }
+            get { return _vPis.Arredondar(2); }
+            set { _vPis = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -86,8 +86,8 @@ namespace NFe.Classes.Informacoes.Total
         /// </summary>
         public decimal? vCOFINS
         {
-            get { return _vCofins; }
-            set { _vCofins = value; }
+            get { return _vCofins.Arredondar(2); }
+            set { _vCofins = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -100,8 +100,8 @@ namespace NFe.Classes.Informacoes.Total
         /// </summary>
         public decimal? vDeducao
         {
-            get { return _vDeducao; }
-            set { _vDeducao = value; }
+            get { return _vDeducao.Arredondar(2); }
+            set { _vDeducao = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -109,8 +109,8 @@ namespace NFe.Classes.Informacoes.Total
         /// </summary>
         public decimal? vOutro
         {
-            get { return _vOutro; }
-            set { _vOutro = value; }
+            get { return _vOutro.Arredondar(2); }
+            set { _vOutro = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -118,8 +118,8 @@ namespace NFe.Classes.Informacoes.Total
         /// </summary>
         public decimal? vDescIncond
         {
-            get { return _vDescIncond; }
-            set { _vDescIncond = value; }
+            get { return _vDescIncond.Arredondar(2); }
+            set { _vDescIncond = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -127,8 +127,8 @@ namespace NFe.Classes.Informacoes.Total
         /// </summary>
         public decimal? vDescCond
         {
-            get { return _vDescCond; }
-            set { _vDescCond = value; }
+            get { return _vDescCond.Arredondar(2); }
+            set { _vDescCond = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -136,8 +136,8 @@ namespace NFe.Classes.Informacoes.Total
         /// </summary>
         public decimal? vISSRet
         {
-            get { return _vIssRet; }
-            set { _vIssRet = value; }
+            get { return _vIssRet.Arredondar(2); }
+            set { _vIssRet = value.Arredondar(2); }
         }
 
         /// <summary>

--- a/NFe.Classes/Informacoes/Total/retTrib.cs
+++ b/NFe.Classes/Informacoes/Total/retTrib.cs
@@ -47,8 +47,8 @@ namespace NFe.Classes.Informacoes.Total
         /// </summary>
         public decimal? vRetPIS
         {
-            get { return _vRetPis; }
-            set { _vRetPis = value; }
+            get { return _vRetPis.Arredondar(2); }
+            set { _vRetPis = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -56,8 +56,8 @@ namespace NFe.Classes.Informacoes.Total
         /// </summary>
         public decimal? vRetCOFINS
         {
-            get { return _vRetCofins; }
-            set { _vRetCofins = value; }
+            get { return _vRetCofins.Arredondar(2); }
+            set { _vRetCofins = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -65,8 +65,8 @@ namespace NFe.Classes.Informacoes.Total
         /// </summary>
         public decimal? vRetCSLL
         {
-            get { return _vRetCsll; }
-            set { _vRetCsll = value; }
+            get { return _vRetCsll.Arredondar(2); }
+            set { _vRetCsll = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -74,8 +74,8 @@ namespace NFe.Classes.Informacoes.Total
         /// </summary>
         public decimal? vBCIRRF
         {
-            get { return _vBcirrf; }
-            set { _vBcirrf = value; }
+            get { return _vBcirrf.Arredondar(2); }
+            set { _vBcirrf = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -83,8 +83,8 @@ namespace NFe.Classes.Informacoes.Total
         /// </summary>
         public decimal? vIRRF
         {
-            get { return _vIrrf; }
-            set { _vIrrf = value; }
+            get { return _vIrrf.Arredondar(2); }
+            set { _vIrrf = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -92,8 +92,8 @@ namespace NFe.Classes.Informacoes.Total
         /// </summary>
         public decimal? vBCRetPrev
         {
-            get { return _vBcRetPrev; }
-            set { _vBcRetPrev = value; }
+            get { return _vBcRetPrev.Arredondar(2); }
+            set { _vBcRetPrev = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -101,8 +101,8 @@ namespace NFe.Classes.Informacoes.Total
         /// </summary>
         public decimal? vRetPrev
         {
-            get { return _vRetPrev; }
-            set { _vRetPrev = value; }
+            get { return _vRetPrev.Arredondar(2); }
+            set { _vRetPrev = value.Arredondar(2); }
         }
 
         public bool ShouldSerializevRetPIS()

--- a/NFe.Classes/Informacoes/Transporte/retTransp.cs
+++ b/NFe.Classes/Informacoes/Transporte/retTransp.cs
@@ -45,7 +45,7 @@ namespace NFe.Classes.Informacoes.Transporte
         public decimal vServ
         {
             get { return _vServ; }
-            set { _vServ = value; }
+            set { _vServ = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -54,7 +54,7 @@ namespace NFe.Classes.Informacoes.Transporte
         public decimal vBCRet
         {
             get { return _vBcRet; }
-            set { _vBcRet = value; }
+            set { _vBcRet = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -63,7 +63,7 @@ namespace NFe.Classes.Informacoes.Transporte
         public decimal pICMSRet
         {
             get { return _pIcmsRet; }
-            set { _pIcmsRet = value; }
+            set { _pIcmsRet = value.Arredondar(4); }
         }
 
         /// <summary>
@@ -72,7 +72,7 @@ namespace NFe.Classes.Informacoes.Transporte
         public decimal vICMSRet
         {
             get { return _vIcmsRet; }
-            set { _vIcmsRet = value; }
+            set { _vIcmsRet = value.Arredondar(2); }
         }
 
         /// <summary>

--- a/NFe.Classes/Informacoes/Transporte/vol.cs
+++ b/NFe.Classes/Informacoes/Transporte/vol.cs
@@ -65,8 +65,8 @@ namespace NFe.Classes.Informacoes.Transporte
         /// </summary>
         public decimal? pesoL
         {
-            get { return _pesoL; }
-            set { _pesoL = value; }
+            get { return _pesoL.Arredondar(3); }
+            set { _pesoL = value.Arredondar(3); }
         }
 
         /// <summary>
@@ -74,8 +74,8 @@ namespace NFe.Classes.Informacoes.Transporte
         /// </summary>
         public decimal? pesoB
         {
-            get { return _pesoB; }
-            set { _pesoB = value; }
+            get { return _pesoB.Arredondar(3); }
+            set { _pesoB = value.Arredondar(3); }
         }
 
         /// <summary>

--- a/NFe.Classes/Informacoes/avulsa.cs
+++ b/NFe.Classes/Informacoes/avulsa.cs
@@ -82,7 +82,7 @@ namespace NFe.Classes.Informacoes
         public decimal vDAR
         {
             get { return _vDar; }
-            set { _vDar = value; }
+            set { _vDar = value.Arredondar(2); }
         }
 
         /// <summary>

--- a/NFe.Classes/NFe.Classes.csproj
+++ b/NFe.Classes/NFe.Classes.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Servicos\Download\retDownloadNFe.cs" />
     <Compile Include="Servicos\Download\retNFe.cs" />
     <Compile Include="Servicos\Inutilizacao\procInutNFe.cs" />
+    <Compile Include="Valor.cs" />
     <Compile Include="Informacoes\Cana\cana.cs" />
     <Compile Include="Informacoes\Cana\deduc.cs" />
     <Compile Include="Informacoes\Cana\forDia.cs" />
@@ -217,7 +218,6 @@
     <Compile Include="Servicos\Status\consStatServ.cs" />
     <Compile Include="Servicos\Status\retConsStatServ.cs" />
     <Compile Include="Servicos\Tipos\ServicosTipos.cs" />
-    <Compile Include="Valor.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="NFe.Classes.licenseheader" />

--- a/NFe.Classes/NFe.Classes.csproj.user
+++ b/NFe.Classes/NFe.Classes.csproj.user
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <ProjectView>ShowAllFiles</ProjectView>
+    <ProjectView>ProjectFiles</ProjectView>
   </PropertyGroup>
 </Project>

--- a/NFe.Classes/Servicos/Evento/dest.cs
+++ b/NFe.Classes/Servicos/Evento/dest.cs
@@ -120,7 +120,7 @@ namespace NFe.Classes.Servicos.Evento
         public decimal vNF
         {
             get { return _vNf; }
-            set { _vNf = value; }
+            set { _vNf = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -129,7 +129,7 @@ namespace NFe.Classes.Servicos.Evento
         public decimal vICMS
         {
             get { return _vIcms; }
-            set { _vIcms = value; }
+            set { _vIcms = value.Arredondar(2); }
         }
 
         /// <summary>
@@ -138,7 +138,7 @@ namespace NFe.Classes.Servicos.Evento
         public decimal vST
         {
             get { return _vSt; }
-            set { _vSt = value; }
+            set { _vSt = value.Arredondar(2); }
         }
 
         public bool ShouldSerializeIE()


### PR DESCRIPTION
Reverts adeniltonbs/Zeus.Net.NFe.NFCe#539~

Revertido. O arredondamento será removido. No entanto será necessário formatar os campos para o número de decimais informado no manual, para os casos onde o número de decimais informado no campo seja menor.
Ex: No manual o campo prod.vProd tem o tamanho 13v2. Se passar para a biblioteca um valor com uma decimal, como 1,1, o XML não será validado e gerará a exceção abaixo:
![image](https://user-images.githubusercontent.com/6733483/32249084-813b94be-be66-11e7-9ca8-c1b71f908eb5.png)
