### PR TITLE
Configurando os shproj para controle de versão dentro do TFS

### DIFF
--- a/Shared.DFe.Classes/Shared.DFe.Classes.shproj
+++ b/Shared.DFe.Classes/Shared.DFe.Classes.shproj
@@ -3,6 +3,10 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>3108968d-d505-4365-966f-bbe3cbf63c35</ProjectGuid>
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+    <SccProjectName>SAK</SccProjectName>
+    <SccProvider>SAK</SccProvider>
+    <SccAuxPath>SAK</SccAuxPath>
+    <SccLocalPath>SAK</SccLocalPath>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />

--- a/Shared.DFe.Utils/Shared.DFe.Utils.shproj
+++ b/Shared.DFe.Utils/Shared.DFe.Utils.shproj
@@ -3,6 +3,10 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>e1888e9e-0273-40cb-a569-2ad023907140</ProjectGuid>
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+    <SccProjectName>SAK</SccProjectName>
+    <SccProvider>SAK</SccProvider>
+    <SccAuxPath>SAK</SccAuxPath>
+    <SccLocalPath>SAK</SccLocalPath>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />

--- a/Shared.NFe.Classes/Shared.NFe.Classes.shproj
+++ b/Shared.NFe.Classes/Shared.NFe.Classes.shproj
@@ -3,6 +3,10 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>4cc78350-9e01-465a-ac60-e31a53cefe24</ProjectGuid>
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+    <SccProjectName>SAK</SccProjectName>
+    <SccProvider>SAK</SccProvider>
+    <SccAuxPath>SAK</SccAuxPath>
+    <SccLocalPath>SAK</SccLocalPath>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />

--- a/Shared.NFe.Utils/Shared.NFe.Utils.shproj
+++ b/Shared.NFe.Utils/Shared.NFe.Utils.shproj
@@ -3,6 +3,10 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>e7a4800f-b2ed-4495-b847-c4bf5654e24e</ProjectGuid>
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+    <SccProjectName>SAK</SccProjectName>
+    <SccProvider>SAK</SccProvider>
+    <SccAuxPath>SAK</SccAuxPath>
+    <SccLocalPath>SAK</SccLocalPath>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />


### PR DESCRIPTION
Configuração necessária no arquivos .shproj, para quem costuma controlar a versão destes arquivos também dentro TFS (Team Foundation Server) internamente em seu time de desenvolvimento (meu caso).

Isso não afeta em nada para aqueles que NÃO utilizam o TFS para controlarem a versão do Zeus.

Segui as orientações abaixo para fazer estes ajustes:
https://github.com/dotnet/project-system/issues/1802
http://kb.dynamsoft.com/questions/538/What+does+SAK+stand+for%3F