### PR TITLE
Otimizando geração de imagem nativa e gravando em PNG

### DIFF
--- a/NFe.Danfe.Nativo/NFCe/DanfeNativoNfce.cs
+++ b/NFe.Danfe.Nativo/NFCe/DanfeNativoNfce.cs
@@ -108,7 +108,7 @@ namespace NFe.Danfe.Nativo.NFCe
             GerarNfCe(e.Graphics);
         }
 
-        public void GerarJPEG(string filename)
+        public void GerarImagem(string filename, ImageFormat format)
         {
 
             // Feito esse de cima para poder pegar o tamanho real da mesma desenhando
@@ -119,18 +119,28 @@ namespace NFe.Danfe.Nativo.NFCe
                     g.Clear(Color.White);
                     GerarNfCe(g);
                 }
-            }
 
-            // Obtive o tamanho real na posição y agora vou fazer um com tamanho exato
-            using (Bitmap bmpFinal = new Bitmap(300, _y))
-            {
-                using (Graphics g = Graphics.FromImage(bmpFinal))
+                // Obtive o tamanho real na posição y agora vou fazer um com tamanho exato
+                using (Bitmap bmpFinal = new Bitmap(300, _y))
                 {
-                    g.Clear(Color.White);
-                    GerarNfCe(g);
-                    bmpFinal.Save(filename, ImageFormat.Jpeg);
+                    using (Graphics g = Graphics.FromImage(bmpFinal))
+                    {
+                        g.Clear(Color.White);
+                        g.DrawImage(bmp, 0, 0);
+                        bmpFinal.Save(filename, format);
+                    }
                 }
             }
+        }
+
+        public void GerarJPEG(string filename)
+        {
+            GerarImagem(filename, ImageFormat.Jpeg);
+        }
+
+        public void GerarJPG(string filename)
+        {
+            GerarImagem(filename, ImageFormat.Png);
         }
 
         private void GerarNfCe(Graphics graphics)


### PR DESCRIPTION
Ola, Adenilton.
Gostei muito to seu componente, do seu código, e de como estruturou, parabens!
Pude aprender muito e estou iniciando o uso da NFCe em um de meus clientes.

Mas quero contribuir com 2 pequena melhoria que fiz na geração nativa de imagem da DANFE

1) Otimização de geração, em vez de gerar 2 vezes tudo, redesenhando tudo duas vezes, é muito mais "leve" desenha uma unica vez como já é feito, e só dar um CROP em uma nova área com o tamanho correto

2) Salvar em PNG para enviar por email, ou mesmo imprimir garante melhor precisão de leitura, e para compatibilizar criei 2 métodos diferentes para isso e um genérico ainda para qualquer outro formato BMP já existente

Espero que goste, tenho outras sugestões depois faço novos pull-requests.