### PR TITLE
Melhorias no README e ordem de criação das tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Grupo [Skype](https://join.skype.com/CJbtNPlvbycL) para discussão
 
 Grupo [Telegram](https://t.me/joinchat/DyE_jQ7rF3rxTqK1Kwoqog) para discussão
 
+Grupo [Discord](https://discord.gg/n7QkAGF) para discussão
+
 Biblioteca gratuita para Geração de NFe 3.10/4.00, NFCe 3.10/4.00, MDF-e 3.0 e CT-e 3.0 e consumo dos serviços necessários à sua manutenção, conforme descritos em http://www.nfe.fazenda.gov.br/portal/principal.aspx, https://mdfe-portal.sefaz.rs.gov.br e www.cte.fazenda.gov.br/portal.
 
 A biblioteca foi desenvolvida em C# utilizando como IDE o Visual Studio Community 2013 e é compatível com o Visual Studio Community 2015 e 2017. Atualmente utiliza o .NetFramework na versão 4.5.

--- a/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS10.cs
+++ b/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS10.cs
@@ -31,6 +31,7 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 using NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual.Tipos;
+using System.Xml.Serialization;
 
 namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
 {
@@ -54,21 +55,25 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N11 - Origem da Mercadoria
         /// </summary>
+        [XmlElement(Order = 1)]
         public OrigemMercadoria orig { get; set; }
 
         /// <summary>
         ///     N12- Situação Tributária
         /// </summary>
+        [XmlElement(Order = 2)]
         public Csticms CST { get; set; }
 
         /// <summary>
         ///     N13 - Modalidade de determinação da BC do ICMS
         /// </summary>
+        [XmlElement(Order = 3)]
         public DeterminacaoBaseIcms modBC { get; set; }
 
         /// <summary>
         ///     N15 - Valor da BC do ICMS
         /// </summary>
+        [XmlElement(Order = 4)]
         public decimal vBC
         {
             get { return _vBc.Arredondar(2); }
@@ -78,6 +83,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N16 - Alíquota do imposto
         /// </summary>
+        [XmlElement(Order = 5)]
         public decimal pICMS
         {
             get { return _pIcms.Arredondar(4); }
@@ -87,6 +93,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N17 - Valor do ICMS
         /// </summary>
+        [XmlElement(Order = 6)]
         public decimal vICMS
         {
             get { return _vIcms.Arredondar(2); }
@@ -97,6 +104,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// N17a - Valor da Base de Cálculo do FCP
         /// Versão 4.00
         /// </summary>
+        [XmlElement(Order = 7)]
         public decimal? vBCFCP
         {
             get { return _vBcfcp.Arredondar(2); }
@@ -112,6 +120,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// N17b - Percentual do Fundo de Combate à Pobreza (FCP)
         /// Versão 4.00
         /// </summary>
+        [XmlElement(Order = 8)]
         public decimal? pFCP
         {
             get { return _pFcp.Arredondar(4); }
@@ -127,6 +136,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// N17c - Valor do Fundo de Combate à Pobreza (FCP)
         /// Versão 4.00
         /// </summary>
+        [XmlElement(Order = 9)]
         public decimal? vFCP
         {
             get { return _vFcp.Arredondar(2); }
@@ -141,11 +151,13 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N18 - Modalidade de determinação da BC do ICMS ST
         /// </summary>
+        [XmlElement(Order = 10)]
         public DeterminacaoBaseIcmsSt modBCST { get; set; }
 
         /// <summary>
         ///     N19 - Percentual da margem de valor Adicionado do ICMS ST
         /// </summary>
+        [XmlElement(Order = 11)]
         public decimal? pMVAST
         {
             get { return _pMvast.Arredondar(4); }
@@ -155,6 +167,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N20 - Percentual da Redução de BC do ICMS ST
         /// </summary>
+        [XmlElement(Order = 12)]
         public decimal? pRedBCST
         {
             get { return _pRedBcst.Arredondar(4); }
@@ -164,6 +177,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N21 - Valor da BC do ICMS ST
         /// </summary>
+        [XmlElement(Order = 13)]
         public decimal vBCST
         {
             get { return _vBcst.Arredondar(2); }
@@ -173,6 +187,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N22 - Alíquota do imposto do ICMS ST
         /// </summary>
+        [XmlElement(Order = 14)]
         public decimal pICMSST
         {
             get { return _pIcmsst.Arredondar(4); }
@@ -182,6 +197,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N23 - Valor do ICMS ST
         /// </summary>
+        [XmlElement(Order = 15)]
         public decimal vICMSST
         {
             get { return _vIcmsst.Arredondar(2); }
@@ -192,6 +208,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// N23a - Valor da Base de Cálculo do FCP retido por Substituição Tributária
         /// Versão 4.00
         /// </summary>
+        [XmlElement(Order = 16)]
         public decimal? vBCFCPST
         {
             get { return _vBcfcpst.Arredondar(2); }
@@ -207,6 +224,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// N23b - Percentual do FCP retido por Substituição Tributária
         /// Versão 4.00
         /// </summary>
+        [XmlElement(Order = 17)]
         public decimal? pFCPST
         {
             get { return _pFcpst.Arredondar(4); }
@@ -222,6 +240,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// N23d - Valor do FCP retido por Substituição Tributária
         /// Versão 4.00
         /// </summary>
+        [XmlElement(Order = 18)]
         public decimal? vFCPST
         {
             get { return _vFcpst; }

--- a/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS30.cs
+++ b/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS30.cs
@@ -31,6 +31,7 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 using NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual.Tipos;
+using System.Xml.Serialization;
 
 namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
 {
@@ -49,21 +50,25 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N11 - Origem da Mercadoria
         /// </summary>
+        [XmlElement(Order = 1)]
         public OrigemMercadoria orig { get; set; }
 
         /// <summary>
         ///     N12- Situação Tributária
         /// </summary>
+        [XmlElement(Order = 2)]
         public Csticms CST { get; set; }
 
         /// <summary>
         ///     N18 - Modalidade de determinação da BC do ICMS ST
         /// </summary>
+        [XmlElement(Order = 3)]
         public DeterminacaoBaseIcmsSt modBCST { get; set; }
 
         /// <summary>
         ///     N19 - Percentual da margem de valor Adicionado do ICMS ST
         /// </summary>
+        [XmlElement(Order = 4)]
         public decimal? pMVAST
         {
             get { return _pMvast.Arredondar(4); }
@@ -73,6 +78,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N20 - Percentual da Redução de BC do ICMS ST
         /// </summary>
+        [XmlElement(Order = 5)]
         public decimal? pRedBCST
         {
             get { return _pRedBcst.Arredondar(4); }
@@ -82,6 +88,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N21 - Valor da BC do ICMS ST
         /// </summary>
+        [XmlElement(Order = 6)]
         public decimal vBCST
         {
             get { return _vBcst.Arredondar(2); }
@@ -91,6 +98,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N22 - Alíquota do imposto do ICMS ST
         /// </summary>
+        [XmlElement(Order = 7)]
         public decimal pICMSST
         {
             get { return _pIcmsst.Arredondar(4); }
@@ -100,6 +108,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N23 - Valor do ICMS ST
         /// </summary>
+        [XmlElement(Order = 8)]
         public decimal vICMSST
         {
             get { return _vIcmsst.Arredondar(2); }
@@ -110,6 +119,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// N23a - Valor da Base de Cálculo do FCP retido por Substituição Tributária
         /// Versão 4.00
         /// </summary>
+        [XmlElement(Order = 9)]
         public decimal? vBCFCPST
         {
             get { return _vBcfcpst.Arredondar(2); }
@@ -125,6 +135,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// N23b - Percentual do FCP retido por Substituição Tributária
         /// Versão 4.00
         /// </summary>
+        [XmlElement(Order = 10)]
         public decimal? pFCPST
         {
             get { return _pFcpst.Arredondar(4); }
@@ -140,6 +151,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// N23d - Valor do FCP retido por Substituição Tributária
         /// Versão 4.00
         /// </summary>
+        [XmlElement(Order = 11)]
         public decimal? vFCPST
         {
             get { return _vFcpst; }
@@ -154,6 +166,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N27a - Valor do ICMS desonerado
         /// </summary>
+        [XmlElement(Order = 12)]
         public decimal? vICMSDeson
         {
             get { return _vIcmsDeson.Arredondar(2); }
@@ -163,6 +176,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N28 - Motivo da desoneração do ICMS
         /// </summary>
+        [XmlElement(Order = 13)]
         public MotivoDesoneracaoIcms? motDesICMS { get; set; }
 
         public bool ShouldSerializepMVAST()

--- a/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS40.cs
+++ b/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS40.cs
@@ -31,6 +31,7 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 using NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual.Tipos;
+using System.Xml.Serialization;
 
 namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
 {
@@ -41,16 +42,19 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N11 - Origem da Mercadoria
         /// </summary>
+        [XmlElement(Order = 1)]
         public OrigemMercadoria orig { get; set; }
 
         /// <summary>
         ///     N12- Situação Tributária
         /// </summary>
+        [XmlElement(Order = 2)]
         public Csticms CST { get; set; }
 
         /// <summary>
         ///     N27a - Valor do ICMS desonerado
         /// </summary>
+        [XmlElement(Order = 3)]
         public decimal? vICMSDeson
         {
             get { return _vIcmsDeson.Arredondar(2); }
@@ -60,6 +64,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N28 - Motivo da desoneração do ICMS
         /// </summary>
+        [XmlElement(Order = 4)]
         public MotivoDesoneracaoIcms? motDesICMS { get; set; }
 
         public bool ShouldSerializevICMSDeson()

--- a/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS51.cs
+++ b/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS51.cs
@@ -31,6 +31,7 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 using NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual.Tipos;
+using System.Xml.Serialization;
 
 namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
 {
@@ -50,21 +51,25 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N11 - Origem da Mercadoria
         /// </summary>
+        [XmlElement(Order = 1)]
         public OrigemMercadoria orig { get; set; }
 
         /// <summary>
         ///     N12- Situação Tributária
         /// </summary>
+        [XmlElement(Order = 2)]
         public Csticms CST { get; set; }
 
         /// <summary>
         ///     N13 - Modalidade de determinação da BC do ICMS
         /// </summary>
+        [XmlElement(Order = 3)]
         public DeterminacaoBaseIcms? modBC { get; set; }
 
         /// <summary>
         ///     N14 - Percentual de redução da BC
         /// </summary>
+        [XmlElement(Order = 4)]
         public decimal? pRedBC
         {
             get { return _pRedBc.Arredondar(4); }
@@ -74,6 +79,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N15 - Valor da BC do ICMS
         /// </summary>
+        [XmlElement(Order = 5)]
         public decimal? vBC
         {
             get { return _vBc.Arredondar(2); }
@@ -83,6 +89,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N16 - Alíquota do imposto
         /// </summary>
+        [XmlElement(Order = 6)]
         public decimal? pICMS
         {
             get { return _pIcms.Arredondar(4); }
@@ -92,6 +99,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N16a - Valor do ICMS da Operação
         /// </summary>
+        [XmlElement(Order = 7)]
         public decimal? vICMSOp
         {
             get { return _vIcmsOp.Arredondar(2); }
@@ -101,6 +109,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N16b - Percentual do diferimento
         /// </summary>
+        [XmlElement(Order = 8)]
         public decimal? pDif
         {
             get { return _pDif.Arredondar(2); }
@@ -110,6 +119,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N16c - Valor do ICMS diferido
         /// </summary>
+        [XmlElement(Order = 9)]
         public decimal? vICMSDif
         {
             get { return _vIcmsDif.Arredondar(2); }
@@ -119,6 +129,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N17 - Valor do ICMS
         /// </summary>
+        [XmlElement(Order = 10)]
         public decimal? vICMS
         {
             get { return _vIcms.Arredondar(2); }
@@ -129,6 +140,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// N17a - Valor da Base de Cálculo do FCP
         /// Versão 4.00
         /// </summary>
+        [XmlElement(Order = 11)]
         public decimal? vBCFCP
         {
             get { return _vBcfcp.Arredondar(2); }
@@ -144,6 +156,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// N17b - Percentual do Fundo de Combate à Pobreza (FCP)
         /// Versão 4.00
         /// </summary>
+        [XmlElement(Order = 12)]
         public decimal? pFCP
         {
             get { return _pFcp.Arredondar(4); }
@@ -159,6 +172,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// N17c - Valor do Fundo de Combate à Pobreza (FCP)
         /// Versão 4.00
         /// </summary>
+        [XmlElement(Order = 13)]
         public decimal? vFCP
         {
             get { return _vFcp.Arredondar(2); }

--- a/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS60.cs
+++ b/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS60.cs
@@ -31,6 +31,7 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 using NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual.Tipos;
+using System.Xml.Serialization;
 
 namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
 {
@@ -50,16 +51,19 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N11 - Origem da Mercadoria
         /// </summary>
+        [XmlElement(Order = 1)]
         public OrigemMercadoria orig { get; set; }
 
         /// <summary>
         ///     N12- Situação Tributária
         /// </summary>
+        [XmlElement(Order = 2)]
         public Csticms CST { get; set; }
 
         /// <summary>
         ///     N26 - Valor da BC do ICMS ST retido
         /// </summary>
+        [XmlElement(Order = 3)]
         public decimal? vBCSTRet
         {
             get { return _vBcstRet.Arredondar(2); }
@@ -74,6 +78,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N26a - Alíquota suportada pelo Consumidor Final
         /// </summary>
+        [XmlElement(Order = 4)]
         public decimal? pST
         {
             get { return _pST.Arredondar(4); }
@@ -88,6 +93,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N27 - Valor do ICMS ST retido
         /// </summary>
+        [XmlElement(Order = 5)]
         public decimal? vICMSSTRet
         {
             get { return _vIcmsstRet.Arredondar(2); }
@@ -103,6 +109,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// N27a - Valor da Base de Cálculo do FCP retido anteriormente por ST 
         /// Versão 4.00
         /// </summary>
+        [XmlElement(Order = 6)]
         public decimal? vBCFCPSTRet
         {
             get { return _vBcfcpstRet.Arredondar(2); }
@@ -118,6 +125,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// N27b - Percentual do FCP retido anteriormente por Substituição Tributária
         /// Versão 4.00
         /// </summary>
+        [XmlElement(Order = 7)]
         public decimal? pFCPSTRet
         {
             get { return _pFcpstRet.Arredondar(4); }
@@ -134,6 +142,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// N27d - Valor do FCP retido por Substituição Tributária
         /// Versão 4.00
         /// </summary>
+        [XmlElement(Order = 8)]
         public decimal? vFCPSTRet
         {
             get { return _vFcpstRet.Arredondar(2); }
@@ -148,6 +157,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N34 - Percentual de redução da base de cálculo efetiva 
         /// </summary>
+        [XmlElement(Order = 9)]
         public decimal? pRedBCEfet
         {
             get { return _pRedBCEfet.Arredondar(4); }
@@ -162,6 +172,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N35 - Valor da base de cálculo efetiva 
         /// </summary>
+        [XmlElement(Order = 10)]
         public decimal? vBCEfet
         {
             get { return _vBCEfet.Arredondar(2); }
@@ -176,6 +187,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N36 - Alíquota do ICMS efetiva 
         /// </summary>
+        [XmlElement(Order = 11)]
         public decimal? pICMSEfet
         {
             get { return _pICMSEfet.Arredondar(4); }
@@ -190,6 +202,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N37 - Valor do ICMS efetivo 
         /// </summary>
+        [XmlElement(Order = 12)]
         public decimal? vICMSEfet
         {
             get { return _vICMSEfet.Arredondar(2); }

--- a/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS70.cs
+++ b/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS70.cs
@@ -31,6 +31,7 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 using NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual.Tipos;
+using System.Xml.Serialization;
 
 namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
 {
@@ -56,21 +57,25 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N11 - Origem da Mercadoria
         /// </summary>
+        [XmlElement(Order = 1)]
         public OrigemMercadoria orig { get; set; }
 
         /// <summary>
         ///     N12- Situação Tributária
         /// </summary>
+        [XmlElement(Order = 2)]
         public Csticms CST { get; set; }
 
         /// <summary>
         ///     N13 - Modalidade de determinação da BC do ICMS
         /// </summary>
+        [XmlElement(Order = 3)]
         public DeterminacaoBaseIcms modBC { get; set; }
 
         /// <summary>
         ///     N14 - Percentual de redução da BC
         /// </summary>
+        [XmlElement(Order = 4)]
         public decimal pRedBC
         {
             get { return _pRedBc; }
@@ -80,6 +85,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N15 - Valor da BC do ICMS
         /// </summary>
+        [XmlElement(Order = 5)]
         public decimal vBC
         {
             get { return _vBc; }
@@ -89,6 +95,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N16 - Alíquota do imposto
         /// </summary>
+        [XmlElement(Order = 6)]
         public decimal pICMS
         {
             get { return _pIcms; }
@@ -98,6 +105,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N17 - Valor do ICMS
         /// </summary>
+        [XmlElement(Order = 7)]
         public decimal vICMS
         {
             get { return _vIcms; }
@@ -108,6 +116,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// N17a - Valor da Base de Cálculo do FCP
         /// Versão 4.00
         /// </summary>
+        [XmlElement(Order = 8)]
         public decimal? vBCFCP
         {
             get { return _vBcfcp.Arredondar(2); }
@@ -123,6 +132,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// N17b - Percentual do Fundo de Combate à Pobreza (FCP)
         /// Versão 4.00
         /// </summary>
+        [XmlElement(Order = 9)]
         public decimal? pFCP
         {
             get { return _pFcp.Arredondar(4); }
@@ -138,6 +148,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// N17c - Valor do Fundo de Combate à Pobreza (FCP)
         /// Versão 4.00
         /// </summary>
+        [XmlElement(Order = 10)]
         public decimal? vFCP
         {
             get { return _vFcp.Arredondar(2); }
@@ -152,11 +163,13 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N18 - Modalidade de determinação da BC do ICMS ST
         /// </summary>
+        [XmlElement(Order = 11)]
         public DeterminacaoBaseIcmsSt modBCST { get; set; }
 
         /// <summary>
         ///     N19 - Percentual da margem de valor Adicionado do ICMS ST
         /// </summary>
+        [XmlElement(Order = 12)]
         public decimal? pMVAST
         {
             get { return _pMvast.Arredondar(4); }
@@ -166,6 +179,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N20 - Percentual da Redução de BC do ICMS ST
         /// </summary>
+        [XmlElement(Order = 13)]
         public decimal? pRedBCST
         {
             get { return _pRedBcst.Arredondar(4); }
@@ -175,6 +189,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N21 - Valor da BC do ICMS ST
         /// </summary>
+        [XmlElement(Order = 14)]
         public decimal vBCST
         {
             get { return _vBcst; }
@@ -184,6 +199,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N22 - Alíquota do imposto do ICMS ST
         /// </summary>
+        [XmlElement(Order = 15)]
         public decimal pICMSST
         {
             get { return _pIcmsst; }
@@ -193,6 +209,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N23 - Valor do ICMS ST
         /// </summary>
+        [XmlElement(Order = 16)]
         public decimal vICMSST
         {
             get { return _vIcmsst; }
@@ -203,6 +220,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// N23a - Valor da Base de Cálculo do FCP retido por Substituição Tributária
         /// Versão 4.00
         /// </summary>
+        [XmlElement(Order = 17)]
         public decimal? vBCFCPST
         {
             get { return _vBcfcpst.Arredondar(2); }
@@ -218,6 +236,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// N23b - Percentual do FCP retido por Substituição Tributária
         /// Versão 4.00
         /// </summary>
+        [XmlElement(Order = 18)]
         public decimal? pFCPST
         {
             get { return _pFcpst.Arredondar(4); }
@@ -233,6 +252,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// N23d - Valor do FCP retido por Substituição Tributária
         /// Versão 4.00
         /// </summary>
+        [XmlElement(Order = 19)]
         public decimal? vFCPST
         {
             get { return _vFcpst; }
@@ -247,6 +267,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N27a - Valor do ICMS desonerado
         /// </summary>
+        [XmlElement(Order = 20)]
         public decimal? vICMSDeson
         {
             get { return _vIcmsDeson.Arredondar(2); }
@@ -256,6 +277,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N28 - Motivo da desoneração do ICMS
         /// </summary>
+        [XmlElement(Order = 21)]
         public MotivoDesoneracaoIcms? motDesICMS { get; set; }
 
         public bool ShouldSerializepMVAST()

--- a/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS90.cs
+++ b/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS90.cs
@@ -31,6 +31,7 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 using NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual.Tipos;
+using System.Xml.Serialization;
 
 namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
 {
@@ -56,21 +57,25 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N11 - Origem da Mercadoria
         /// </summary>
+        [XmlElement(Order = 1)]
         public OrigemMercadoria orig { get; set; }
 
         /// <summary>
         ///     N12- Situação Tributária
         /// </summary>
+        [XmlElement(Order = 2)]
         public Csticms CST { get; set; }
 
         /// <summary>
         ///     N13 - Modalidade de determinação da BC do ICMS
         /// </summary>
+        [XmlElement(Order = 3)]
         public DeterminacaoBaseIcms? modBC { get; set; }
 
         /// <summary>
         ///     N15 - Valor da BC do ICMS
         /// </summary>
+        [XmlElement(Order = 4)]
         public decimal? vBC
         {
             get { return _vBc.Arredondar(2); }
@@ -80,6 +85,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N14 - Percentual de redução da BC
         /// </summary>
+        [XmlElement(Order = 5)]
         public decimal? pRedBC
         {
             get { return _pRedBc.Arredondar(4); }
@@ -89,6 +95,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N16 - Alíquota do imposto
         /// </summary>
+        [XmlElement(Order = 6)]
         public decimal? pICMS
         {
             get { return _pIcms.Arredondar(4); }
@@ -98,6 +105,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N17 - Valor do ICMS
         /// </summary>
+        [XmlElement(Order = 7)]
         public decimal? vICMS
         {
             get { return _vIcms.Arredondar(2); }
@@ -108,6 +116,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// N17a - Valor da Base de Cálculo do FCP
         /// Versão 4.00
         /// </summary>
+        [XmlElement(Order = 8)]
         public decimal? vBCFCP
         {
             get { return _vBcfcp.Arredondar(2); }
@@ -123,6 +132,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// N17b - Percentual do Fundo de Combate à Pobreza (FCP)
         /// Versão 4.00
         /// </summary>
+        [XmlElement(Order = 9)]
         public decimal? pFCP
         {
             get { return _pFcp.Arredondar(4); }
@@ -138,6 +148,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// N17c - Valor do Fundo de Combate à Pobreza (FCP)
         /// Versão 4.00
         /// </summary>
+        [XmlElement(Order = 10)]
         public decimal? vFCP
         {
             get { return _vFcp.Arredondar(2); }
@@ -152,11 +163,13 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N18 - Modalidade de determinação da BC do ICMS ST
         /// </summary>
+        [XmlElement(Order = 11)]
         public DeterminacaoBaseIcmsSt? modBCST { get; set; }
 
         /// <summary>
         ///     N19 - Percentual da margem de valor Adicionado do ICMS ST
         /// </summary>
+        [XmlElement(Order = 12)]
         public decimal? pMVAST
         {
             get { return _pMvast.Arredondar(4); }
@@ -166,6 +179,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N20 - Percentual da Redução de BC do ICMS ST
         /// </summary>
+        [XmlElement(Order = 13)]
         public decimal? pRedBCST
         {
             get { return _pRedBcst.Arredondar(4); }
@@ -175,6 +189,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N21 - Valor da BC do ICMS ST
         /// </summary>
+        [XmlElement(Order = 14)]
         public decimal? vBCST
         {
             get { return _vBcst.Arredondar(2); }
@@ -184,6 +199,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N22 - Alíquota do imposto do ICMS ST
         /// </summary>
+        [XmlElement(Order = 15)]
         public decimal? pICMSST
         {
             get { return _pIcmsst.Arredondar(4); }
@@ -193,6 +209,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N23 - Valor do ICMS ST
         /// </summary>
+        [XmlElement(Order = 16)]
         public decimal? vICMSST
         {
             get { return _vIcmsst.Arredondar(2); }
@@ -203,6 +220,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// N23a - Valor da Base de Cálculo do FCP retido por Substituição Tributária
         /// Versão 4.00
         /// </summary>
+        [XmlElement(Order = 17)]
         public decimal? vBCFCPST
         {
             get { return _vBcfcpst.Arredondar(2); }
@@ -218,6 +236,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// N23b - Percentual do FCP retido por Substituição Tributária
         /// Versão 4.00
         /// </summary>
+        [XmlElement(Order = 18)]
         public decimal? pFCPST
         {
             get { return _pFcpst.Arredondar(4); }
@@ -233,6 +252,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// N23d - Valor do FCP retido por Substituição Tributária
         /// Versão 4.00
         /// </summary>
+        [XmlElement(Order = 19)]
         public decimal? vFCPST
         {
             get { return _vFcpst; }
@@ -247,6 +267,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N27a - Valor do ICMS desonerado
         /// </summary>
+        [XmlElement(Order = 20)]
         public decimal? vICMSDeson
         {
             get { return _vIcmsDeson.Arredondar(2); }
@@ -256,6 +277,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N28 - Motivo da desoneração do ICMS
         /// </summary>
+        [XmlElement(Order = 21)]
         public MotivoDesoneracaoIcms? motDesICMS { get; set; }
 
         public bool ShouldSerializemodBC()

--- a/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMSPart.cs
+++ b/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMSPart.cs
@@ -31,6 +31,7 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 using NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual.Tipos;
+using System.Xml.Serialization;
 
 namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
 {
@@ -50,21 +51,25 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N11 - Origem da Mercadoria
         /// </summary>
+        [XmlElement(Order = 1)]
         public OrigemMercadoria orig { get; set; }
 
         /// <summary>
         ///     N12- Situação Tributária
         /// </summary>
+        [XmlElement(Order = 2)]
         public Csticms CST { get; set; }
 
         /// <summary>
         ///     N13 - Modalidade de determinação da BC do ICMS
         /// </summary>
+        [XmlElement(Order = 3)]
         public DeterminacaoBaseIcms modBC { get; set; }
 
         /// <summary>
         ///     N15 - Valor da BC do ICMS
         /// </summary>
+        [XmlElement(Order = 4)]
         public decimal vBC
         {
             get { return _vBc; }
@@ -74,6 +79,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N14 - Percentual de redução da BC
         /// </summary>
+        [XmlElement(Order = 5)]
         public decimal? pRedBC
         {
             get { return _pRedBc.Arredondar(4); }
@@ -83,6 +89,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N16 - Alíquota do imposto
         /// </summary>
+        [XmlElement(Order = 6)]
         public decimal pICMS
         {
             get { return _pIcms; }
@@ -92,6 +99,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N17 - Valor do ICMS
         /// </summary>
+        [XmlElement(Order = 7)]
         public decimal vICMS
         {
             get { return _vIcms; }
@@ -101,11 +109,13 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N18 - Modalidade de determinação da BC do ICMS ST
         /// </summary>
+        [XmlElement(Order = 8)]
         public DeterminacaoBaseIcmsSt modBCST { get; set; }
 
         /// <summary>
         ///     N19 - Percentual da margem de valor Adicionado do ICMS ST
         /// </summary>
+        [XmlElement(Order = 9)]
         public decimal? pMVAST
         {
             get { return _pMvast.Arredondar(4); }
@@ -115,6 +125,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N20 - Percentual da Redução de BC do ICMS ST
         /// </summary>
+        [XmlElement(Order = 10)]
         public decimal? pRedBCST
         {
             get { return _pRedBcst.Arredondar(4); }
@@ -124,6 +135,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N21 - Valor da BC do ICMS ST
         /// </summary>
+        [XmlElement(Order = 11)]
         public decimal vBCST
         {
             get { return _vBcst; }
@@ -133,6 +145,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N22 - Alíquota do imposto do ICMS ST
         /// </summary>
+        [XmlElement(Order = 12)]
         public decimal pICMSST
         {
             get { return _pIcmsst; }
@@ -142,6 +155,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N23 - Valor do ICMS ST
         /// </summary>
+        [XmlElement(Order = 13)]
         public decimal vICMSST
         {
             get { return _vIcmsst; }
@@ -151,6 +165,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N25 - Percentual da BC operação própria
         /// </summary>
+        [XmlElement(Order = 14)]
         public decimal pBCOp
         {
             get { return _pBcOp; }
@@ -160,6 +175,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N24 - UF para qual é devido o ICMS ST
         /// </summary>
+        [XmlElement(Order = 15)]
         public string UFST { get; set; }
 
         public bool ShouldSerializepRedBC()

--- a/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMSSN101.cs
+++ b/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMSSN101.cs
@@ -31,6 +31,7 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 using NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual.Tipos;
+using System.Xml.Serialization;
 
 namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
 {
@@ -42,16 +43,19 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N11 - Origem da Mercadoria
         /// </summary>
+        [XmlElement(Order = 1)]
         public OrigemMercadoria orig { get; set; }
 
         /// <summary>
         ///     N12a - Código de Situação da Operação – Simples Nacional
         /// </summary>
+        [XmlElement(Order = 2)]
         public Csosnicms CSOSN { get; set; }
 
         /// <summary>
         ///     N29 - pCredSN - Alíquota aplicável de cálculo do crédito (Simples Nacional).
         /// </summary>
+        [XmlElement(Order = 3)]
         public decimal pCredSN
         {
             get { return _pCredSn; }
@@ -61,6 +65,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N30 - Valor crédito do ICMS que pode ser aproveitado nos termos do art. 23 da LC 123 (Simples Nacional)
         /// </summary>
+        [XmlElement(Order = 4)]
         public decimal vCredICMSSN
         {
             get { return _vCredIcmssn; }

--- a/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMSSN102.cs
+++ b/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMSSN102.cs
@@ -31,6 +31,7 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 using NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual.Tipos;
+using System.Xml.Serialization;
 
 namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
 {
@@ -39,11 +40,13 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N11 - Origem da Mercadoria
         /// </summary>
+        [XmlElement(Order = 1)]
         public OrigemMercadoria orig { get; set; }
 
         /// <summary>
         ///     N12a - Código de Situação da Operação – Simples Nacional
         /// </summary>
+        [XmlElement(Order = 2)]
         public Csosnicms CSOSN { get; set; }
     }
 }

--- a/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMSSN201.cs
+++ b/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMSSN201.cs
@@ -31,6 +31,7 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 using NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual.Tipos;
+using System.Xml.Serialization;
 
 namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
 {
@@ -50,21 +51,25 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N11 - Origem da Mercadoria
         /// </summary>
+        [XmlElement(Order = 1)]
         public OrigemMercadoria orig { get; set; }
 
         /// <summary>
         ///     N12a - Código de Situação da Operação – Simples Nacional
         /// </summary>
+        [XmlElement(Order = 2)]
         public Csosnicms CSOSN { get; set; }
 
         /// <summary>
         ///     N18 - Modalidade de determinação da BC do ICMS ST
         /// </summary>
+        [XmlElement(Order = 3)]
         public DeterminacaoBaseIcmsSt modBCST { get; set; }
 
         /// <summary>
         ///     N19 - Percentual da margem de valor Adicionado do ICMS ST
         /// </summary>
+        [XmlElement(Order = 4)]
         public decimal? pMVAST
         {
             get { return _pMvast.Arredondar(4); }
@@ -74,6 +79,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N20 - Percentual da Redução de BC do ICMS ST
         /// </summary>
+        [XmlElement(Order = 5)]
         public decimal? pRedBCST
         {
             get { return _pRedBcst.Arredondar(4); }
@@ -83,6 +89,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N21 - Valor da BC do ICMS ST
         /// </summary>
+        [XmlElement(Order = 6)]
         public decimal vBCST
         {
             get { return _vBcst; }
@@ -92,6 +99,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N22 - Alíquota do imposto do ICMS ST
         /// </summary>
+        [XmlElement(Order = 7)]
         public decimal pICMSST
         {
             get { return _pIcmsst; }
@@ -101,6 +109,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N23 - Valor do ICMS ST
         /// </summary>
+        [XmlElement(Order = 8)]
         public decimal vICMSST
         {
             get { return _vIcmsst; }
@@ -111,12 +120,13 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// N23a - Valor da Base de Cálculo do FCP retido por Substituição Tributária
         /// Versão 4.00
         /// </summary>
+        [XmlElement(Order = 9)]
         public decimal? vBCFCPST
         {
             get { return _vBcfcpst.Arredondar(2); }
             set { _vBcfcpst = value.Arredondar(2); }
         }
-
+        
         public bool vBCFCPSTSpecified
         {
             get { return vBCFCPST.HasValue; }
@@ -126,6 +136,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// N23b - Percentual do FCP retido por Substituição Tributária
         /// Versão 4.00
         /// </summary>
+        [XmlElement(Order = 10)]
         public decimal? pFCPST
         {
             get { return _pFcpst.Arredondar(4); }
@@ -141,6 +152,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// N23d - Valor do FCP retido por Substituição Tributária
         /// Versão 4.00
         /// </summary>
+        [XmlElement(Order = 11)]
         public decimal? vFCPST
         {
             get { return _vFcpst.Arredondar(2); }
@@ -155,6 +167,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N29 - pCredSN - Alíquota aplicável de cálculo do crédito (Simples Nacional).
         /// </summary>
+        [XmlElement(Order = 12)]
         public decimal pCredSN
         {
             get { return _pCredSn; }
@@ -164,6 +177,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N30 - Valor crédito do ICMS que pode ser aproveitado nos termos do art. 23 da LC 123 (Simples Nacional)
         /// </summary>
+        [XmlElement(Order = 13)]
         public decimal vCredICMSSN
         {
             get { return _vCredIcmssn; }

--- a/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMSSN202.cs
+++ b/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMSSN202.cs
@@ -31,6 +31,7 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 using NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual.Tipos;
+using System.Xml.Serialization;
 
 namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
 {
@@ -48,21 +49,25 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N11 - Origem da Mercadoria
         /// </summary>
+        [XmlElement(Order = 1)]
         public OrigemMercadoria orig { get; set; }
 
         /// <summary>
         ///     N12a - Código de Situação da Operação – Simples Nacional
         /// </summary>
+        [XmlElement(Order = 2)]
         public Csosnicms CSOSN { get; set; }
 
         /// <summary>
         ///     N18 - Modalidade de determinação da BC do ICMS ST
         /// </summary>
+        [XmlElement(Order = 3)]
         public DeterminacaoBaseIcmsSt modBCST { get; set; }
 
         /// <summary>
         ///     N19 - Percentual da margem de valor Adicionado do ICMS ST
         /// </summary>
+        [XmlElement(Order = 4)]
         public decimal? pMVAST
         {
             get { return _pMvast.Arredondar(4); }
@@ -72,6 +77,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N20 - Percentual da Redução de BC do ICMS ST
         /// </summary>
+        [XmlElement(Order = 5)]
         public decimal? pRedBCST
         {
             get { return _pRedBcst.Arredondar(4); }
@@ -81,6 +87,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N21 - Valor da BC do ICMS ST
         /// </summary>
+        [XmlElement(Order = 6)]
         public decimal vBCST
         {
             get { return _vBcst; }
@@ -90,6 +97,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N22 - Alíquota do imposto do ICMS ST
         /// </summary>
+        [XmlElement(Order = 7)]
         public decimal pICMSST
         {
             get { return _pIcmsst; }
@@ -99,6 +107,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N23 - Valor do ICMS ST
         /// </summary>
+        [XmlElement(Order = 8)]
         public decimal vICMSST
         {
             get { return _vIcmsst; }
@@ -109,6 +118,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// N23a - Valor da Base de Cálculo do FCP retido por Substituição Tributária
         /// Versão 4.00
         /// </summary>
+        [XmlElement(Order = 9)]
         public decimal? vBCFCPST
         {
             get { return _vBcfcpst.Arredondar(2); }
@@ -124,6 +134,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// N23b - Percentual do FCP retido por Substituição Tributária
         /// Versão 4.00
         /// </summary>
+        [XmlElement(Order = 10)]
         public decimal? pFCPST
         {
             get { return _pFcpst.Arredondar(4); }
@@ -139,6 +150,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// N23d - Valor do FCP retido por Substituição Tributária
         /// Versão 4.00
         /// </summary>
+        [XmlElement(Order = 11)]
         public decimal? vFCPST
         {
             get { return _vFcpst.Arredondar(2); }

--- a/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMSSN500.cs
+++ b/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMSSN500.cs
@@ -31,6 +31,7 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 using NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual.Tipos;
+using System.Xml.Serialization;
 
 namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
 {
@@ -50,16 +51,19 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N11 - Origem da Mercadoria
         /// </summary>
+        [XmlElement(Order = 1)]
         public OrigemMercadoria orig { get; set; }
 
         /// <summary>
         ///     N12a - Código de Situação da Operação – Simples Nacional
         /// </summary>
+        [XmlElement(Order = 2)]
         public Csosnicms CSOSN { get; set; }
 
         /// <summary>
         ///     N26 - Valor da BC do ICMS ST retido
         /// </summary>
+        [XmlElement(Order = 3)]
         public decimal? vBCSTRet
         {
             get { return _vBcstRet.Arredondar(2); }
@@ -74,6 +78,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         /// N26a  - Alíquota suportada pelo Consumidor Final
         /// </summary>
+        [XmlElement(Order = 4)]
         public decimal? pST
         {
             get { return _pSt.Arredondar(4); }
@@ -88,6 +93,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N27 - Valor do ICMS ST retido
         /// </summary>
+        [XmlElement(Order = 5)]
         public decimal? vICMSSTRet
         {
             get { return _vIcmsstRet.Arredondar(2); }
@@ -103,6 +109,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// N27a - Valor da Base de Cálculo do FCP 
         /// Versão 4.00
         /// </summary>
+        [XmlElement(Order = 6)]
         public decimal? vBCFCPSTRet
         {
             get { return _vBcfcpstRet.Arredondar(2); }
@@ -117,6 +124,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         /// N27b - Percentual do FCP retido anteriormente por Substituição Tributária
         /// </summary>
+        [XmlElement(Order = 7)]
         public decimal? pFCPSTRet
         {
             get { return _pFcpstRet.Arredondar(4); }
@@ -131,6 +139,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         /// N27d - Valor do FCP retido anteriormente por Substituição Tributária
         /// </summary>
+        [XmlElement(Order = 8)]
         public decimal? vFCPSTRet
         {
             get { return _vFcpstRet.Arredondar(2); }
@@ -145,6 +154,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N34 - Percentual de redução da base de cálculo efetiva 
         /// </summary>
+        [XmlElement(Order = 9)]
         public decimal? pRedBCEfet
         {
             get { return _pRedBCEfet.Arredondar(4); }
@@ -159,6 +169,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N35 - Valor da base de cálculo efetiva 
         /// </summary>
+        [XmlElement(Order = 10)]
         public decimal? vBCEfet
         {
             get { return _vBCEfet.Arredondar(2); }
@@ -173,6 +184,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N36 - Alíquota do ICMS efetiva 
         /// </summary>
+        [XmlElement(Order = 11)]
         public decimal? pICMSEfet
         {
             get { return _pICMSEfet.Arredondar(4); }
@@ -187,6 +199,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N37 - Valor do ICMS efetivo 
         /// </summary>
+        [XmlElement(Order = 12)]
         public decimal? vICMSEfet
         {
             get { return _vICMSEfet.Arredondar(2); }

--- a/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMSSN900.cs
+++ b/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMSSN900.cs
@@ -31,6 +31,7 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 using NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual.Tipos;
+using System.Xml.Serialization;
 
 namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
 {
@@ -54,21 +55,25 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N11 - Origem da Mercadoria
         /// </summary>
+        [XmlElement(Order = 1)]
         public OrigemMercadoria orig { get; set; }
 
         /// <summary>
         ///     N12a - Código de Situação da Operação – Simples Nacional
         /// </summary>
+        [XmlElement(Order = 2)]
         public Csosnicms CSOSN { get; set; }
 
         /// <summary>
         ///     N13 - Modalidade de determinação da BC do ICMS
         /// </summary>
+        [XmlElement(Order = 3)]
         public DeterminacaoBaseIcms? modBC { get; set; }
 
         /// <summary>
         ///     N15 - Valor da BC do ICMS
         /// </summary>
+        [XmlElement(Order = 4)]
         public decimal? vBC
         {
             get { return _vBc.Arredondar(2); }
@@ -78,6 +83,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N14 - Percentual de redução da BC
         /// </summary>
+        [XmlElement(Order = 5)]
         public decimal? pRedBC
         {
             get { return _pRedBc.Arredondar(4); }
@@ -87,6 +93,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N16 - Alíquota do imposto
         /// </summary>
+        [XmlElement(Order = 6)]
         public decimal? pICMS
         {
             get { return _pIcms.Arredondar(4); }
@@ -96,6 +103,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N17 - Valor do ICMS
         /// </summary>
+        [XmlElement(Order = 7)]
         public decimal? vICMS
         {
             get { return _vIcms.Arredondar(2); }
@@ -105,11 +113,13 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N18 - Modalidade de determinação da BC do ICMS ST
         /// </summary>
+        [XmlElement(Order = 8)]
         public DeterminacaoBaseIcmsSt? modBCST { get; set; }
 
         /// <summary>
         ///     N19 - Percentual da margem de valor Adicionado do ICMS ST
         /// </summary>
+        [XmlElement(Order = 9)]
         public decimal? pMVAST
         {
             get { return _pMvast.Arredondar(4); }
@@ -119,6 +129,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N20 - Percentual da Redução de BC do ICMS ST
         /// </summary>
+        [XmlElement(Order = 10)]
         public decimal? pRedBCST
         {
             get { return _pRedBcst.Arredondar(4); }
@@ -128,6 +139,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N21 - Valor da BC do ICMS ST
         /// </summary>
+        [XmlElement(Order = 11)]
         public decimal? vBCST
         {
             get { return _vBcst.Arredondar(2); }
@@ -137,6 +149,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N22 - Alíquota do imposto do ICMS ST
         /// </summary>
+        [XmlElement(Order = 12)]
         public decimal? pICMSST
         {
             get { return _pIcmsst.Arredondar(4); }
@@ -146,6 +159,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N23 - Valor do ICMS ST
         /// </summary>
+        [XmlElement(Order = 13)]
         public decimal? vICMSST
         {
             get { return _vIcmsst.Arredondar(2); }
@@ -156,6 +170,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// N23a - Valor da Base de Cálculo do FCP retido por Substituição Tributária
         /// Versão 4.00
         /// </summary>
+        [XmlElement(Order = 14)]
         public decimal? vBCFCPST
         {
             get { return _vBcfcpst.Arredondar(2); }
@@ -171,6 +186,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// N23b - Percentual do FCP retido por Substituição Tributária
         /// Versão 4.00
         /// </summary>
+        [XmlElement(Order = 15)]
         public decimal? pFCPST
         {
             get { return _pFcpst.Arredondar(4); }
@@ -186,6 +202,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// N23d - Valor do FCP retido por Substituição Tributária
         /// Versão 4.00
         /// </summary>
+        [XmlElement(Order = 16)]
         public decimal? vFCPST
         {
             get { return _vFcpst; }
@@ -200,6 +217,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N29 - pCredSN - Alíquota aplicável de cálculo do crédito (Simples Nacional).
         /// </summary>
+        [XmlElement(Order = 17)]
         public decimal? pCredSN
         {
             get { return _pCredSn.Arredondar(4); }
@@ -209,6 +227,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N30 - Valor crédito do ICMS que pode ser aproveitado nos termos do art. 23 da LC 123 (Simples Nacional)
         /// </summary>
+        [XmlElement(Order = 18)]
         public decimal? vCredICMSSN
         {
             get { return _vCredIcmssn.Arredondar(2); }

--- a/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMSST.cs
+++ b/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMSST.cs
@@ -31,6 +31,7 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 using NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual.Tipos;
+using System.Xml.Serialization;
 
 namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
 {
@@ -44,16 +45,19 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N11 - Origem da Mercadoria
         /// </summary>
+        [XmlElement(Order = 1)]
         public OrigemMercadoria orig { get; set; }
 
         /// <summary>
         ///     N12- Situação Tributária
         /// </summary>
+        [XmlElement(Order = 2)]
         public Csticms CST { get; set; }
 
         /// <summary>
         ///     N26 - Valor da BC do ICMS ST retido
         /// </summary>
+        [XmlElement(Order = 3)]
         public decimal vBCSTRet
         {
             get { return _vBcstRet; }
@@ -63,6 +67,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N27 - Valor do ICMS ST retido
         /// </summary>
+        [XmlElement(Order = 4)]
         public decimal vICMSSTRet
         {
             get { return _vIcmsstRet; }
@@ -72,6 +77,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N31 - Valor da BC do ICMS ST da UF destino
         /// </summary>
+        [XmlElement(Order = 5)]
         public decimal vBCSTDest
         {
             get { return _vBcstDest; }
@@ -81,6 +87,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N32 - Valor do ICMS ST da UF destino
         /// </summary>
+        [XmlElement(Order = 6)]
         public decimal vICMSSTDest
         {
             get { return _vIcmsstDest; }

--- a/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMSUFDest.cs
+++ b/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMSUFDest.cs
@@ -25,6 +25,8 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 
+using System.Xml.Serialization;
+
 namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
 {
     public class ICMSUFDest
@@ -42,6 +44,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         /// NA03 - Valor da BC do ICMS na UF de destino
         /// </summary>
+        [XmlElement(Order = 1)]
         public decimal vBCUFDest
         {
             get { return _vBcufDest; }
@@ -52,6 +55,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// NA04 - Valor da BC FCP na UF de destino
         /// Versão 4.00
         /// </summary>
+        [XmlElement(Order = 2)]
         public decimal? vBCFCPUFDest
         {
             get { return _vBcfcpufDest.Arredondar(2); }
@@ -66,6 +70,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         /// NA05 - Percentual do ICMS relativo ao Fundo de Combate à Pobreza (FCP) na UF de destino
         /// </summary>
+        [XmlElement(Order = 3)]
         public decimal? pFCPUFDest
         {
             get { return _pFcpufDest; }
@@ -82,6 +87,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         /// NA07 - Alíquota interna da UF de destino
         /// </summary>
+        [XmlElement(Order = 4)]
         public decimal pICMSUFDest
         {
             get { return _pIcmsufDest; }
@@ -91,6 +97,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         /// NA09 - Alíquota interestadual das UF envolvidas
         /// </summary>
+        [XmlElement(Order = 5)]
         public decimal pICMSInter
         {
             get { return _pIcmsInter; }
@@ -100,6 +107,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         /// NA11 - Percentual provisório de partilha do ICMS Interestadual
         /// </summary>
+        [XmlElement(Order = 6)]
         public decimal pICMSInterPart
         {
             get { return _pIcmsInterPart; }
@@ -109,6 +117,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         /// NA13 - Valor do ICMS relativo ao Fundo de Combate à Pobreza(FCP) da UF de destino
         /// </summary>
+        [XmlElement(Order = 7)]
         public decimal? vFCPUFDest
         {
             get { return _vFcpufDest; }
@@ -123,6 +132,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         /// NA15 - Valor do ICMS Interestadual para a UF de destino
         /// </summary>
+        [XmlElement(Order = 8)]
         public decimal vICMSUFDest
         {
             get { return _vIcmsufDest; }
@@ -132,6 +142,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         /// NA17 - Valor do ICMS Interestadual para a UF do remetente
         /// </summary>
+        [XmlElement(Order = 9)]
         public decimal vICMSUFRemet
         {
             get { return _vIcmsufRemet; }


### PR DESCRIPTION
- Para sanar ao problema levantado na issue #828, foram adicionados os atributos [XmlElement(Order)] nas propriedades das classes do grupo ICMS, a fim de explicitar a ordem exata que as tags deverão ser geradas.
- Acrescentado no README do projeto o link para referencia do novo grupo de discussão do projeto Zeus no aplicativo Discord.