### PR TITLE
Portabilidade Validador.Valida Linux

### DIFF
--- a/Shared.NFe.Utils/Validacao/Validador.cs
+++ b/Shared.NFe.Utils/Validacao/Validador.cs
@@ -123,7 +123,7 @@ namespace NFe.Utils.Validacao
             if (!Directory.Exists(pathSchema))
                 throw new Exception("Diretório de Schemas não encontrado: \n" + pathSchema);
 
-            var arquivoSchema = pathSchema + @"\" + ObterArquivoSchema(servicoNFe, versaoServico, loteNfe);
+            var arquivoSchema = Path.Combine(pathSchema, ObterArquivoSchema(servicoNFe, versaoServico, loteNfe));
 
             // Define o tipo de validação
             var cfg = new XmlReaderSettings { ValidationType = ValidationType.Schema };

--- a/Shared.NFe.Utils/Validacao/Validador.cs
+++ b/Shared.NFe.Utils/Validacao/Validador.cs
@@ -130,7 +130,9 @@ namespace NFe.Utils.Validacao
 
             // Carrega o arquivo de esquema
             var schemas = new XmlSchemaSet();
-            cfg.Schemas = schemas;
+			schemas.XmlResolver = new XmlUrlResolver();
+
+			cfg.Schemas = schemas;
             // Quando carregar o eschema, especificar o namespace que ele valida
             // e a localização do arquivo 
             schemas.Add(null, arquivoSchema);

--- a/Shared.NFe.Utils/Validacao/Validador.cs
+++ b/Shared.NFe.Utils/Validacao/Validador.cs
@@ -130,9 +130,9 @@ namespace NFe.Utils.Validacao
 
             // Carrega o arquivo de esquema
             var schemas = new XmlSchemaSet();
-			schemas.XmlResolver = new XmlUrlResolver();
+            schemas.XmlResolver = new XmlUrlResolver();
 
-			cfg.Schemas = schemas;
+            cfg.Schemas = schemas;
             // Quando carregar o eschema, especificar o namespace que ele valida
             // e a localização do arquivo 
             schemas.Add(null, arquivoSchema);


### PR DESCRIPTION
Estou utilizando essa biblioteca no linux e não consigo utilizar o método `Validador.Valida` pois o separador de caminho está fixado com `\`, que é o separador do Windows. Isso faz com que o arquivo nunca seja encontrado pois o caminho é montando da seguinte forma: `/home/user/schema\nfe_4.00.xsd`, o que não é um caminho válido no linux.

Esse PR utiliza `Path.combine` para montar o caminho do arquivo do schema, que por sua vez utiliza o separador de caminho do sistema operacional que está executando a biblioteca.

Além disso, no linux é utilizado o `.net core `ao invés do `.net framework` e conforme explicado [aqui](https://github.com/dotnet/corefx/issues/20263#issuecomment-304149620) é necessário adicionar uma instância de `XmlUrlResolver` explicitamente ao `XmlSchemaSet` para resolver URIs dentro do schema. Essa alteração não impacta no `.net framework`, ou seja, continua funcionando normalmente.

