### PR TITLE
Criado SegundaViaContingencia

### DIFF
--- a/NFe.Danfe.Base/NFCe/ConfiguracaoDanfeNfce.cs
+++ b/NFe.Danfe.Base/NFCe/ConfiguracaoDanfeNfce.cs
@@ -58,6 +58,7 @@ namespace NFe.Danfe.Base.NFCe
             NfceLayoutQrCode = nfceLayoutQrCode;
             CarregarFontePadraoNfceNativa();
             VersaoQrCode = versaoQrCode;
+            SegundaViaContingencia = true;
         }
 
         /// <summary>
@@ -111,6 +112,8 @@ namespace NFe.Danfe.Base.NFCe
         public VersaoQrCode VersaoQrCode { get; set; }
 
         public string FontPadraoNfceNativa { get; set; }
+
+        public bool SegundaViaContingencia { get; set; }
 
         public FontFamily CarregarFontePadraoNfceNativa(string font = null)
         {

--- a/NFe.Danfe.Fast/NFCe/DanfeFrNfce.cs
+++ b/NFe.Danfe.Fast/NFCe/DanfeFrNfce.cs
@@ -77,10 +77,13 @@ namespace NFe.Danfe.Fast.NFCe
             ((PictureObject) Relatorio.FindObject("poEmitLogo")).Image = configuracaoDanfeNfce.ObterLogo();
             ((TextObject)Relatorio.FindObject("txtUrl")).Text = string.IsNullOrEmpty(proc.NFe.infNFeSupl.urlChave) ? proc.NFe.infNFeSupl.ObterUrlConsulta(proc.NFe, configuracaoDanfeNfce.VersaoQrCode) : proc.NFe.infNFeSupl.urlChave;
             ((BarcodeObject)Relatorio.FindObject("bcoQrCode")).Text = proc.NFe.infNFeSupl  == null ? proc.NFe.infNFeSupl.ObterUrlQrCode(proc.NFe, configuracaoDanfeNfce.VersaoQrCode, cIdToken, csc) : proc.NFe.infNFeSupl.qrCode;
-            ((BarcodeObject)Relatorio.FindObject("bcoQrCodeLateral")).Text = proc.NFe.infNFeSupl == null ? proc.NFe.infNFeSupl.ObterUrlQrCode(proc.NFe, configuracaoDanfeNfce.VersaoQrCode, cIdToken, csc) : proc.NFe.infNFeSupl.qrCode;            
+            ((BarcodeObject)Relatorio.FindObject("bcoQrCodeLateral")).Text = proc.NFe.infNFeSupl == null ? proc.NFe.infNFeSupl.ObterUrlQrCode(proc.NFe, configuracaoDanfeNfce.VersaoQrCode, cIdToken, csc) : proc.NFe.infNFeSupl.qrCode;
+
+
 
             //Segundo o Manual de Padrões Técnicos do DANFE - NFC - e e QR Code, versão 3.2, página 9, nos casos de emissão em contingência deve ser impresso uma segunda cópia como via do estabelecimento
-            Relatorio.PrintSettings.Copies = (proc.NFe.infNFe.ide.tpEmis == TipoEmissao.teNormal | (proc.protNFe != null && proc.protNFe.infProt != null && NfeSituacao.Autorizada(proc.protNFe.infProt.cStat))
+            if (configuracaoDanfeNfce.SegundaViaContingencia)
+                Relatorio.PrintSettings.Copies = (proc.NFe.infNFe.ide.tpEmis == TipoEmissao.teNormal | (proc.protNFe != null && proc.protNFe.infProt != null && NfeSituacao.Autorizada(proc.protNFe.infProt.cStat))
                 /*Se a NFe for autorizada, mesmo que seja em contingência, imprime somente uma via*/ ) ? 1 : 2;
 
             #endregion

--- a/NFe.Danfe.Fast/NFe.Danfe.Fast.csproj
+++ b/NFe.Danfe.Fast/NFe.Danfe.Fast.csproj
@@ -37,17 +37,17 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FastReport, Version=2017.4.1.0, Culture=neutral, PublicKeyToken=db7e5ce63278458c, processorArchitecture=MSIL">
+    <Reference Include="FastReport, Version=2018.3.18.0, Culture=neutral, PublicKeyToken=db7e5ce63278458c, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>Dlls\FastReport.dll</HintPath>
+      <HintPath>..\..\..\fusion\3rd\FastReport\FastReport.dll</HintPath>
     </Reference>
-    <Reference Include="FastReport.Bars, Version=2017.4.1.0, Culture=neutral, PublicKeyToken=db7e5ce63278458c, processorArchitecture=MSIL">
+    <Reference Include="FastReport.Bars, Version=2018.3.18.0, Culture=neutral, PublicKeyToken=db7e5ce63278458c, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>Dlls\FastReport.Bars.dll</HintPath>
+      <HintPath>..\..\..\fusion\3rd\FastReport\FastReport.Bars.dll</HintPath>
     </Reference>
-    <Reference Include="FastReport.Editor, Version=2017.4.1.0, Culture=neutral, PublicKeyToken=db7e5ce63278458c, processorArchitecture=MSIL">
+    <Reference Include="FastReport.Editor, Version=2018.3.18.0, Culture=neutral, PublicKeyToken=db7e5ce63278458c, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>Dlls\FastReport.Editor.dll</HintPath>
+      <HintPath>..\..\..\fusion\3rd\FastReport\FastReport.Editor.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/NFe.Danfe.Fast/NFe.Danfe.Fast.csproj
+++ b/NFe.Danfe.Fast/NFe.Danfe.Fast.csproj
@@ -39,15 +39,15 @@
   <ItemGroup>
     <Reference Include="FastReport, Version=2018.3.18.0, Culture=neutral, PublicKeyToken=db7e5ce63278458c, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\fusion\3rd\FastReport\FastReport.dll</HintPath>
+      <HintPath>Dlls\FastReport.dll</HintPath>
     </Reference>
     <Reference Include="FastReport.Bars, Version=2018.3.18.0, Culture=neutral, PublicKeyToken=db7e5ce63278458c, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\fusion\3rd\FastReport\FastReport.Bars.dll</HintPath>
+      <HintPath>Dlls\FastReport.Bars.dll</HintPath>
     </Reference>
     <Reference Include="FastReport.Editor, Version=2018.3.18.0, Culture=neutral, PublicKeyToken=db7e5ce63278458c, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\fusion\3rd\FastReport\FastReport.Editor.dll</HintPath>
+      <HintPath>Dlls\FastReport.Editor.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
Se o parametro da configuração da nfc-e SegundaViaContingencia = false ele não vai irmpirmir duas vias..

Por padrão o parametro é true no construtor da classe e setado true ou seja , nada muda para quem já usa a impressão do zeus no fastreport