### PR TITLE
remover acentos antes de enviar request para sefaz, lembrando que 

### DIFF
--- a/NFe.Servicos/ServicosNFe.cs
+++ b/NFe.Servicos/ServicosNFe.cs
@@ -73,6 +73,7 @@ using System.Reflection;
 using System.Security.Cryptography.X509Certificates;
 using System.Xml;
 using NFe.Classes;
+using Shared.DFe.Utils;
 using FuncoesXml = DFe.Utils.FuncoesXml;
 
 namespace NFe.Servicos
@@ -319,13 +320,20 @@ namespace NFe.Servicos
                 pedInutilizacao.infInut.nNFFin.ToString().PadLeft(9, '0'));
             pedInutilizacao.infInut.Id = "ID" + numId;
 
-            pedInutilizacao.Assina(_certificado, _cFgServico.Certificado.SignatureMethodSignedXml, _cFgServico.Certificado.DigestMethodReference);
+            pedInutilizacao.Assina(_certificado, _cFgServico.Certificado.SignatureMethodSignedXml, _cFgServico.Certificado.DigestMethodReference, _cFgServico.RemoverAcentos);
 
             #endregion
 
             #region Valida, Envia os dados e obtém a resposta
 
-            var xmlInutilizacao = pedInutilizacao.ObterXmlString();
+            var xmlInutilizacao = string.Empty;
+
+            if (_cFgServico.RemoverAcentos)
+                xmlInutilizacao = pedInutilizacao.ObterXmlString().RemoverAcentos();
+
+            if (_cFgServico.RemoverAcentos == false)
+                xmlInutilizacao = pedInutilizacao.ObterXmlString();
+
             Validador.Valida(ServicoNFe.NfeInutilizacao, _cFgServico.VersaoNfeInutilizacao, xmlInutilizacao, cfgServico: _cFgServico);
             var dadosInutilizacao = new XmlDocument();
             dadosInutilizacao.LoadXml(xmlInutilizacao);

--- a/NFe.Servicos/ServicosNFe.cs
+++ b/NFe.Servicos/ServicosNFe.cs
@@ -413,14 +413,24 @@ namespace NFe.Servicos
             {
                 evento.infEvento.Id = "ID" + evento.infEvento.tpEvento + evento.infEvento.chNFe +
                                       evento.infEvento.nSeqEvento.ToString().PadLeft(2, '0');
-                evento.Assina(_certificado, _cFgServico.Certificado.SignatureMethodSignedXml,_cFgServico.Certificado.DigestMethodReference);
+                evento.Assina(_certificado, _cFgServico.Certificado.SignatureMethodSignedXml,_cFgServico.Certificado.DigestMethodReference, _cFgServico.RemoverAcentos);
             }
 
             #endregion
 
             #region Valida, Envia os dados e obtém a resposta
 
-            var xmlEvento = pedEvento.ObterXmlString();
+
+
+            var xmlEvento = string.Empty;
+
+            if (_cFgServico.RemoverAcentos == false)
+                xmlEvento = pedEvento.ObterXmlString();
+
+            if (_cFgServico.RemoverAcentos) 
+                xmlEvento = pedEvento.ObterXmlString().RemoverAcentos();
+
+
             Validador.Valida(servicoEvento, _cFgServico.VersaoRecepcaoEventoCceCancelamento, xmlEvento, cfgServico: _cFgServico);
             var dadosEvento = new XmlDocument();
             dadosEvento.LoadXml(xmlEvento);
@@ -535,7 +545,7 @@ namespace NFe.Servicos
             };
 
 
-            if (_cFgServico.cUF == Estado.MT)
+            if (_cFgServico.cUF == Estado.MT || _cFgServico.RemoverAcentos)
             {
                 detEvento.xCondUso =
                     "A Carta de Correcao e disciplinada pelo paragrafo 1o-A do art. 7o do Convenio S/N, de 15 de dezembro de 1970 e pode ser utilizada para regularizacao de erro ocorrido na emissao de documento fiscal, desde que o erro nao esteja relacionado com: I - as variaveis que determinam o valor do imposto tais como: base de calculo, aliquota, diferenca de preco, quantidade, valor da operacao ou da prestacao; II - a correcao de dados cadastrais que implique mudanca do remetente ou do destinatario; III - a data de emissao ou de saida.";
@@ -1063,7 +1073,14 @@ namespace NFe.Servicos
 
             #region Valida, Envia os dados e obtém a resposta
 
-            var xmlEnvio = pedEnvio.ObterXmlString();
+            var xmlEnvio = string.Empty;
+
+            if (_cFgServico.RemoverAcentos == false)
+                xmlEnvio = pedEnvio.ObterXmlString();
+
+            if (_cFgServico.RemoverAcentos)
+                xmlEnvio = pedEnvio.ObterXmlString().RemoverAcentos();
+
             if (_cFgServico.cUF == Estado.PR)
                 //Caso o lote seja enviado para o PR, colocar o namespace nos elementos <NFe> do lote, pois o serviço do PR o exige, conforme https://github.com/adeniltonbs/Zeus.Net.NFe.NFCe/issues/33
                 xmlEnvio = xmlEnvio.Replace("<NFe>", "<NFe xmlns=\"http://www.portalfiscal.inf.br/nfe\">");

--- a/Shared.DFe.Utils/Shared.DFe.Utils.projitems
+++ b/Shared.DFe.Utils/Shared.DFe.Utils.projitems
@@ -18,5 +18,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)EnumExt.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FuncoesXml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Reflexao.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)StringExtencoes.cs" />
   </ItemGroup>
 </Project>

--- a/Shared.DFe.Utils/StringExtencoes.cs
+++ b/Shared.DFe.Utils/StringExtencoes.cs
@@ -1,0 +1,28 @@
+﻿using System.Text.RegularExpressions;
+
+namespace Shared.DFe.Utils
+{
+    public static class StringExtencoes
+    {
+        public static string RemoverAcentos(this string valor)
+        {
+            if (string.IsNullOrEmpty(valor))
+                return valor;
+
+            valor = Regex.Replace(valor, "[áàâãª]", "a");
+            valor = Regex.Replace(valor, "[ÁÀÂÃÄ]", "A");
+            valor = Regex.Replace(valor, "[éèêë]", "e");
+            valor = Regex.Replace(valor, "[ÉÈÊË]", "E");
+            valor = Regex.Replace(valor, "[íìîï]", "i");
+            valor = Regex.Replace(valor, "[ÍÌÎÏ]", "I");
+            valor = Regex.Replace(valor, "[óòôõöº]", "o");
+            valor = Regex.Replace(valor, "[ÓÒÔÕÖ]", "O");
+            valor = Regex.Replace(valor, "[úùûü]", "u");
+            valor = Regex.Replace(valor, "[ÚÙÛÜ]", "U");
+            valor = Regex.Replace(valor, "[Ç]", "C");
+            valor = Regex.Replace(valor, "[ç]", "c");
+
+            return valor;
+        }
+    }
+}

--- a/Shared.NFe.Utils/ConfiguracaoServico.cs
+++ b/Shared.NFe.Utils/ConfiguracaoServico.cs
@@ -506,6 +506,8 @@ namespace NFe.Utils
             }
         }
 
+        public bool RemoverAcentos { get; set; }
+
         /// <summary>
         ///     Limpa a instancia atual caso exista
         /// </summary>

--- a/Shared.NFe.Utils/Evento/Extevento.cs
+++ b/Shared.NFe.Utils/Evento/Extevento.cs
@@ -55,14 +55,19 @@ namespace NFe.Utils.Evento
         /// </summary>
         /// <param name="evento"></param>
         /// <param name="certificadoDigital">Informe o certificado digital, se já possuir esse em cache, evitando novo acesso ao certificado</param>
+        /// <param name="signatureMethodSignedXml"></param>
+        /// <param name="digestMethodReference"></param>
+        /// <param name="removerAcentos"></param>
         /// <returns>Retorna um objeto do tipo evento assinado</returns>
-        public static evento Assina(this evento evento, X509Certificate2 certificadoDigital, string signatureMethodSignedXml = "http://www.w3.org/2000/09/xmldsig#rsa-sha1", string digestMethodReference = "http://www.w3.org/2000/09/xmldsig#sha1")
+        public static evento Assina(this evento evento, X509Certificate2 certificadoDigital,
+            string signatureMethodSignedXml = "http://www.w3.org/2000/09/xmldsig#rsa-sha1",
+            string digestMethodReference = "http://www.w3.org/2000/09/xmldsig#sha1", bool removerAcentos = false)
         {
             var eventoLocal = evento;
             if (eventoLocal.infEvento.Id == null)
                 throw new Exception("Não é possível assinar um objeto evento sem sua respectiva Id!");
 
-            var assinatura = Assinador.ObterAssinatura(eventoLocal, eventoLocal.infEvento.Id, certificadoDigital, false, signatureMethodSignedXml, digestMethodReference);
+            var assinatura = Assinador.ObterAssinatura(eventoLocal, eventoLocal.infEvento.Id, certificadoDigital, false, signatureMethodSignedXml, digestMethodReference, removerAcentos);
             eventoLocal.Signature = assinatura;
             return eventoLocal;
         }

--- a/Shared.NFe.Utils/Inutilizacao/ExtinutNFe.cs
+++ b/Shared.NFe.Utils/Inutilizacao/ExtinutNFe.cs
@@ -67,13 +67,13 @@ namespace NFe.Utils.Inutilizacao
         /// <param name="inutNFe"></param>
         /// <param name="certificadoDigital">Informe o certificado digital, se já possuir esse em cache, evitando novo acesso ao certificado</param>
         /// <returns>Retorna um objeto do tipo inutNFe assinado</returns>
-        public static inutNFe Assina(this inutNFe inutNFe, X509Certificate2 certificadoDigital, string signatureMethodSignedXml = "http://www.w3.org/2000/09/xmldsig#rsa-sha1", string digestMethodReference = "http://www.w3.org/2000/09/xmldsig#sha1")
+        public static inutNFe Assina(this inutNFe inutNFe, X509Certificate2 certificadoDigital, string signatureMethodSignedXml = "http://www.w3.org/2000/09/xmldsig#rsa-sha1", string digestMethodReference = "http://www.w3.org/2000/09/xmldsig#sha1", bool removerAcentos = false)
         {
             var inutNFeLocal = inutNFe;
             if (inutNFeLocal.infInut.Id == null)
                 throw new Exception("Não é possível assinar um onjeto inutNFe sem sua respectiva Id!");
 
-            var assinatura = Assinador.ObterAssinatura(inutNFeLocal, inutNFeLocal.infInut.Id, certificadoDigital, false, signatureMethodSignedXml, digestMethodReference);
+            var assinatura = Assinador.ObterAssinatura(inutNFeLocal, inutNFeLocal.infInut.Id, certificadoDigital, false, signatureMethodSignedXml, digestMethodReference, removerAcentos);
             inutNFeLocal.Signature = assinatura;
             return inutNFeLocal;
         }


### PR DESCRIPTION
dentro da classe ConfiguracaoServico.cs temos o atributo `public bool RemoverAcentos { get; set; }`

por padrão = false ou seja.. o padrão e não fazer nada alem do normal de sempre 

motivo da criação, o estado de MT não aceita com acentos. Bom não consegui enviar. 