### PR TITLE
Acerto de acentuação para Sefaz MT - issue 893 

### DIFF
--- a/NFe.Servicos/ServicosNFe.cs
+++ b/NFe.Servicos/ServicosNFe.cs
@@ -540,6 +540,7 @@ namespace NFe.Servicos
                 detEvento.xCondUso =
                     "A Carta de Correcao e disciplinada pelo paragrafo 1o-A do art. 7o do Convenio S/N, de 15 de dezembro de 1970 e pode ser utilizada para regularizacao de erro ocorrido na emissao de documento fiscal, desde que o erro nao esteja relacionado com: I - as variaveis que determinam o valor do imposto tais como: base de calculo, aliquota, diferenca de preco, quantidade, valor da operacao ou da prestacao; II - a correcao de dados cadastrais que implique mudanca do remetente ou do destinatario; III - a data de emissao ou de saida.";
                 detEvento.descEvento = "Carta de Correcao";
+                detEvento.xCorrecao = correcao.RemoverAcentucaoSimples();
             }
 
             var infEvento = new infEventoEnv

--- a/Shared.NFe.Utils/Conversao.cs
+++ b/Shared.NFe.Utils/Conversao.cs
@@ -257,5 +257,17 @@ namespace NFe.Utils
             }
             return hex;
         }
+        
+        public static string RemoverAcentucaoSimples(this string texto)
+        {
+            string comAcentos = "ÄÅÁÂÀÃäáâàãÉÊËÈéêëèÍÎÏÌíîïìÖÓÔÒÕöóôòõÜÚÛüúûùÇçñÑ";
+            string semAcentos = "AAAAAAaaaaaEEEEeeeeIIIIiiiiOOOOOoooooUUUuuuuCcnN";
+            
+            for (int i = 0; i < comAcentos.Length; i++)
+            {
+                texto = texto.Replace(comAcentos[i].ToString(), semAcentos[i].ToString());
+            }
+            return texto;
+        }
     }
 }


### PR DESCRIPTION
Erro ocorria ao enviar a carta de correção (em ambiente de Produção) com acentuação para a Sefaz MT.

Correção conforme issue:
https://github.com/ZeusAutomacao/DFe.NET/issues/893#event-1992073252