### PR TITLE
Correções na AppTeste e melhorias diversas

### DIFF
--- a/NFe.AppTeste/MainWindow.xaml.cs
+++ b/NFe.AppTeste/MainWindow.xaml.cs
@@ -1355,14 +1355,14 @@ namespace NFe.AppTeste
 
         protected virtual cobr GetCobranca(ICMSTot icmsTot)
         {
-            var valorParcela = Valor.Arredondar(icmsTot.vNF/2, 2);
+            var valorParcela = Valor.Arredondar(icmsTot.vNF / 2, 2);
             var c = new cobr
             {
-                fat = new fat {nFat = "12345678910", vLiq = icmsTot.vNF, vOrig = icmsTot.vNF },
+                fat = new fat { nFat = "12345678910", vLiq = icmsTot.vNF, vOrig = icmsTot.vNF, vDesc = 0m },
                 dup = new List<dup>
                 {
-                    new dup {nDup = "12345678", vDup = valorParcela},
-                    new dup {nDup = "987654321", vDup = icmsTot.vNF - valorParcela}
+                    new dup {nDup = "001", dVenc = DateTime.Now.AddDays(30), vDup = valorParcela},
+                    new dup {nDup = "002", dVenc = DateTime.Now.AddDays(60), vDup = icmsTot.vNF - valorParcela}
                 }
             };
 

--- a/NFe.AppTeste/MainWindow.xaml.cs
+++ b/NFe.AppTeste/MainWindow.xaml.cs
@@ -1069,9 +1069,12 @@ namespace NFe.AppTeste
                 {
                     vTotTrib = 0.17m,
 
-                    //Se você já tem os dados de toda a tributação persistida no banco em uma única tabela, utilize a classe NFe.Utils.Tributacao.Estadual.ICMSGeral para obter os dados básicos. Veja um exemplo no método ObterIcmsBasico()
                     ICMS = new ICMS
                     {
+                        //Se você já tem os dados de toda a tributação persistida no banco em uma única tabela, utilize a linha comentada abaixo para preencher as tags do ICMS
+                        //TipoICMS = ObterIcmsBasico(crt),
+
+                        //Caso você resolva utilizar método ObterIcmsBasico(), comente esta proxima linha
                         TipoICMS =
                             crt == CRT.SimplesNacional
                                 ? InformarCSOSN(Csosnicms.Csosn102)
@@ -1090,15 +1093,21 @@ namespace NFe.AppTeste
                     //    vICMSUFRemet = 0
                     //},
 
-                    //Se você já tem os dados de toda a tributação persistida no banco em uma única tabela, utilize a classe NFe.Utils.Tributacao.Federal.COFINSGeral para obter os dados básicos. Veja um exemplo no método ObterCofinsBasico()
                     COFINS = new COFINS
                     {
+                        //Se você já tem os dados de toda a tributação persistida no banco em uma única tabela, utilize a linha comentada abaixo para preencher as tags do COFINS
+                        //TipoCOFINS = ObterCofinsBasico(),
+
+                        //Caso você resolva utilizar método ObterCofinsBasico(), comente esta proxima linha
                         TipoCOFINS = new COFINSOutr {CST = CSTCOFINS.cofins99, pCOFINS = 0, vBC = 0, vCOFINS = 0}
                     },
-
-                    //Se você já tem os dados de toda a tributação persistida no banco em uma única tabela, utilize a classe NFe.Utils.Tributacao.Federal.PISGeral para obter os dados básicos. Veja um exemplo no método ObterPisBasico()
+                    
                     PIS = new PIS
                     {
+                        //Se você já tem os dados de toda a tributação persistida no banco em uma única tabela, utilize a linha comentada abaixo para preencher as tags do PIS
+                        //TipoPIS = ObterPisBasico(),
+
+                        //Caso você resolva utilizar método ObterPisBasico(), comente esta proxima linha
                         TipoPIS = new PISOutr {CST = CSTPIS.pis99, pPIS = 0, vBC = 0, vPIS = 0}
                     }
                 }
@@ -1106,10 +1115,14 @@ namespace NFe.AppTeste
 
             if (modelo == ModeloDocumento.NFe) //NFCe não aceita grupo "IPI"
             {
-                //Se você já tem os dados de toda a tributação persistida no banco em uma única tabela, utilize a classe NFe.Utils.Tributacao.Federal.IPIGeral para obter os dados básicos. Veja um exemplo no método ObterIpiBasico()
                 det.imposto.IPI = new IPI()
                 {
                     cEnq = 999,
+
+                    //Se você já tem os dados de toda a tributação persistida no banco em uma única tabela, utilize a linha comentada abaixo para preencher as tags do IPI
+                    //TipoIPI = ObterIPIBasico(),
+
+                    //Caso você resolva utilizar método ObterIPIBasico(), comente esta proxima linha
                     TipoIPI = new IPITrib() { CST = CSTIPI.ipi00, pIPI = 5, vBC = 1, vIPI = 0.05m }
                 };
             }
@@ -1193,7 +1206,7 @@ namespace NFe.AppTeste
             var icmsGeral = new ICMSGeral
             {
                 orig = OrigemMercadoria.OmNacional,
-                CST = Csticms.Cst20,
+                CST = Csticms.Cst00,
                 modBC = DeterminacaoBaseIcms.DbiValorOperacao,
                 vBC = 1.1m,
                 pICMS = 18,

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/Tipos/ICMSTipos.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/Tipos/ICMSTipos.cs
@@ -50,14 +50,49 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual.Tipos
     /// </summary>
     public enum OrigemMercadoria
     {
+        /// <summary>
+        /// 0-Nacional exceto as indicadas nos códigos 3, 4, 5 e 8
+        /// </summary>
         [XmlEnum("0")] OmNacional = 0,
+
+        /// <summary>
+        /// 2-Estrangeira - Adquirida no mercado interno
+        /// </summary>
         [XmlEnum("1")] OmEstrangeiraImportacaoDireta = 1,
+
+        /// <summary>
+        /// 3-Nacional, conteudo superior 40% e inferior ou igual a 70%
+        /// </summary>
         [XmlEnum("2")] OmEstrangeiraAdquiridaBrasil = 2,
+
+        /// <summary>
+        /// 3-Nacional, conteudo superior 40% e inferior ou igual a 70%
+        /// </summary>
         [XmlEnum("3")] OmNacionalConteudoImportacaoSuperior40 = 3,
+
+        /// <summary>
+        /// 4-Nacional, processos produtivos básicos
+        /// </summary>
         [XmlEnum("4")] OmNacionalProcessosBasicos = 4,
+
+        /// <summary>
+        /// 5-Nacional, conteudo inferior 40%
+        /// </summary>
         [XmlEnum("5")] OmNacionalConteudoImportacaoInferiorIgual40 = 5,
+
+        /// <summary>
+        /// 6-Estrangeira - Importação direta, com similar nacional, lista CAMEX
+        /// </summary>
         [XmlEnum("6")] OmEstrangeiraImportacaoDiretaSemSimilar = 6,
+
+        /// <summary>
+        /// 7-Estrangeira - mercado interno, sem simular,lista CAMEX
+        /// </summary>
         [XmlEnum("7")] OmEstrangeiraAdquiridaBrasilSemSimilar = 7,
+
+        /// <summary>
+        /// 8-Nacional, Conteúdo de Importação superior a 70%
+        /// </summary>
         [XmlEnum("8")] OmNacionalConteudoImportacaoSuperior70 = 8
     }
 
@@ -163,9 +198,24 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual.Tipos
     /// </summary>
     public enum DeterminacaoBaseIcms
     {
+        /// <summary>
+        /// 0 - Margem Valor Agregado (%)
+        /// </summary>
         [XmlEnum("0")] DbiMargemValorAgregado = 0,
+
+        /// <summary>
+        /// 1 - Pauta (valor)
+        /// </summary>
         [XmlEnum("1")] DbiPauta = 1,
+
+        /// <summary>
+        /// 2 - Preço Tabelado Máximo (valor)
+        /// </summary>
         [XmlEnum("2")] DbiPrecoTabelado = 2,
+
+        /// <summary>
+        /// 3 - Valor da Operação
+        /// </summary>
         [XmlEnum("3")] DbiValorOperacao = 3
     }
 
@@ -183,11 +233,34 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual.Tipos
     /// </summary>
     public enum DeterminacaoBaseIcmsSt
     {
+        /// <summary>
+        /// 0 – Preço tabelado ou máximo  sugerido
+        /// </summary>
         [XmlEnum("0")] DbisPrecoTabelado = 0,
+
+        /// <summary>
+        /// 1 - Lista Negativa (valor)
+        /// </summary>
         [XmlEnum("1")] DbisListaNegativa = 1,
+
+        /// <summary>
+        /// 2 - Lista Positiva (valor)
+        /// </summary>
         [XmlEnum("2")] DbisListaPositiva = 2,
+
+        /// <summary>
+        /// 3 - Lista Neutra (valor)
+        /// </summary>
         [XmlEnum("3")] DbisListaNeutra = 3,
+
+        /// <summary>
+        /// 4 - Margem Valor Agregado (%)
+        /// </summary>
         [XmlEnum("4")] DbisMargemValorAgregado = 4,
+
+        /// <summary>
+        /// 5 - Pauta (valor)
+        /// </summary>
         [XmlEnum("5")] DbisPauta = 5
     }
 

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/Tipos/ICMSTipos.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/Tipos/ICMSTipos.cs
@@ -218,15 +218,54 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual.Tipos
     /// </summary>
     public enum Csosnicms
     {
+        /// <summary>
+        /// 101 - Tributada pelo Simples Nacional com permissão de crédito
+        /// </summary>
         [XmlEnum("101")] Csosn101 = 101,
+
+        /// <summary>
+        /// 102 - Tributada pelo Simples Nacional sem permissão de crédito
+        /// </summary>
         [XmlEnum("102")] Csosn102 = 102,
+
+        /// <summary>
+        /// 103 – Isenção do ICMS  no Simples Nacional para faixa de receita bruta
+        /// </summary>
         [XmlEnum("103")] Csosn103 = 103,
+
+        /// <summary>
+        /// 201 - Tributada pelo Simples Nacional com permissão de crédito e com cobrança do ICMS por Substituição Tributária 
+        /// </summary>
         [XmlEnum("201")] Csosn201 = 201,
+
+        /// <summary>
+        /// 202 - Tributada pelo Simples Nacional sem permissão de crédito e com cobrança do ICMS por Substituição Tributária
+        /// </summary>
         [XmlEnum("202")] Csosn202 = 202,
+
+        /// <summary>
+        /// 203 -  Isenção do ICMS nos Simples Nacional para faixa de receita bruta e com cobrança do ICMS por Substituição Tributária 
+        /// </summary>
         [XmlEnum("203")] Csosn203 = 203,
+
+        /// <summary>
+        /// 300 – Imune
+        /// </summary>
         [XmlEnum("300")] Csosn300 = 300,
+
+        /// <summary>
+        /// 400 – Não tributada pelo Simples Nacional
+        /// </summary>
         [XmlEnum("400")] Csosn400 = 400,
+
+        /// <summary>
+        /// 500 – ICMS cobrado anterirmente por substituição tributária (substituído) ou por antecipação
+        /// </summary>
         [XmlEnum("500")] Csosn500 = 500,
+
+        /// <summary>
+        /// 900 - Outros
+        /// </summary>
         [XmlEnum("900")] Csosn900 = 900
     }
 

--- a/NFe.Classes/Informacoes/Emitente/emitTipos.cs
+++ b/NFe.Classes/Informacoes/Emitente/emitTipos.cs
@@ -41,8 +41,19 @@ namespace NFe.Classes.Informacoes.Emitente
     /// </summary>
     public enum CRT
     {
+        /// <summary>
+        /// 1 – Simples Nacional
+        /// </summary>
         [XmlEnum("1")] SimplesNacional = 1,
+
+        /// <summary>
+        /// 2 – Simples Nacional – excesso de sublimite de receita bruta
+        /// </summary>
         [XmlEnum("2")] SimplesNacionalExcessoSublimite = 2,
+
+        /// <summary>
+        /// 3 – Regime Normal
+        /// </summary>
         [XmlEnum("3")] RegimeNormal = 3
     }
 }

--- a/NFe.Classes/Informacoes/Pagamento/pagTipos.cs
+++ b/NFe.Classes/Informacoes/Pagamento/pagTipos.cs
@@ -54,35 +54,72 @@ namespace NFe.Classes.Informacoes.Pagamento
     /// </summary>
     public enum FormaPagamento
     {
+        /// <summary>
+        /// 01-Dinheiro
+        /// </summary>
         [Description("Dinheiro")] [XmlEnum("01")] fpDinheiro,
 
+        /// <summary>
+        /// 02-Cheque
+        /// </summary>
         [Description("Cheque")] [XmlEnum("02")] fpCheque,
 
+        /// <summary>
+        /// 03-Cartão de Crédito
+        /// </summary>
         [Description("Cartão de Crédito")] [XmlEnum("03")] fpCartaoCredito,
 
+        /// <summary>
+        /// 04-Cartão de Débito
+        /// </summary>
         [Description("Cartão de Débito")] [XmlEnum("04")] fpCartaoDebito,
 
+        /// <summary>
+        /// 05-Crédito Loja
+        /// </summary>
         [Description("Crédito Loja")] [XmlEnum("05")] fpCreditoLoja,
 
+        /// <summary>
+        /// 10-Vale Alimentação
+        /// </summary>
         [Description("Vale Alimentação")] [XmlEnum("10")] fpValeAlimentacao,
 
+        /// <summary>
+        /// 11-Vale Refeição
+        /// </summary>
         [Description("Vale Refeição")] [XmlEnum("11")] fpValeRefeicao,
 
+        /// <summary>
+        /// 12-Vale Presente
+        /// </summary>
         [Description("Vale Presente")] [XmlEnum("12")] fpValePresente,
 
+        /// <summary>
+        /// 13-Vale Combustível
+        /// </summary>
         [Description("Vale Combustível")] [XmlEnum("13")] fpValeCombustivel,
 
         /// <summary>
-        /// Foi excluido pela NT 2016. 002 v1.50
-        /// Continuara aqui pois a mesma alguém já pode ter utilizado
-        /// Foi excluido pela NT 2016. 002 v1.50, Continua pois a mesma pode ter sido utilizada já
+        /// 14-Duplicata Mercantil      
+        /// <para>Na NT2016.002 (v1.50), foi excluida esta forma de pagamento na emissão de NFC-e (modelo 65), 
+        /// porém para NFe (modelo 55) a SEFAZ, até o momento, ainda permite o seu uso.</para>
+        /// <see langword="https://github.com/ZeusAutomacao/DFe.NET/issues/790"></see>
         /// </summary>
         [Description("Duplicata Mercantil")] [XmlEnum("14")] fpDuplicataMercantil, // VERSÃO 4.00
 
+        /// <summary>
+        /// 15-Boleto Bancário
+        /// </summary>
         [Description("Boleto Bancário")] [XmlEnum("15")] fpBoletoBancario, // VERSÃO 4.00
 
+        /// <summary>
+        /// 90-Sem pagamento
+        /// </summary>
         [Description("Sem pagamento")] [XmlEnum("90")] fpSemPagamento, // VERSÃO 4.00
 
+        /// <summary>
+        /// 99-Outros
+        /// </summary>
         [Description("Outros")] [XmlEnum("99")] fpOutro
     }
 

--- a/NFe.Classes/Informacoes/Transporte/transpTipos.cs
+++ b/NFe.Classes/Informacoes/Transporte/transpTipos.cs
@@ -40,11 +40,38 @@ namespace NFe.Classes.Informacoes.Transporte
     /// </summary>
     public enum ModalidadeFrete
     {
+        /// <summary>
+        /// <para>0=Por conta do emitente [NFe 3.10]</para>
+        /// <para>0=Contratação do Frete por conta do Remetente (CIF) [NFe 4.00]</para>
+        /// </summary>
         [XmlEnum("0")] mfContaEmitenteOumfContaRemetente, // Versão 3.1 ou 4.00 com objetivos diferentes e claro
+
+        /// <summary>
+        /// <para>1=Por conta do destinatário/remetente [NFe 3.10]</para>
+        /// <para>1=Contratação do Frete por conta do Destinatário (FOB) [NFe 4.00]</para>
+        /// </summary>
         [XmlEnum("1")] mfContaDestinatario,
+
+        /// <summary>
+        /// <para>2=Por conta de terceiros [NFe 3.10]</para>
+        /// <para>2=Contratação do Frete por conta de Terceiros [NFe 4.00]</para>
+        /// </summary>
         [XmlEnum("2")] mfContaTerceiros,
+
+        /// <summary>
+        /// 3=Transporte Próprio por conta do Remetente [NFe 4.00]
+        /// </summary>
         [XmlEnum("3")] mfProprioContaRemente, // Versão 4.00
+
+        /// <summary>
+        /// 4=Transporte Próprio por conta do Destinatário [NFe 4.00]
+        /// </summary>
         [XmlEnum("4")] mfProprioContaDestinatario, // Versão 4.00
+
+        /// <summary>
+        /// <para>9=Sem frete [NFe 3.10]</para>
+        /// <para>9=Sem Ocorrência de Transporte [NFe 4.00]</para>
+        /// </summary>
         [XmlEnum("9")] mfSemFrete
     }
 }


### PR DESCRIPTION
Este PR contempla as seguinte alterações:

- Novas documentações summary adicionadas em alguns Enums faltantes.
- Melhoria nos exemplos de uso dos métodos ObterIcmsBasico(), ObterPisBasico(), ObterCofinsBasico() e ObterIPIBasico() na NFe.AppTeste.
- Correção no preenchimento das tags do grupo fat na emissão da NFe de exemplo (AppTeste), conforme as novas regras previstas na NT 2016.002 v.1.60 (issue #779). Vale lembrar que esta correção exigirá também a atualização dos arquivos de Esquema XML para a versão [PL_009_V4_2016_002_v160b](http://www.nfe.fazenda.gov.br/portal/exibirArquivo.aspx?conteudo=CoNA9VIgZ3E=), publicada pela SEFAZ em 02/07/2018

