### PR TITLE
Correção casas decimais pDif

### DIFF
--- a/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS51.cs
+++ b/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS51.cs
@@ -112,8 +112,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         [XmlElement(Order = 8)]
         public decimal? pDif
         {
-            get { return _pDif.Arredondar(2); }
-            set { _pDif = value.Arredondar(2); }
+            get { return _pDif.Arredondar(4); }
+            set { _pDif = value.Arredondar(4); }
         }
 
         /// <summary>


### PR DESCRIPTION
O percentual de diferença pode conter 4 casas decimais, ajustado para atender essa necessidade