### PR TITLE
DAMDFE - correção para exibição correta dos vales pedágio

### DIFF
--- a/MDFe.Damdfe.Fast/Resources/MDFeRetrato.frx
+++ b/MDFe.Damdfe.Fast/Resources/MDFeRetrato.frx
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Report ScriptLanguage="CSharp" ReferencedAssemblies="System.dll&#13;&#10;System.Drawing.dll&#13;&#10;System.Windows.Forms.dll&#13;&#10;System.Data.dll&#13;&#10;System.Xml.dll&#13;&#10;MDFe.Classes.dll&#13;&#10;DFe.Classes.dll&#13;&#10;MDFe.Utils.dll" ReportInfo.Created="01/12/2017 09:00:32" ReportInfo.Modified="03/18/2019 17:09:02" ReportInfo.CreatorVersion="2018.1.4.0">
+<Report ScriptLanguage="CSharp" ReferencedAssemblies="System.dll&#13;&#10;System.Drawing.dll&#13;&#10;System.Windows.Forms.dll&#13;&#10;System.Data.dll&#13;&#10;System.Xml.dll&#13;&#10;MDFe.Classes.dll&#13;&#10;DFe.Classes.dll&#13;&#10;MDFe.Utils.dll" ReportInfo.Created="01/12/2017 09:00:32" ReportInfo.Modified="05/07/2019 15:26:13" ReportInfo.CreatorVersion="2018.1.4.0">
   <ScriptText>using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -121,14 +121,14 @@ namespace FastReport
       txtCnpjResp.Text = &quot;&quot;;
       txtCnpjFornec.Text = &quot;&quot;;
       txtNumComprovante.Text = &quot;&quot;;      
-      var vale = Report.GetDataSource(&quot;MDFeProcMDFe.MDFe.InfMDFe.InfModal.Modal.ValePed.Disp&quot;); 
+      var vale = Report.GetDataSource(&quot;MDFeProcMDFe.MDFe.InfMDFe.InfModal.Modal.infANTT.valePed.disp&quot;); 
       vale.Init();
       while (vale.HasMoreRows)
       {
-        txtCnpjResp.Text += FormatarCampo(((String)Report.GetColumnValue(&quot;MDFeProcMDFe.MDFe.InfMDFe.InfModal.Modal.ValePed.Disp.CNPJPg&quot;)), 'd') + Environment.NewLine;
-        txtCnpjFornec.Text += FormatarCampo(((String)Report.GetColumnValue(&quot;MDFeProcMDFe.MDFe.InfMDFe.InfModal.Modal.ValePed.Disp.CNPJForn&quot;)), 'd') + Environment.NewLine;
-        txtNumComprovante.Text += ((String)Report.GetColumnValue(&quot;MDFeProcMDFe.MDFe.InfMDFe.InfModal.Modal.ValePed.Disp.NCompra&quot;)) + Environment.NewLine;
-        vale.Next();
+        txtCnpjResp.Text += FormatarCampo(((String)Report.GetColumnValue(&quot;MDFeProcMDFe.MDFe.InfMDFe.InfModal.Modal.infANTT.valePed.disp.CNPJPg&quot;)), 'd') + Environment.NewLine;
+        txtCnpjFornec.Text += FormatarCampo(((String)Report.GetColumnValue(&quot;MDFeProcMDFe.MDFe.InfMDFe.InfModal.Modal.infANTT.valePed.disp.CNPJForn&quot;)), 'd') + Environment.NewLine;
+        txtNumComprovante.Text += ((String)Report.GetColumnValue(&quot;MDFeProcMDFe.MDFe.InfMDFe.InfModal.Modal.infANTT.valePed.disp.NCompra&quot;)) + Environment.NewLine;
+        vale.Next();   
       }
       
       //Seguros
@@ -195,51 +195,52 @@ namespace FastReport
 }
 </ScriptText>
   <Dictionary>
-    <BusinessObjectDataSource Name="MDFeProcMDFe" ReferenceName="MDFeProcMDFe" DataType="MDFe.Classes.Retorno.MDFeProcMDFe[], MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null" Enabled="true">
-      <Column Name="Versao" DataType="MDFe.Utils.Flags.VersaoServico, MDFe.Utils, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null"/>
-      <Column Name="MDFe" DataType="MDFe.Classes.Informacoes.MDFe, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null">
-        <Column Name="InfMDFe" DataType="MDFe.Classes.Informacoes.MDFeInfMDFe, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null">
-          <Column Name="Versao" DataType="MDFe.Utils.Flags.VersaoServico, MDFe.Utils, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null"/>
+    <BusinessObjectDataSource Name="MDFeProcMDFe" ReferenceName="MDFeProcMDFe" DataType="MDFe.Classes.Retorno.MDFeProcMDFe[], MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null" Enabled="true">
+      <Column Name="Versao" DataType="MDFe.Utils.Flags.VersaoServico, MDFe.Utils, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null"/>
+      <Column Name="MDFe" DataType="MDFe.Classes.Informacoes.MDFe, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null">
+        <Column Name="InfMDFe" DataType="MDFe.Classes.Informacoes.MDFeInfMDFe, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null">
+          <Column Name="Versao" DataType="MDFe.Utils.Flags.VersaoServico, MDFe.Utils, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null"/>
           <Column Name="Id" DataType="System.String"/>
-          <Column Name="Ide" DataType="MDFe.Classes.Informacoes.MDFeIde, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null">
-            <Column Name="CUF" DataType="DFe.Classes.Entidades.Estado, DFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null"/>
-            <Column Name="TpAmb" DataType="DFe.Classes.Flags.TipoAmbiente, DFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null"/>
-            <Column Name="TpEmit" DataType="MDFe.Classes.Flags.MDFeTipoEmitente, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null"/>
-            <Column Name="TpTransp" DataType="System.Nullable`1[[MDFe.Classes.Flags.MDFeTpTransp, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null]]"/>
+          <Column Name="Ide" DataType="MDFe.Classes.Informacoes.MDFeIde, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null">
+            <Column Name="CUF" DataType="DFe.Classes.Entidades.Estado, DFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null"/>
+            <Column Name="TpAmb" DataType="DFe.Classes.Flags.TipoAmbiente, DFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null"/>
+            <Column Name="TpEmit" DataType="MDFe.Classes.Flags.MDFeTipoEmitente, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null"/>
+            <Column Name="TpTransp" DataType="System.Nullable`1[[MDFe.Classes.Flags.MDFeTpTransp, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null]]"/>
             <Column Name="TpTranspSpecified" DataType="System.Boolean" BindableControl="CheckBox"/>
-            <Column Name="Mod" DataType="DFe.Classes.Flags.ModeloDocumento, DFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null"/>
+            <Column Name="Mod" DataType="DFe.Classes.Flags.ModeloDocumento, DFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null"/>
             <Column Name="Serie" DataType="System.Int16"/>
             <Column Name="NMDF" DataType="System.Int64"/>
             <Column Name="CMDF" DataType="System.Int32"/>
             <Column Name="ProxyCMDF" DataType="System.String"/>
             <Column Name="CDV" DataType="System.Byte"/>
-            <Column Name="Modal" DataType="MDFe.Classes.Flags.MDFeModal, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null"/>
+            <Column Name="Modal" DataType="MDFe.Classes.Flags.MDFeModal, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null"/>
             <Column Name="DhEmi" DataType="System.DateTime"/>
             <Column Name="ProxyDhEmi" DataType="System.String"/>
-            <Column Name="TpEmis" DataType="MDFe.Classes.Flags.MDFeTipoEmissao, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null"/>
-            <Column Name="ProcEmi" DataType="MDFe.Classes.Flags.MDFeIdentificacaoProcessoEmissao, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null"/>
+            <Column Name="TpEmis" DataType="MDFe.Classes.Flags.MDFeTipoEmissao, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null"/>
+            <Column Name="ProcEmi" DataType="MDFe.Classes.Flags.MDFeIdentificacaoProcessoEmissao, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null"/>
             <Column Name="VerProc" DataType="System.String"/>
-            <Column Name="UFIni" DataType="DFe.Classes.Entidades.Estado, DFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null"/>
+            <Column Name="UFIni" DataType="DFe.Classes.Entidades.Estado, DFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null"/>
             <Column Name="ProxyUFIni" DataType="System.String"/>
-            <Column Name="UFFim" DataType="DFe.Classes.Entidades.Estado, DFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null"/>
+            <Column Name="UFFim" DataType="DFe.Classes.Entidades.Estado, DFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null"/>
             <Column Name="ProxyUFFim" DataType="System.String"/>
-            <BusinessObjectDataSource Name="BusinessObjectDataSource1" Alias="InfMunCarrega" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeInfMunCarrega, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null]]" PropName="InfMunCarrega" Enabled="true">
+            <BusinessObjectDataSource Name="BusinessObjectDataSource1" Alias="InfMunCarrega" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeInfMunCarrega, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null]]" PropName="InfMunCarrega" Enabled="true">
               <Column Name="CMunCarrega" DataType="System.String"/>
               <Column Name="XMunCarrega" DataType="System.String"/>
             </BusinessObjectDataSource>
-            <BusinessObjectDataSource Name="BusinessObjectDataSource2" Alias="InfPercurso" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeInfPercurso, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null]]" PropName="InfPercurso" Enabled="true">
-              <Column Name="UFPer" DataType="DFe.Classes.Entidades.Estado, DFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null"/>
+            <BusinessObjectDataSource Name="BusinessObjectDataSource2" Alias="InfPercurso" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeInfPercurso, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null]]" PropName="InfPercurso" Enabled="true">
+              <Column Name="UFPer" DataType="DFe.Classes.Entidades.Estado, DFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null"/>
               <Column Name="ProxyUFPer" DataType="System.String"/>
             </BusinessObjectDataSource>
             <Column Name="DhIniViagem" DataType="System.Nullable`1[[System.DateTime, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
             <Column Name="ProxyDhIniViagem" DataType="System.String"/>
           </Column>
-          <Column Name="Emit" DataType="MDFe.Classes.Informacoes.MDFeEmit, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null">
+          <Column Name="Emit" DataType="MDFe.Classes.Informacoes.MDFeEmit, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null">
             <Column Name="CNPJ" DataType="System.String"/>
+            <Column Name="CPF" DataType="System.String"/>
             <Column Name="IE" DataType="System.String"/>
             <Column Name="XNome" DataType="System.String"/>
             <Column Name="XFant" DataType="System.String"/>
-            <Column Name="EnderEmit" DataType="MDFe.Classes.Informacoes.MDFeEnderEmit, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null">
+            <Column Name="EnderEmit" DataType="MDFe.Classes.Informacoes.MDFeEnderEmit, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null">
               <Column Name="XLgr" DataType="System.String"/>
               <Column Name="Nro" DataType="System.String"/>
               <Column Name="XCpl" DataType="System.String"/>
@@ -248,110 +249,107 @@ namespace FastReport
               <Column Name="XMun" DataType="System.String"/>
               <Column Name="CEP" DataType="System.Int64"/>
               <Column Name="ProxyCEP" DataType="System.String"/>
-              <Column Name="UF" DataType="DFe.Classes.Entidades.Estado, DFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null"/>
+              <Column Name="UF" DataType="DFe.Classes.Entidades.Estado, DFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null"/>
               <Column Name="ProxyUF" DataType="System.String"/>
               <Column Name="Fone" DataType="System.String"/>
               <Column Name="Email" DataType="System.String"/>
             </Column>
-            <Column Name="CPF" DataType="System.String"/>
           </Column>
-          <Column Name="InfModal" DataType="MDFe.Classes.Informacoes.MDFeInfModal, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null">
-            <Column Name="VersaoModal" DataType="MDFe.Classes.Flags.MDFeVersaoModal, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null"/>
-            <Column Name="Modal" DataType="MDFe.Classes.Contratos.MDFeModalContainer, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null">
-              <Column Name="infANTT" DataType="MDFe.Classes.Informacoes.MDFeInfANTT, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null">
+          <Column Name="InfModal" DataType="MDFe.Classes.Informacoes.MDFeInfModal, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null">
+            <Column Name="VersaoModal" DataType="MDFe.Classes.Flags.MDFeVersaoModal, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null"/>
+            <Column Name="Modal" DataType="MDFe.Classes.Contratos.MDFeModalContainer, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null">
+              <Column Name="infANTT" DataType="MDFe.Classes.Informacoes.MDFeInfANTT, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null">
                 <Column Name="RNTRC" DataType="System.String"/>
-                <Column Name="valePed" DataType="MDFe.Classes.Informacoes.MDFeValePed, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null">
-                  <BusinessObjectDataSource Name="BusinessObjectDataSource25" Alias="Disp" Enabled="false" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeDisp, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null]]" PropName="Disp"/>
+                <Column Name="valePed" DataType="MDFe.Classes.Informacoes.MDFeValePed, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null">
+                  <BusinessObjectDataSource Name="BusinessObjectDataSource25" Alias="Disp" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeDisp, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null]]" PropName="Disp" Enabled="true">
+                    <Column Name="CNPJForn" DataType="System.String"/>
+                    <Column Name="CNPJPg" DataType="System.String"/>
+                    <Column Name="CPFPg" DataType="System.String"/>
+                    <Column Name="NCompra" DataType="System.String"/>
+                    <Column Name="vValePed" DataType="System.Decimal"/>
+                  </BusinessObjectDataSource>
                 </Column>
-                <BusinessObjectDataSource Name="infContratante" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.infContratante, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
+                <BusinessObjectDataSource Name="infContratante" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.infContratante, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
                   <Column Name="CPF" DataType="System.String"/>
                   <Column Name="CNPJ" DataType="System.String"/>
                 </BusinessObjectDataSource>
-                <BusinessObjectDataSource Name="BusinessObjectDataSource24" Alias="infCIOT" Enabled="false" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.infCIOT, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null]]" PropName="infCIOT"/>
+                <BusinessObjectDataSource Name="BusinessObjectDataSource26" Alias="infCIOT" Enabled="false" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.infCIOT, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null]]" PropName="infCIOT"/>
               </Column>
               <Column Name="RNTRC" DataType="System.String"/>
               <Column Name="CIOT" DataType="System.String"/>
-              <Column Name="VeicTracao" DataType="MDFe.Classes.Informacoes.MDFeVeicTracao, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null">
+              <Column Name="VeicTracao" DataType="MDFe.Classes.Informacoes.MDFeVeicTracao, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null">
                 <Column Name="CInt" DataType="System.String"/>
                 <Column Name="Placa" DataType="System.String"/>
                 <Column Name="RENAVAM" DataType="System.String"/>
                 <Column Name="Tara" DataType="System.Nullable`1[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
                 <Column Name="CapKG" DataType="System.Nullable`1[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
                 <Column Name="CapM3" DataType="System.Nullable`1[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
-                <Column Name="Prop" DataType="MDFe.Classes.Informacoes.MDFeProp, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null">
+                <Column Name="Prop" DataType="MDFe.Classes.Informacoes.MDFeProp, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null">
                   <Column Name="CPF" DataType="System.String"/>
                   <Column Name="CNPJ" DataType="System.String"/>
                   <Column Name="RNTRC" DataType="System.String"/>
                   <Column Name="XNome" DataType="System.String"/>
                   <Column Name="IE" DataType="System.String"/>
-                  <Column Name="UF" DataType="DFe.Classes.Entidades.Estado, DFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null"/>
+                  <Column Name="UF" DataType="DFe.Classes.Entidades.Estado, DFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null"/>
                   <Column Name="ProxyUF" DataType="System.String"/>
-                  <Column Name="MDFeTpProp" DataType="MDFe.Classes.Flags.MDFeTpProp, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null"/>
+                  <Column Name="MDFeTpProp" DataType="MDFe.Classes.Flags.MDFeTpProp, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null"/>
                 </Column>
-                <BusinessObjectDataSource Name="BusinessObjectDataSource3" Alias="Condutor" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeCondutor, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null]]" PropName="Condutor" Enabled="true">
+                <BusinessObjectDataSource Name="BusinessObjectDataSource3" Alias="Condutor" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeCondutor, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null]]" PropName="Condutor" Enabled="true">
                   <Column Name="XNome" DataType="System.String"/>
                   <Column Name="CPF" DataType="System.String"/>
                 </BusinessObjectDataSource>
-                <Column Name="TpRod" DataType="MDFe.Classes.Flags.MDFeTpRod, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null"/>
-                <Column Name="TpCar" DataType="MDFe.Classes.Flags.MDFeTpCar, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null"/>
-                <Column Name="UF" DataType="DFe.Classes.Entidades.Estado, DFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null"/>
+                <Column Name="TpRod" DataType="MDFe.Classes.Flags.MDFeTpRod, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null"/>
+                <Column Name="TpCar" DataType="MDFe.Classes.Flags.MDFeTpCar, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null"/>
+                <Column Name="UF" DataType="DFe.Classes.Entidades.Estado, DFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null"/>
                 <Column Name="ProxyUF" DataType="System.String"/>
                 <Column Name="CapKGSpecified" DataType="System.Boolean" BindableControl="CheckBox"/>
                 <Column Name="CapM3Specified" DataType="System.Boolean" BindableControl="CheckBox"/>
               </Column>
-              <BusinessObjectDataSource Name="BusinessObjectDataSource4" Alias="VeicReboque" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeVeicReboque, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null]]" PropName="VeicReboque" Enabled="true">
+              <BusinessObjectDataSource Name="BusinessObjectDataSource4" Alias="VeicReboque" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeVeicReboque, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null]]" PropName="VeicReboque" Enabled="true">
                 <Column Name="CInt" DataType="System.String"/>
                 <Column Name="Placa" DataType="System.String"/>
                 <Column Name="RENAVAM" DataType="System.String"/>
                 <Column Name="Tara" DataType="System.Nullable`1[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
                 <Column Name="CapKG" DataType="System.Nullable`1[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
                 <Column Name="CapM3" DataType="System.Nullable`1[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
-                <Column Name="Prop" DataType="MDFe.Classes.Informacoes.MDFeProp, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null">
+                <Column Name="Prop" DataType="MDFe.Classes.Informacoes.MDFeProp, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null">
                   <Column Name="CPF" DataType="System.String"/>
                   <Column Name="CNPJ" DataType="System.String"/>
                   <Column Name="RNTRC" DataType="System.String"/>
                   <Column Name="XNome" DataType="System.String"/>
                   <Column Name="IE" DataType="System.String"/>
-                  <Column Name="UF" DataType="DFe.Classes.Entidades.Estado, DFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null"/>
+                  <Column Name="UF" DataType="DFe.Classes.Entidades.Estado, DFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null"/>
                   <Column Name="ProxyUF" DataType="System.String"/>
-                  <Column Name="MDFeTpProp" DataType="MDFe.Classes.Flags.MDFeTpProp, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null"/>
+                  <Column Name="MDFeTpProp" DataType="MDFe.Classes.Flags.MDFeTpProp, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null"/>
                 </Column>
-                <Column Name="TpCar" DataType="MDFe.Classes.Flags.MDFeTpCar, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null"/>
-                <Column Name="UF" DataType="DFe.Classes.Entidades.Estado, DFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null"/>
+                <Column Name="TpCar" DataType="MDFe.Classes.Flags.MDFeTpCar, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null"/>
+                <Column Name="UF" DataType="DFe.Classes.Entidades.Estado, DFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null"/>
                 <Column Name="ProxyUF" DataType="System.String"/>
               </BusinessObjectDataSource>
-              <Column Name="ValePed" DataType="MDFe.Classes.Informacoes.MDFeValePed, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null">
-                <BusinessObjectDataSource Name="BusinessObjectDataSource5" Alias="Disp" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeDisp, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null]]" PropName="Disp" Enabled="true">
-                  <Column Name="CNPJForn" DataType="System.String"/>
-                  <Column Name="CNPJPg" DataType="System.String"/>
-                  <Column Name="CPFPg" DataType="System.String"/>
-                  <Column Name="NCompra" DataType="System.String"/>
-                  <Column Name="vValePed" DataType="System.Decimal"/>
-                </BusinessObjectDataSource>
-              </Column>
+              <Column Name="ValePed" Enabled="false" DataType="MDFe.Classes.Informacoes.MDFeValePed, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null"/>
               <Column Name="CodAgPorto" DataType="System.String"/>
-              <BusinessObjectDataSource Name="BusinessObjectDataSource26" Alias="lacRodo" Enabled="false" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeLacre, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null]]" PropName="lacRodo"/>
+              <BusinessObjectDataSource Name="BusinessObjectDataSource27" Alias="lacRodo" Enabled="false" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeLacre, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null]]" PropName="lacRodo"/>
             </Column>
           </Column>
-          <Column Name="InfDoc" DataType="MDFe.Classes.Informacoes.MDFeInfDoc, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null">
-            <BusinessObjectDataSource Name="BusinessObjectDataSource9" Alias="InfMunDescarga" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeInfMunDescarga, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null]]" PropName="InfMunDescarga" Enabled="true">
+          <Column Name="InfDoc" DataType="MDFe.Classes.Informacoes.MDFeInfDoc, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null">
+            <BusinessObjectDataSource Name="BusinessObjectDataSource9" Alias="InfMunDescarga" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeInfMunDescarga, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null]]" PropName="InfMunDescarga" Enabled="true">
               <Column Name="CMunDescarga" DataType="System.String"/>
               <Column Name="XMunDescarga" DataType="System.String"/>
-              <BusinessObjectDataSource Name="InfCTe" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeInfCTe, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
+              <BusinessObjectDataSource Name="InfCTe" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeInfCTe, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
                 <Column Name="ChCTe" DataType="System.String"/>
                 <Column Name="SegCodBarra" DataType="System.String"/>
                 <Column Name="IndReentrega" DataType="System.Nullable`1[[System.Byte, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
                 <Column Name="IndReentregaSpecified" DataType="System.Boolean" BindableControl="CheckBox"/>
-                <BusinessObjectDataSource Name="InfUnidTransps" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeInfUnidTransp, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
-                  <Column Name="TpUnidTransp" DataType="MDFe.Classes.Flags.MDFeTpUnidTransp, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null"/>
+                <BusinessObjectDataSource Name="InfUnidTransps" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeInfUnidTransp, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
+                  <Column Name="TpUnidTransp" DataType="MDFe.Classes.Flags.MDFeTpUnidTransp, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null"/>
                   <Column Name="IdUnidTransp" DataType="System.String"/>
-                  <BusinessObjectDataSource Name="LacUnidTransps" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeLacUnidTransp, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
+                  <BusinessObjectDataSource Name="LacUnidTransps" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeLacUnidTransp, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
                     <Column Name="NLacre" DataType="System.String"/>
                   </BusinessObjectDataSource>
-                  <BusinessObjectDataSource Name="InfUnidCargas" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeInfUnidCarga, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
-                    <Column Name="TpUnidCarga" DataType="MDFe.Classes.Flags.MDFeTpUnidCarga, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null"/>
+                  <BusinessObjectDataSource Name="InfUnidCargas" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeInfUnidCarga, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
+                    <Column Name="TpUnidCarga" DataType="MDFe.Classes.Flags.MDFeTpUnidCarga, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null"/>
                     <Column Name="IdUnidCarga" DataType="System.String"/>
-                    <BusinessObjectDataSource Name="LacUnidCargas" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeLacUnidCarga, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
+                    <BusinessObjectDataSource Name="LacUnidCargas" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeLacUnidCarga, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
                       <Column Name="NLacre" DataType="System.String"/>
                     </BusinessObjectDataSource>
                     <Column Name="QtdRat" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
@@ -360,24 +358,24 @@ namespace FastReport
                   <Column Name="QtdRat" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
                   <Column Name="QtdRatSpecified" DataType="System.Boolean" BindableControl="CheckBox"/>
                 </BusinessObjectDataSource>
-                <BusinessObjectDataSource Name="BusinessObjectDataSource27" Alias="Peri" Enabled="false" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFePeri, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null]]" PropName="Peri"/>
-                <Column Name="infEntregaParcial" Enabled="false" DataType="MDFe.Classes.Informacoes.infEntregaParcial, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null"/>
+                <Column Name="infEntregaParcial" Enabled="false" DataType="MDFe.Classes.Informacoes.infEntregaParcial, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null"/>
+                <BusinessObjectDataSource Name="BusinessObjectDataSource28" Alias="Peri" Enabled="false" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFePeri, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null]]" PropName="Peri"/>
               </BusinessObjectDataSource>
-              <BusinessObjectDataSource Name="InfNFe" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeInfNFe, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
+              <BusinessObjectDataSource Name="InfNFe" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeInfNFe, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
                 <Column Name="ChNFe" DataType="System.String"/>
                 <Column Name="SegCodBarra" DataType="System.String"/>
                 <Column Name="IndReentrega" DataType="System.Nullable`1[[System.Byte, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
                 <Column Name="IndReentregaSpecified" DataType="System.Boolean" BindableControl="CheckBox"/>
-                <BusinessObjectDataSource Name="InfUnidTransps1" Alias="InfUnidTransps" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeInfUnidTransp, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null]]" PropName="InfUnidTransps" Enabled="true">
-                  <Column Name="TpUnidTransp" DataType="MDFe.Classes.Flags.MDFeTpUnidTransp, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null"/>
+                <BusinessObjectDataSource Name="InfUnidTransps1" Alias="InfUnidTransps" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeInfUnidTransp, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null]]" PropName="InfUnidTransps" Enabled="true">
+                  <Column Name="TpUnidTransp" DataType="MDFe.Classes.Flags.MDFeTpUnidTransp, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null"/>
                   <Column Name="IdUnidTransp" DataType="System.String"/>
-                  <BusinessObjectDataSource Name="LacUnidTransps1" Alias="LacUnidTransps" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeLacUnidTransp, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null]]" PropName="LacUnidTransps" Enabled="true">
+                  <BusinessObjectDataSource Name="LacUnidTransps1" Alias="LacUnidTransps" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeLacUnidTransp, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null]]" PropName="LacUnidTransps" Enabled="true">
                     <Column Name="NLacre" DataType="System.String"/>
                   </BusinessObjectDataSource>
-                  <BusinessObjectDataSource Name="InfUnidCargas1" Alias="InfUnidCargas" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeInfUnidCarga, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null]]" PropName="InfUnidCargas" Enabled="true">
-                    <Column Name="TpUnidCarga" DataType="MDFe.Classes.Flags.MDFeTpUnidCarga, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null"/>
+                  <BusinessObjectDataSource Name="InfUnidCargas1" Alias="InfUnidCargas" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeInfUnidCarga, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null]]" PropName="InfUnidCargas" Enabled="true">
+                    <Column Name="TpUnidCarga" DataType="MDFe.Classes.Flags.MDFeTpUnidCarga, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null"/>
                     <Column Name="IdUnidCarga" DataType="System.String"/>
-                    <BusinessObjectDataSource Name="LacUnidCargas1" Alias="LacUnidCargas" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeLacUnidCarga, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null]]" PropName="LacUnidCargas" Enabled="true">
+                    <BusinessObjectDataSource Name="LacUnidCargas1" Alias="LacUnidCargas" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeLacUnidCarga, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null]]" PropName="LacUnidCargas" Enabled="true">
                       <Column Name="NLacre" DataType="System.String"/>
                     </BusinessObjectDataSource>
                     <Column Name="QtdRat" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
@@ -386,22 +384,22 @@ namespace FastReport
                   <Column Name="QtdRat" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
                   <Column Name="QtdRatSpecified" DataType="System.Boolean" BindableControl="CheckBox"/>
                 </BusinessObjectDataSource>
-                <BusinessObjectDataSource Name="BusinessObjectDataSource28" Alias="Peri" Enabled="false" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFePeri, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null]]" PropName="Peri"/>
+                <BusinessObjectDataSource Name="BusinessObjectDataSource29" Alias="Peri" Enabled="false" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFePeri, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null]]" PropName="Peri"/>
               </BusinessObjectDataSource>
-              <BusinessObjectDataSource Name="InfMdFeTransps" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeInfMDFeTransp, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
+              <BusinessObjectDataSource Name="InfMdFeTransps" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeInfMDFeTransp, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
                 <Column Name="ChMDFe" DataType="System.String"/>
                 <Column Name="IndReentrega" DataType="System.Nullable`1[[System.Byte, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
                 <Column Name="IndReentregaSpecified" DataType="System.Boolean" BindableControl="CheckBox"/>
-                <BusinessObjectDataSource Name="InfUnidTransp" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeInfUnidTransp, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
-                  <Column Name="TpUnidTransp" DataType="MDFe.Classes.Flags.MDFeTpUnidTransp, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null"/>
+                <BusinessObjectDataSource Name="InfUnidTransp" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeInfUnidTransp, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
+                  <Column Name="TpUnidTransp" DataType="MDFe.Classes.Flags.MDFeTpUnidTransp, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null"/>
                   <Column Name="IdUnidTransp" DataType="System.String"/>
-                  <BusinessObjectDataSource Name="LacUnidTransps2" Alias="LacUnidTransps" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeLacUnidTransp, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null]]" PropName="LacUnidTransps" Enabled="true">
+                  <BusinessObjectDataSource Name="LacUnidTransps2" Alias="LacUnidTransps" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeLacUnidTransp, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null]]" PropName="LacUnidTransps" Enabled="true">
                     <Column Name="NLacre" DataType="System.String"/>
                   </BusinessObjectDataSource>
-                  <BusinessObjectDataSource Name="InfUnidCargas2" Alias="InfUnidCargas" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeInfUnidCarga, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null]]" PropName="InfUnidCargas" Enabled="true">
-                    <Column Name="TpUnidCarga" DataType="MDFe.Classes.Flags.MDFeTpUnidCarga, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null"/>
+                  <BusinessObjectDataSource Name="InfUnidCargas2" Alias="InfUnidCargas" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeInfUnidCarga, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null]]" PropName="InfUnidCargas" Enabled="true">
+                    <Column Name="TpUnidCarga" DataType="MDFe.Classes.Flags.MDFeTpUnidCarga, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null"/>
                     <Column Name="IdUnidCarga" DataType="System.String"/>
-                    <BusinessObjectDataSource Name="LacUnidCargas2" Alias="LacUnidCargas" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeLacUnidCarga, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null]]" PropName="LacUnidCargas" Enabled="true">
+                    <BusinessObjectDataSource Name="LacUnidCargas2" Alias="LacUnidCargas" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeLacUnidCarga, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null]]" PropName="LacUnidCargas" Enabled="true">
                       <Column Name="NLacre" DataType="System.String"/>
                     </BusinessObjectDataSource>
                     <Column Name="QtdRat" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
@@ -410,17 +408,17 @@ namespace FastReport
                   <Column Name="QtdRat" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
                   <Column Name="QtdRatSpecified" DataType="System.Boolean" BindableControl="CheckBox"/>
                 </BusinessObjectDataSource>
-                <BusinessObjectDataSource Name="BusinessObjectDataSource29" Alias="Peri" Enabled="false" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFePeri, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null]]" PropName="Peri"/>
+                <BusinessObjectDataSource Name="BusinessObjectDataSource30" Alias="Peri" Enabled="false" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFePeri, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null]]" PropName="Peri"/>
               </BusinessObjectDataSource>
             </BusinessObjectDataSource>
           </Column>
-          <BusinessObjectDataSource Name="BusinessObjectDataSource16" Alias="Seg" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeSeg, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null]]" PropName="Seg" Enabled="true">
-            <Column Name="InfResp" DataType="MDFe.Classes.Informacoes.MDFeInfResp, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null">
-              <Column Name="RespSeg" DataType="MDFe.Classes.Flags.MDFeRespSeg, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null"/>
+          <BusinessObjectDataSource Name="BusinessObjectDataSource16" Alias="Seg" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeSeg, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null]]" PropName="Seg" Enabled="true">
+            <Column Name="InfResp" DataType="MDFe.Classes.Informacoes.MDFeInfResp, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null">
+              <Column Name="RespSeg" DataType="MDFe.Classes.Flags.MDFeRespSeg, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null"/>
               <Column Name="CNPJ" DataType="System.String"/>
               <Column Name="CPF" DataType="System.String"/>
             </Column>
-            <Column Name="InfSeg" DataType="MDFe.Classes.Informacoes.MDFeInfSeg, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null">
+            <Column Name="InfSeg" DataType="MDFe.Classes.Informacoes.MDFeInfSeg, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null">
               <Column Name="XSeg" DataType="System.String"/>
               <Column Name="CNPJ" DataType="System.String"/>
             </Column>
@@ -429,60 +427,60 @@ namespace FastReport
               <Column Name="Length" DataType="System.Int32"/>
             </BusinessObjectDataSource>
           </BusinessObjectDataSource>
-          <Column Name="Tot" DataType="MDFe.Classes.Informacoes.MDFeTot, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null">
+          <Column Name="Tot" DataType="MDFe.Classes.Informacoes.MDFeTot, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null">
             <Column Name="QCTe" DataType="System.Nullable`1[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
             <Column Name="QNFe" DataType="System.Nullable`1[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
             <Column Name="QMDFe" DataType="System.Nullable`1[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
             <Column Name="vCarga" DataType="System.Decimal"/>
-            <Column Name="CUnid" DataType="MDFe.Classes.Flags.MDFeCUnid, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null"/>
+            <Column Name="CUnid" DataType="MDFe.Classes.Flags.MDFeCUnid, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null"/>
             <Column Name="QCarga" DataType="System.Decimal"/>
             <Column Name="QCTeSpecified" DataType="System.Boolean" BindableControl="CheckBox"/>
             <Column Name="QNFeSpecified" DataType="System.Boolean" BindableControl="CheckBox"/>
             <Column Name="QMDFeSpecified" DataType="System.Boolean" BindableControl="CheckBox"/>
           </Column>
-          <BusinessObjectDataSource Name="BusinessObjectDataSource7" Alias="Lacres" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeLacre, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null]]" PropName="Lacres" Enabled="true">
+          <BusinessObjectDataSource Name="BusinessObjectDataSource7" Alias="Lacres" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeLacre, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null]]" PropName="Lacres" Enabled="true">
             <Column Name="NLacre" DataType="System.String"/>
           </BusinessObjectDataSource>
-          <BusinessObjectDataSource Name="BusinessObjectDataSource8" Alias="AutXml" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeAutXML, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null]]" PropName="AutXml" Enabled="true">
+          <BusinessObjectDataSource Name="BusinessObjectDataSource8" Alias="AutXml" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeAutXML, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null]]" PropName="AutXml" Enabled="true">
             <Column Name="CNPJ" DataType="System.String"/>
             <Column Name="CPF" DataType="System.String"/>
           </BusinessObjectDataSource>
-          <Column Name="InfAdic" DataType="MDFe.Classes.Informacoes.MDFeInfAdic, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null">
+          <Column Name="InfAdic" DataType="MDFe.Classes.Informacoes.MDFeInfAdic, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null">
             <Column Name="InfAdFisco" DataType="System.String"/>
             <Column Name="InfCpl" DataType="System.String"/>
           </Column>
-          <Column Name="infRespTec" Enabled="false" DataType="MDFe.Classes.Informacoes.infRespTec, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null"/>
+          <Column Name="infRespTec" Enabled="false" DataType="MDFe.Classes.Informacoes.infRespTec, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null"/>
         </Column>
-        <Column Name="Signature" DataType="DFe.Classes.Assinatura.Signature, DFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null">
-          <Column Name="SignedInfo" DataType="DFe.Classes.Assinatura.SignedInfo, DFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null">
-            <Column Name="CanonicalizationMethod" DataType="DFe.Classes.Assinatura.CanonicalizationMethod, DFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null">
+        <Column Name="Signature" DataType="DFe.Classes.Assinatura.Signature, DFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null">
+          <Column Name="SignedInfo" DataType="DFe.Classes.Assinatura.SignedInfo, DFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null">
+            <Column Name="CanonicalizationMethod" DataType="DFe.Classes.Assinatura.CanonicalizationMethod, DFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null">
               <Column Name="Algorithm" DataType="System.String"/>
             </Column>
-            <Column Name="SignatureMethod" DataType="DFe.Classes.Assinatura.SignatureMethod, DFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null">
+            <Column Name="SignatureMethod" DataType="DFe.Classes.Assinatura.SignatureMethod, DFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null">
               <Column Name="Algorithm" DataType="System.String"/>
             </Column>
-            <Column Name="Reference" DataType="DFe.Classes.Assinatura.Reference, DFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null">
+            <Column Name="Reference" DataType="DFe.Classes.Assinatura.Reference, DFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null">
               <Column Name="URI" DataType="System.String"/>
-              <Column Name="DigestMethod" DataType="DFe.Classes.Assinatura.DigestMethod, DFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null">
+              <Column Name="DigestMethod" DataType="DFe.Classes.Assinatura.DigestMethod, DFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null">
                 <Column Name="Algorithm" DataType="System.String"/>
               </Column>
               <Column Name="DigestValue" DataType="System.String"/>
-              <BusinessObjectDataSource Name="BusinessObjectDataSource30" Alias="Transforms" Enabled="false" DataType="System.Collections.Generic.List`1[[DFe.Classes.Assinatura.Transform, DFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null]]" PropName="Transforms"/>
+              <BusinessObjectDataSource Name="BusinessObjectDataSource31" Alias="Transforms" Enabled="false" DataType="System.Collections.Generic.List`1[[DFe.Classes.Assinatura.Transform, DFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null]]" PropName="Transforms"/>
             </Column>
           </Column>
           <Column Name="SignatureValue" DataType="System.String"/>
-          <Column Name="KeyInfo" DataType="DFe.Classes.Assinatura.KeyInfo, DFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null">
-            <Column Name="X509Data" DataType="DFe.Classes.Assinatura.X509Data, DFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null">
+          <Column Name="KeyInfo" DataType="DFe.Classes.Assinatura.KeyInfo, DFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null">
+            <Column Name="X509Data" DataType="DFe.Classes.Assinatura.X509Data, DFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null">
               <Column Name="X509Certificate" DataType="System.String"/>
             </Column>
           </Column>
         </Column>
       </Column>
-      <Column Name="ProtMDFe" DataType="MDFe.Classes.Retorno.MDFeRetRecepcao.MDFeProtMDFe, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null">
+      <Column Name="ProtMDFe" DataType="MDFe.Classes.Retorno.MDFeRetRecepcao.MDFeProtMDFe, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null">
         <Column Name="Versao" DataType="System.String"/>
-        <Column Name="InfProt" DataType="MDFe.Classes.Retorno.MDFeRetRecepcao.MDFeInfProtMDFe, MDFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null">
+        <Column Name="InfProt" DataType="MDFe.Classes.Retorno.MDFeRetRecepcao.MDFeInfProtMDFe, MDFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null">
           <Column Name="Id" DataType="System.String"/>
-          <Column Name="TpAmb" DataType="DFe.Classes.Flags.TipoAmbiente, DFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null"/>
+          <Column Name="TpAmb" DataType="DFe.Classes.Flags.TipoAmbiente, DFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null"/>
           <Column Name="VerAplic" DataType="System.String"/>
           <Column Name="ChMDFe" DataType="System.String"/>
           <Column Name="DhRecbto" DataType="System.DateTime"/>
@@ -490,26 +488,26 @@ namespace FastReport
           <Column Name="DigVal" DataType="System.String"/>
           <Column Name="CStat" DataType="System.Int16"/>
           <Column Name="XMotivo" DataType="System.String"/>
-          <Column Name="Signature" DataType="DFe.Classes.Assinatura.Signature, DFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null">
-            <Column Name="SignedInfo" DataType="DFe.Classes.Assinatura.SignedInfo, DFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null">
-              <Column Name="CanonicalizationMethod" DataType="DFe.Classes.Assinatura.CanonicalizationMethod, DFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null">
+          <Column Name="Signature" DataType="DFe.Classes.Assinatura.Signature, DFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null">
+            <Column Name="SignedInfo" DataType="DFe.Classes.Assinatura.SignedInfo, DFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null">
+              <Column Name="CanonicalizationMethod" DataType="DFe.Classes.Assinatura.CanonicalizationMethod, DFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null">
                 <Column Name="Algorithm" DataType="System.String"/>
               </Column>
-              <Column Name="SignatureMethod" DataType="DFe.Classes.Assinatura.SignatureMethod, DFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null">
+              <Column Name="SignatureMethod" DataType="DFe.Classes.Assinatura.SignatureMethod, DFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null">
                 <Column Name="Algorithm" DataType="System.String"/>
               </Column>
-              <Column Name="Reference" DataType="DFe.Classes.Assinatura.Reference, DFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null">
+              <Column Name="Reference" DataType="DFe.Classes.Assinatura.Reference, DFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null">
                 <Column Name="URI" DataType="System.String"/>
-                <Column Name="DigestMethod" DataType="DFe.Classes.Assinatura.DigestMethod, DFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null">
+                <Column Name="DigestMethod" DataType="DFe.Classes.Assinatura.DigestMethod, DFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null">
                   <Column Name="Algorithm" DataType="System.String"/>
                 </Column>
                 <Column Name="DigestValue" DataType="System.String"/>
-                <BusinessObjectDataSource Name="BusinessObjectDataSource31" Alias="Transforms" Enabled="false" DataType="System.Collections.Generic.List`1[[DFe.Classes.Assinatura.Transform, DFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null]]" PropName="Transforms"/>
+                <BusinessObjectDataSource Name="BusinessObjectDataSource32" Alias="Transforms" Enabled="false" DataType="System.Collections.Generic.List`1[[DFe.Classes.Assinatura.Transform, DFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null]]" PropName="Transforms"/>
               </Column>
             </Column>
             <Column Name="SignatureValue" DataType="System.String"/>
-            <Column Name="KeyInfo" DataType="DFe.Classes.Assinatura.KeyInfo, DFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null">
-              <Column Name="X509Data" DataType="DFe.Classes.Assinatura.X509Data, DFe.Classes, Version=1.0.0.740, Culture=neutral, PublicKeyToken=null">
+            <Column Name="KeyInfo" DataType="DFe.Classes.Assinatura.KeyInfo, DFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null">
+              <Column Name="X509Data" DataType="DFe.Classes.Assinatura.X509Data, DFe.Classes, Version=1.0.0.742, Culture=neutral, PublicKeyToken=null">
                 <Column Name="X509Certificate" DataType="System.String"/>
               </Column>
             </Column>
@@ -523,7 +521,7 @@ namespace FastReport
     <Parameter Name="QuebrarLinhasObservacao" DataType="System.Boolean"/>
   </Dictionary>
   <ReportPage Name="Page1" RawPaperSize="9" LeftMargin="6" TopMargin="8" RightMargin="6" BottomMargin="8" FirstPageSource="261" OtherPagesSource="261">
-    <PageHeaderBand Name="PageHeader1" Top="20" Width="748.44" Height="411.9" BeforePrintEvent="PageHeader1_BeforePrint">
+    <PageHeaderBand Name="PageHeader1" Width="748.44" Height="411.9" BeforePrintEvent="PageHeader1_BeforePrint">
       <ShapeObject Name="Shape1" Width="746.55" Height="200.34"/>
       <LineObject Name="Line1" Left="368.55" Top="1.45" Height="197.45"/>
       <LineObject Name="Line3" Left="368.55" Top="41.58" Width="376"/>
@@ -602,9 +600,9 @@ namespace FastReport
       <LineObject Name="Line34" Left="405.35" Top="288.95" Height="118.85" Border.Width="2"/>
       <TextObject Name="Text67" Left="314.85" Top="305.4" Width="88.05" Height="11.9" Text="CNPJs" Font="Times New Roman, 8.25pt"/>
       <TextObject Name="txtContratantes" Left="313.85" Top="320.3" Width="89.7" Height="87.15" Font="Times New Roman, 6.75pt"/>
-      <ChildBand Name="Child1" Top="451.9" Width="748.44" Height="27.35" Visible="false">
+      <ChildBand Name="Child1" Top="415.9" Width="748.44" Height="27.35" Visible="false">
         <TextObject Name="Text60" Left="242.25" Top="6" Width="235.25" Height="16.25" Fill.Color="Gray" Text="DOCUMENTO CANCELADO" HorzAlign="Center" Font="Times New Roman, 11.25pt, style=Bold" TextFill.Color="White"/>
-        <ChildBand Name="Child2" Top="499.25" Width="748.44" Height="92.4">
+        <ChildBand Name="Child2" Top="447.25" Width="748.44" Height="92.4">
           <ShapeObject Name="Shape3" Top="3.45" Width="746.55" Height="49.25"/>
           <TextObject Name="Text42" Left="0.45" Top="64.6" Width="745.2" Height="19.35" Text="RELAÇÃO DOS DOCUMENTOS FISCAIS ELETRÔNICOS" HorzAlign="Center" Font="Times New Roman, 14.25pt, style=Bold, Underline"/>
           <TextObject Name="Text38" Left="2" Top="34.8" Width="195.1" Height="11.9" Text="[MDFeProcMDFe.MDFe.InfMDFe.Tot.QCTe]" HorzAlign="Center" Font="Times New Roman, 8.25pt, style=Bold"/>
@@ -623,13 +621,13 @@ namespace FastReport
         </ChildBand>
       </ChildBand>
     </PageHeaderBand>
-    <DataBand Name="Data1" Top="611.65" Width="748.44" Height="32.35" DataSource="BusinessObjectDataSource9">
+    <DataBand Name="Data1" Top="543.65" Width="748.44" Height="32.35" DataSource="BusinessObjectDataSource9">
       <TextObject Name="Text43" Left="28.35" Top="1" Width="678.95" Height="17.9" Border.Lines="All" Text="Município: [MDFeProcMDFe.MDFe.InfMDFe.InfDoc.InfMunDescarga.XMunDescarga] - [MDFeProcMDFe.MDFe.InfMDFe.InfDoc.InfMunDescarga.CMunDescarga]" HorzAlign="Center" VertAlign="Center" Font="Times New Roman, 9.75pt, style=Bold"/>
       <SubreportObject Name="Subreport1" Top="20.35" Width="742.1" Height="10.45" ReportPage="Page2"/>
       <SubreportObject Name="Subreport2" Top="20.35" Width="742.01" Height="10.58" ReportPage="Page3"/>
       <SubreportObject Name="Subreport3" Top="20.35" Width="742.01" Height="10.45" ReportPage="Page4"/>
     </DataBand>
-    <PageFooterBand Name="PageFooter1" Top="664" Width="748.44" Height="97.5">
+    <PageFooterBand Name="PageFooter1" Top="580" Width="748.44" Height="97.5">
       <TextObject Name="Text61" Left="4.45" Top="4.45" Width="738.55" Height="88.5" BeforePrintEvent="txtChaveMDFe_BeforePrint" Text="MDF-e EMITIDO EM  AMIENTE DE HOMOLOGAÇÃO&#13;&#10;SEM VALOR FISCAL" HorzAlign="Center" VertAlign="Center" Font="Arial Black, 12pt, style=Bold" TextFill.Color="DarkGray"/>
       <ShapeObject Name="Shape4" Top="1" Width="746.55" Height="96.5"/>
       <TextObject Name="Text56" Left="3" Top="4.45" Width="63.5" Height="14.45" Text="Observação" Font="Times New Roman, 8.25pt"/>


### PR DESCRIPTION
Não exibia os vales pedágios no DAMDFE, alterado para pegar as informações da TAG ANTT.

![image](https://user-images.githubusercontent.com/6295777/57326446-e34e7380-70e2-11e9-8b80-167e539d670b.png)
