### PR TITLE
Alteracao do tipo da proriedade cStat para inteiro

### DIFF
--- a/NFe.Classes/Servicos/DistribuicaoDFe/retDistDFeInt.cs
+++ b/NFe.Classes/Servicos/DistribuicaoDFe/retDistDFeInt.cs
@@ -62,7 +62,7 @@ namespace NFe.Classes.Servicos.DistribuicaoDFe
         /// <summary>
         /// B05 - Código do status da resposta (vide item 5)
         /// </summary>
-        public byte cStat { get; set; }
+        public int cStat { get; set; }
 
         /// <summary>
         /// B06 - Descrição literal do status da resposta


### PR DESCRIPTION
Retornos acima de 255 gera erro durante serialização da classe