### PR TITLE
Propriedade Specified

### DIFF
--- a/MDFe.Classes/Informacoes/MDFeInfUnidCarga.cs
+++ b/MDFe.Classes/Informacoes/MDFeInfUnidCarga.cs
@@ -63,5 +63,7 @@ namespace MDFe.Classes.Informacoes
         /// </summary>
         [XmlElement(ElementName = "qtdRat")]
         public decimal? QtdRat { get; set; }
-    }
+
+        public bool QtdRatSpecified { get { return QtdRat.HasValue; } }
+   }
 }

--- a/MDFe.Classes/Informacoes/MDFeInfUnidTransp.cs
+++ b/MDFe.Classes/Informacoes/MDFeInfUnidTransp.cs
@@ -69,5 +69,7 @@ namespace MDFe.Classes.Informacoes
         /// </summary>
         [XmlElement(ElementName = "qtdRat")]
         public decimal? QtdRat { get; set; }
-    }
+
+        public bool QtdRatSpecified { get { return QtdRat.HasValue; } }
+   }
 }


### PR DESCRIPTION
Está faltando a propriedade QtdRatQtdRatSpecified, pois de acordo com o manual são campos opcionais, e quando não alimentados o arquivo xml fica inválido, com valor nulo.