### PR TITLE
Inclusão do Evento de registro de passagem automático gerado pela Sefaz

### DIFF
--- a/MDFe.Classes/Informacoes/Evento/Flags/MDFeTipoEvento.cs
+++ b/MDFe.Classes/Informacoes/Evento/Flags/MDFeTipoEvento.cs
@@ -43,6 +43,8 @@ namespace MDFe.Classes.Informacoes.Evento.Flags
         [XmlEnum("110114")]
         InclusaoDeCondutor = 110114,
         [XmlEnum("310620")]
-        RegistroDePassagem = 310620
+        RegistroDePassagem = 310620,
+        [XmlEnum("510620")]
+        RegistroDePassagemAutomatico = 510620
     }
 }


### PR DESCRIPTION
Inclusão do Evento de registro de passagem automático gerado pela Sefaz quando há algum evento vinculado ao MDF-e ou as notas referenciadas no MDF-e. Obtive um erro ao tentar um MDF-e que trazia o  tipo de evento 510620 que não tinha implementado na classe modificada. Ao adicionar o evento a classe, consegui encerrar os MDF-es