### PR TITLE
Melhorias e correções no AppTeste

### DIFF
--- a/NFe.AppTeste/MainWindow.xaml
+++ b/NFe.AppTeste/MainWindow.xaml
@@ -68,6 +68,11 @@
     <Grid>
         <GroupBox Header="Configurações" HorizontalAlignment="Left" Width="500" Margin="1,0,0,0">
             <StackPanel HorizontalAlignment="Left" Margin="0,10,-2,-12" Width="490" VerticalAlignment="Top">
+                <DockPanel Dock="Bottom" Height="45">
+                    <Button x:Name="BtnSalvar" Content="Salvar Configurações para arquivo" Width="203"
+                            HorizontalAlignment="Center" VerticalAlignment="Center"
+                            Height="27" Click="btnSalvar_Click" />
+                </DockPanel>
                 <TabControl VerticalAlignment="Top" Height="700">
                     <TabItem Header="Certificado">
                         <Grid Background="White">
@@ -779,11 +784,6 @@
                         </Grid>
                     </TabItem>
                 </TabControl>
-                <DockPanel Dock="Bottom" Height="45">
-                    <Button x:Name="BtnSalvar" Content="Salvar Configurações para arquivo" Width="203"
-                            HorizontalAlignment="Center" VerticalAlignment="Center"
-                            Height="27" Click="btnSalvar_Click" />
-                </DockPanel>
             </StackPanel>
         </GroupBox>
         <TabControl Name="TabSuperior" Height="266" Margin="510,10,-0,0" VerticalAlignment="Top">

--- a/NFe.AppTeste/MainWindow.xaml.cs
+++ b/NFe.AppTeste/MainWindow.xaml.cs
@@ -1285,7 +1285,6 @@ namespace NFe.AppTeste
             var icmsTot = new ICMSTot
             {
                 vProd = produtos.Sum(p => p.prod.vProd),
-                vNF = produtos.Sum(p => p.prod.vProd) - produtos.Sum(p => p.prod.vDesc ?? 0),
                 vDesc = produtos.Sum(p => p.prod.vDesc ?? 0),
                 vTotTrib = produtos.Sum(p => p.imposto.vTotTrib ?? 0),
             };
@@ -1321,6 +1320,8 @@ namespace NFe.AppTeste
                 //Outros Ifs aqui, caso vá usar as classes ICMS00, ICMS10 para totalizar
             }
 
+             icmsTot.vNF = Convert.ToDecimal(icmsTot.vProd - icmsTot.vDesc - icmsTot.vICMSDeson + icmsTot.vST + icmsTot.vFCPST + icmsTot.vFrete + icmsTot.vSeg + icmsTot.vOutro + icmsTot.vII + icmsTot.vIPI + icmsTot.vIPIDevol);
+
             var t = new total {ICMSTot = icmsTot};
             return t;
         }
@@ -1351,14 +1352,14 @@ namespace NFe.AppTeste
 
         protected virtual cobr GetCobranca(ICMSTot icmsTot)
         {
-            var valorParcela = Valor.Arredondar(icmsTot.vProd/2, 2);
+            var valorParcela = Valor.Arredondar(icmsTot.vNF/2, 2);
             var c = new cobr
             {
-                fat = new fat {nFat = "12345678910", vLiq = icmsTot .vProd},
+                fat = new fat {nFat = "12345678910", vLiq = icmsTot.vNF, vOrig = icmsTot.vNF},
                 dup = new List<dup>
                 {
                     new dup {nDup = "12345678", vDup = valorParcela},
-                    new dup {nDup = "987654321", vDup = icmsTot.vProd - valorParcela}
+                    new dup {nDup = "987654321", vDup = icmsTot.vNF - valorParcela}
                 }
             };
 
@@ -1367,14 +1368,14 @@ namespace NFe.AppTeste
 
         protected virtual List<pag> GetPagamento(ICMSTot icmsTot, VersaoServico versao)
         {
-            var valorPagto = Valor.Arredondar(icmsTot.vProd / 2, 2);
+            var valorPagto = Valor.Arredondar(icmsTot.vNF / 2, 2);
 
             if (versao != VersaoServico.ve400) // difernte de versão 4 retorna isso
             {
                 var p = new List<pag>
                 {
                     new pag {tPag = FormaPagamento.fpDinheiro, vPag = valorPagto},
-                    new pag {tPag = FormaPagamento.fpCheque, vPag = icmsTot.vProd - valorPagto}
+                    new pag {tPag = FormaPagamento.fpCheque, vPag = icmsTot.vNF - valorPagto}
                 };
                 return p;
             }
@@ -1390,9 +1391,8 @@ namespace NFe.AppTeste
                     detPag = new List<detPag>
                     {
                         new detPag {tPag = FormaPagamento.fpDuplicataMercantil, vPag = valorPagto},
-                        new detPag {tPag = FormaPagamento.fpDuplicataMercantil, vPag = icmsTot.vProd - valorPagto}
+                        new detPag {tPag = FormaPagamento.fpDuplicataMercantil, vPag = icmsTot.vNF - valorPagto}
                     },
-                    vTroco = 0.50m
                 }
             };
 

--- a/NFe.AppTeste/MainWindow.xaml.cs
+++ b/NFe.AppTeste/MainWindow.xaml.cs
@@ -1285,7 +1285,6 @@ namespace NFe.AppTeste
             var icmsTot = new ICMSTot
             {
                 vProd = produtos.Sum(p => p.prod.vProd),
-                vNF = produtos.Sum(p => p.prod.vProd) - produtos.Sum(p => p.prod.vDesc ?? 0),
                 vDesc = produtos.Sum(p => p.prod.vDesc ?? 0),
                 vTotTrib = produtos.Sum(p => p.imposto.vTotTrib ?? 0),
             };
@@ -1320,6 +1319,9 @@ namespace NFe.AppTeste
                 }
                 //Outros Ifs aqui, caso vá usar as classes ICMS00, ICMS10 para totalizar
             }
+
+            //** Regra de validação W16-10 que rege sobre o Total da NF **//
+            icmsTot.vNF = Convert.ToDecimal(icmsTot.vProd - icmsTot.vDesc - icmsTot.vICMSDeson + icmsTot.vST + icmsTot.vFCPST + icmsTot.vFrete + icmsTot.vSeg + icmsTot.vOutro + icmsTot.vII + icmsTot.vIPI + icmsTot.vIPIDevol);
 
             var t = new total {ICMSTot = icmsTot};
             return t;

--- a/NFe.AppTeste/MainWindow.xaml.cs
+++ b/NFe.AppTeste/MainWindow.xaml.cs
@@ -1351,14 +1351,14 @@ namespace NFe.AppTeste
 
         protected virtual cobr GetCobranca(ICMSTot icmsTot)
         {
-            var valorParcela = Valor.Arredondar(icmsTot.vProd/2, 2);
+            var valorParcela = Valor.Arredondar(icmsTot.vNF/2, 2);
             var c = new cobr
             {
-                fat = new fat {nFat = "12345678910", vLiq = icmsTot.vProd, vOrig = icmsTot.vProd},
+                fat = new fat {nFat = "12345678910", vLiq = icmsTot.vNF, vOrig = icmsTot.vNF },
                 dup = new List<dup>
                 {
                     new dup {nDup = "12345678", vDup = valorParcela},
-                    new dup {nDup = "987654321", vDup = icmsTot.vProd - valorParcela}
+                    new dup {nDup = "987654321", vDup = icmsTot.vNF - valorParcela}
                 }
             };
 
@@ -1367,14 +1367,14 @@ namespace NFe.AppTeste
 
         protected virtual List<pag> GetPagamento(ICMSTot icmsTot, VersaoServico versao)
         {
-            var valorPagto = Valor.Arredondar(icmsTot.vProd / 2, 2);
+            var valorPagto = Valor.Arredondar(icmsTot.vNF / 2, 2);
 
             if (versao != VersaoServico.ve400) // difernte de versão 4 retorna isso
             {
                 var p = new List<pag>
                 {
                     new pag {tPag = FormaPagamento.fpDinheiro, vPag = valorPagto},
-                    new pag {tPag = FormaPagamento.fpCheque, vPag = icmsTot.vProd - valorPagto}
+                    new pag {tPag = FormaPagamento.fpCheque, vPag = icmsTot.vNF - valorPagto}
                 };
                 return p;
             }
@@ -1384,15 +1384,14 @@ namespace NFe.AppTeste
             var p4 = new List<pag>
             {
                 //new pag {detPag = new detPag {tPag = FormaPagamento.fpDinheiro, vPag = valorPagto}},
-                //new pag {detPag = new detPag {tPag = FormaPagamento.fpCheque, vPag = icmsTot.vProd - valorPagto}}
+                //new pag {detPag = new detPag {tPag = FormaPagamento.fpCheque, vPag = icmsTot.vNF - valorPagto}}
                 new pag
                 {
                     detPag = new List<detPag>
                     {
                         new detPag {tPag = FormaPagamento.fpDuplicataMercantil, vPag = valorPagto},
-                        new detPag {tPag = FormaPagamento.fpDuplicataMercantil, vPag = icmsTot.vProd - valorPagto}
-                    },
-                    vTroco = 0.50m
+                        new detPag {tPag = FormaPagamento.fpDuplicataMercantil, vPag = icmsTot.vNF - valorPagto}
+                    }                    
                 }
             };
 

--- a/NFe.AppTeste/MainWindow.xaml.cs
+++ b/NFe.AppTeste/MainWindow.xaml.cs
@@ -1285,6 +1285,7 @@ namespace NFe.AppTeste
             var icmsTot = new ICMSTot
             {
                 vProd = produtos.Sum(p => p.prod.vProd),
+                vNF = produtos.Sum(p => p.prod.vProd) - produtos.Sum(p => p.prod.vDesc ?? 0),
                 vDesc = produtos.Sum(p => p.prod.vDesc ?? 0),
                 vTotTrib = produtos.Sum(p => p.imposto.vTotTrib ?? 0),
             };
@@ -1320,8 +1321,6 @@ namespace NFe.AppTeste
                 //Outros Ifs aqui, caso vá usar as classes ICMS00, ICMS10 para totalizar
             }
 
-             icmsTot.vNF = Convert.ToDecimal(icmsTot.vProd - icmsTot.vDesc - icmsTot.vICMSDeson + icmsTot.vST + icmsTot.vFCPST + icmsTot.vFrete + icmsTot.vSeg + icmsTot.vOutro + icmsTot.vII + icmsTot.vIPI + icmsTot.vIPIDevol);
-
             var t = new total {ICMSTot = icmsTot};
             return t;
         }
@@ -1352,14 +1351,14 @@ namespace NFe.AppTeste
 
         protected virtual cobr GetCobranca(ICMSTot icmsTot)
         {
-            var valorParcela = Valor.Arredondar(icmsTot.vNF/2, 2);
+            var valorParcela = Valor.Arredondar(icmsTot.vProd/2, 2);
             var c = new cobr
             {
-                fat = new fat {nFat = "12345678910", vLiq = icmsTot.vNF, vOrig = icmsTot.vNF},
+                fat = new fat {nFat = "12345678910", vLiq = icmsTot .vProd},
                 dup = new List<dup>
                 {
                     new dup {nDup = "12345678", vDup = valorParcela},
-                    new dup {nDup = "987654321", vDup = icmsTot.vNF - valorParcela}
+                    new dup {nDup = "987654321", vDup = icmsTot.vProd - valorParcela}
                 }
             };
 
@@ -1368,14 +1367,14 @@ namespace NFe.AppTeste
 
         protected virtual List<pag> GetPagamento(ICMSTot icmsTot, VersaoServico versao)
         {
-            var valorPagto = Valor.Arredondar(icmsTot.vNF / 2, 2);
+            var valorPagto = Valor.Arredondar(icmsTot.vProd / 2, 2);
 
             if (versao != VersaoServico.ve400) // difernte de versão 4 retorna isso
             {
                 var p = new List<pag>
                 {
                     new pag {tPag = FormaPagamento.fpDinheiro, vPag = valorPagto},
-                    new pag {tPag = FormaPagamento.fpCheque, vPag = icmsTot.vNF - valorPagto}
+                    new pag {tPag = FormaPagamento.fpCheque, vPag = icmsTot.vProd - valorPagto}
                 };
                 return p;
             }
@@ -1391,8 +1390,9 @@ namespace NFe.AppTeste
                     detPag = new List<detPag>
                     {
                         new detPag {tPag = FormaPagamento.fpDuplicataMercantil, vPag = valorPagto},
-                        new detPag {tPag = FormaPagamento.fpDuplicataMercantil, vPag = icmsTot.vNF - valorPagto}
+                        new detPag {tPag = FormaPagamento.fpDuplicataMercantil, vPag = icmsTot.vProd - valorPagto}
                     },
+                    vTroco = 0.50m
                 }
             };
 

--- a/NFe.AppTeste/MainWindow.xaml.cs
+++ b/NFe.AppTeste/MainWindow.xaml.cs
@@ -1354,7 +1354,7 @@ namespace NFe.AppTeste
             var valorParcela = Valor.Arredondar(icmsTot.vProd/2, 2);
             var c = new cobr
             {
-                fat = new fat {nFat = "12345678910", vLiq = icmsTot .vProd},
+                fat = new fat {nFat = "12345678910", vLiq = icmsTot.vProd, vOrig = icmsTot.vProd},
                 dup = new List<dup>
                 {
                     new dup {nDup = "12345678", vDup = valorParcela},


### PR DESCRIPTION
- Movido o botão "Salvar Configurações para arquivo" para o topo do formulário, a fim de que este botão ficasse visível em monitores com resolução menor que formulário.

- Correção de acordo com a nova regra de validação **Y06-10** e **Y06-30** da [NT 2016.002 (versão 1.50)](http://tsdn.tecnospeed.com.br/blog-da-tecnospeed/post/o-que-mudou-na-versao-1-50-da-nota-tecnica-2016-002) que já passaram a valer no ambiente de homologação

- Correção de acordo com a nova regra de validação W16-10 que rege sobre o Total da NF 