### PR TITLE
Issue-987 - Correção para usar Path.Combine

### DIFF
--- a/MDFe.Classes/Extensoes/ExtMDFe.cs
+++ b/MDFe.Classes/Extensoes/ExtMDFe.cs
@@ -32,6 +32,7 @@
 /********************************************************************************/
 
 using System;
+using System.IO;
 using DFe.Classes.Entidades;
 using DFe.Utils;
 using DFe.Utils.Assinatura;
@@ -160,7 +161,7 @@ namespace MDFe.Classes.Extencoes
             if (MDFeConfiguracao.NaoSalvarXml()) return;
 
             if (string.IsNullOrEmpty(nomeArquivo))
-                nomeArquivo = MDFeConfiguracao.CaminhoSalvarXml + @"\" + mdfe.Chave() + "-mdfe.xml";
+                nomeArquivo = Path.Combine(MDFeConfiguracao.CaminhoSalvarXml, mdfe.Chave() + "-mdfe.xml");
 
             FuncoesXml.ClasseParaArquivoXml(mdfe, nomeArquivo);
         }

--- a/MDFe.Classes/Extensoes/ExtMDFeConsReciMDFe.cs
+++ b/MDFe.Classes/Extensoes/ExtMDFeConsReciMDFe.cs
@@ -31,6 +31,7 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 
+using System.IO;
 using System.Xml;
 using DFe.Utils;
 using MDFe.Classes.Informacoes.RetRecepcao;
@@ -76,7 +77,7 @@ namespace MDFe.Classes.Extencoes
 
             var caminhoXml = MDFeConfiguracao.CaminhoSalvarXml;
 
-            var arquivoSalvar = caminhoXml + @"\" + consReciMDFe.NRec + "-ped-rec.xml";
+            var arquivoSalvar = Path.Combine(caminhoXml, consReciMDFe.NRec + "-ped-rec.xml");
 
             FuncoesXml.ClasseParaArquivoXml(consReciMDFe, arquivoSalvar);
         }

--- a/MDFe.Classes/Extensoes/ExtMDFeConsSitMDFe.cs
+++ b/MDFe.Classes/Extensoes/ExtMDFeConsSitMDFe.cs
@@ -31,6 +31,7 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 
+using System.IO;
 using System.Xml;
 using DFe.Utils;
 using MDFe.Classes.Informacoes.ConsultaProtocolo;
@@ -76,7 +77,7 @@ namespace MDFe.Classes.Extencoes
 
             var caminhoXml = MDFeConfiguracao.CaminhoSalvarXml;
 
-            var arquivoSalvar = caminhoXml + @"\" + consSitMdfe.ChMDFe + "-ped-sit.xml";
+            var arquivoSalvar = Path.Combine(caminhoXml, consSitMdfe.ChMDFe + "-ped-sit.xml");
 
             FuncoesXml.ClasseParaArquivoXml(consSitMdfe, arquivoSalvar);
         }

--- a/MDFe.Classes/Extensoes/ExtMDFeConsStatServMDFe.cs
+++ b/MDFe.Classes/Extensoes/ExtMDFeConsStatServMDFe.cs
@@ -31,6 +31,7 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 
+using System.IO;
 using System.Xml;
 using DFe.Utils;
 using MDFe.Classes.Informacoes.StatusServico;
@@ -76,7 +77,7 @@ namespace MDFe.Classes.Extencoes
 
             var caminhoXml = MDFeConfiguracao.CaminhoSalvarXml;
 
-            var arquivoSalvar = caminhoXml + @"\-pedido-status-servico.xml";
+            var arquivoSalvar = Path.Combine(caminhoXml, "-pedido-status-servico.xml");
 
             FuncoesXml.ClasseParaArquivoXml(consStatServMdFe, arquivoSalvar);
         }

--- a/MDFe.Classes/Extensoes/ExtMDFeCosMDFeNaoEnc.cs
+++ b/MDFe.Classes/Extensoes/ExtMDFeCosMDFeNaoEnc.cs
@@ -31,6 +31,7 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 
+using System.IO;
 using System.Xml;
 using DFe.Utils;
 using MDFe.Classes.Informacoes.ConsultaNaoEncerrados;
@@ -76,7 +77,7 @@ namespace MDFe.Classes.Extencoes
 
             var caminhoXml = MDFeConfiguracao.CaminhoSalvarXml;
 
-            var arquivoSalvar = caminhoXml + @"\" + cosMdFeNaoEnc.CNPJ + "-ped-sit.xml";
+            var arquivoSalvar = Path.Combine(caminhoXml, cosMdFeNaoEnc.CNPJ + "-ped-sit.xml");
 
             FuncoesXml.ClasseParaArquivoXml(cosMdFeNaoEnc, arquivoSalvar);
         }

--- a/MDFe.Classes/Extensoes/ExtMDFeEnviMDFe.cs
+++ b/MDFe.Classes/Extensoes/ExtMDFeEnviMDFe.cs
@@ -32,6 +32,7 @@
 /********************************************************************************/
 
 using System;
+using System.IO;
 using System.Xml;
 using DFe.Utils;
 using MDFe.Classes.Servicos.Autorizacao;
@@ -83,7 +84,7 @@ namespace MDFe.Classes.Extencoes
 
             var caminhoXml = MDFeConfiguracao.CaminhoSalvarXml;
 
-            var arquivoSalvar = caminhoXml + @"\" + enviMDFe.MDFe.Chave() + "-completo-mdfe.xml";
+            var arquivoSalvar = Path.Combine(caminhoXml, enviMDFe.MDFe.Chave() + "-completo-mdfe.xml");
 
             FuncoesXml.ClasseParaArquivoXml(enviMDFe, arquivoSalvar);
 

--- a/MDFe.Classes/Extensoes/ExtMDFeEventoMDFe.cs
+++ b/MDFe.Classes/Extensoes/ExtMDFeEventoMDFe.cs
@@ -31,6 +31,7 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 
+using System.IO;
 using System.Xml;
 using DFe.Utils;
 using DFe.Utils.Assinatura;
@@ -108,7 +109,7 @@ namespace MDFe.Classes.Extencoes
 
             var caminhoXml = MDFeConfiguracao.CaminhoSalvarXml;
 
-            var arquivoSalvar = caminhoXml + @"\" + chave + "-ped-eve.xml";
+            var arquivoSalvar = Path.Combine(caminhoXml, chave + "-ped-eve.xml");
 
             FuncoesXml.ClasseParaArquivoXml(evento, arquivoSalvar);
         }

--- a/MDFe.Classes/Extensoes/ExtMDFeRetConsMDFeNao.cs
+++ b/MDFe.Classes/Extensoes/ExtMDFeRetConsMDFeNao.cs
@@ -31,6 +31,7 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 
+using System.IO;
 using DFe.Utils;
 using MDFe.Classes.Retorno.MDFeConsultaNaoEncerrado;
 using MDFe.Utils.Configuracoes;
@@ -45,7 +46,7 @@ namespace MDFe.Classes.Extencoes
 
             var caminhoXml = MDFeConfiguracao.CaminhoSalvarXml;
 
-            var arquivoSalvar = caminhoXml + @"\" + cnpj + "-sit.xml";
+            var arquivoSalvar = Path.Combine(caminhoXml, cnpj + "-sit.xml");
 
             FuncoesXml.ClasseParaArquivoXml(retConsMdFeNao, arquivoSalvar);
         }

--- a/MDFe.Classes/Extensoes/ExtMDFeRetConsReciMDFe.cs
+++ b/MDFe.Classes/Extensoes/ExtMDFeRetConsReciMDFe.cs
@@ -31,6 +31,7 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 
+using System.IO;
 using DFe.Utils;
 using MDFe.Classes.Retorno.MDFeRetRecepcao;
 using MDFe.Utils.Configuracoes;
@@ -45,7 +46,7 @@ namespace MDFe.Classes.Extencoes
 
             var caminhoXml = MDFeConfiguracao.CaminhoSalvarXml;
 
-            var arquivoSalvar = caminhoXml + @"\" + consReciMdFe.NRec + "-pro-rec.xml";
+            var arquivoSalvar = Path.Combine(caminhoXml, consReciMdFe.NRec + "-pro-rec.xml");
 
             FuncoesXml.ClasseParaArquivoXml(consReciMdFe, arquivoSalvar);
         }

--- a/MDFe.Classes/Extensoes/ExtMDFeRetConsSitMDFe.cs
+++ b/MDFe.Classes/Extensoes/ExtMDFeRetConsSitMDFe.cs
@@ -31,6 +31,7 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 
+using System.IO;
 using DFe.Utils;
 using MDFe.Classes.Retorno.MDFeConsultaProtocolo;
 using MDFe.Utils.Configuracoes;
@@ -45,7 +46,7 @@ namespace MDFe.Classes.Extencoes
 
             var caminhoXml = MDFeConfiguracao.CaminhoSalvarXml;
 
-            var arquivoSalvar = caminhoXml + @"\" + chave + "-sit.xml";
+            var arquivoSalvar = Path.Combine(caminhoXml,  chave + "-sit.xml");
 
             FuncoesXml.ClasseParaArquivoXml(retConsSitMdFe, arquivoSalvar);
         }

--- a/MDFe.Classes/Extensoes/ExtMDFeRetConsStatServ.cs
+++ b/MDFe.Classes/Extensoes/ExtMDFeRetConsStatServ.cs
@@ -31,6 +31,7 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 
+using System.IO;
 using DFe.Utils;
 using MDFe.Classes.Retorno.MDFeStatusServico;
 using MDFe.Utils.Configuracoes;
@@ -45,7 +46,7 @@ namespace MDFe.Classes.Extencoes
 
             var caminhoXml = MDFeConfiguracao.CaminhoSalvarXml;
 
-            var arquivoSalvar = caminhoXml + @"\-retorno-status-servico.xml";
+            var arquivoSalvar = Path.Combine(caminhoXml, "-retorno-status-servico.xml");
 
             FuncoesXml.ClasseParaArquivoXml(retConsStatServ, arquivoSalvar);
         }

--- a/MDFe.Classes/Extensoes/ExtMDFeRetEnviMDFe.cs
+++ b/MDFe.Classes/Extensoes/ExtMDFeRetEnviMDFe.cs
@@ -31,6 +31,7 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 
+using System.IO;
 using DFe.Utils;
 using MDFe.Classes.Retorno.MDFeRecepcao;
 using MDFe.Utils.Configuracoes;
@@ -45,7 +46,7 @@ namespace MDFe.Classes.Extencoes
 
             var caminhoXml = MDFeConfiguracao.CaminhoSalvarXml;
 
-            var arquivoSalvar = caminhoXml + @"\" + retEnviMDFe.InfRec.NRec + "-rec.xml";
+            var arquivoSalvar = Path.Combine(caminhoXml, retEnviMDFe.InfRec.NRec + "-rec.xml");
 
             FuncoesXml.ClasseParaArquivoXml(retEnviMDFe, arquivoSalvar);
         }

--- a/MDFe.Classes/Extensoes/ExtMDFeRetEventoMDFe.cs
+++ b/MDFe.Classes/Extensoes/ExtMDFeRetEventoMDFe.cs
@@ -31,6 +31,7 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 
+using System.IO;
 using DFe.Utils;
 using MDFe.Classes.Retorno.MDFeEvento;
 using MDFe.Utils.Configuracoes;
@@ -45,7 +46,7 @@ namespace MDFe.Classes.Extencoes
 
             var caminhoXml = MDFeConfiguracao.CaminhoSalvarXml;
 
-            var arquivoSalvar = caminhoXml + @"\" + chave + "-env.xml";
+            var arquivoSalvar = Path.Combine(caminhoXml, chave + "-env.xml");
 
             FuncoesXml.ClasseParaArquivoXml(retEvento, arquivoSalvar);
         }

--- a/Shared.CTe.Utils/CTe/ExCteProc.cs
+++ b/Shared.CTe.Utils/CTe/ExCteProc.cs
@@ -31,6 +31,7 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 
+using System.IO;
 using CTe.Classes;
 using DFe.Utils;
 using cteProc = CTe.Classes.cteProc;
@@ -92,7 +93,7 @@ namespace CTe.Utils.CTe
 
             var caminhoXml = instanciaServico.DiretorioSalvarXml;
 
-            var arquivoSalvar = caminhoXml + @"\" + cteProc.CTe.Chave() + "-cteproc.xml";
+            var arquivoSalvar = Path.Combine(caminhoXml, cteProc.CTe.Chave() + "-cteproc.xml");
 
             FuncoesXml.ClasseParaArquivoXml(cteProc, arquivoSalvar);
         }

--- a/Shared.CTe.Utils/CTe/ExtCTe.cs
+++ b/Shared.CTe.Utils/CTe/ExtCTe.cs
@@ -32,6 +32,7 @@
 /********************************************************************************/
 
 using System;
+using System.IO;
 using CTe.Classes;
 using CTe.Classes.Informacoes.infCTeNormal.infModals;
 using CTe.Classes.Informacoes.Tipos;
@@ -230,7 +231,7 @@ namespace CTe.Utils.CTe
 
             var caminhoXml = instanciaServico.DiretorioSalvarXml;
 
-            var arquivoSalvar = caminhoXml + @"\" + cte.Chave() + "-cte.xml";
+            var arquivoSalvar = Path.Combine(caminhoXml, cte.Chave() + "-cte.xml");
 
             FuncoesXml.ClasseParaArquivoXml(cte, arquivoSalvar);
         }

--- a/Shared.CTe.Utils/CTe/ExtEnvCte.cs
+++ b/Shared.CTe.Utils/CTe/ExtEnvCte.cs
@@ -32,6 +32,7 @@
 /********************************************************************************/
 
 using System;
+using System.IO;
 using System.Xml;
 using CTe.Classes;
 using CTe.Classes.Servicos.Recepcao;
@@ -81,7 +82,7 @@ namespace CTe.Utils.CTe
 
             var caminhoXml = instanciaServico.DiretorioSalvarXml;
 
-            var arquivoSalvar = caminhoXml + @"\" + enviCte.idLote + "-env-lot.xml";
+            var arquivoSalvar = Path.Combine(caminhoXml, enviCte.idLote + "-env-lot.xml");
 
             FuncoesXml.ClasseParaArquivoXml(enviCte, arquivoSalvar);
         }

--- a/Shared.CTe.Utils/Evento/Extevento.cs
+++ b/Shared.CTe.Utils/Evento/Extevento.cs
@@ -32,6 +32,7 @@
 /********************************************************************************/
 
 using System;
+using System.IO;
 using System.Xml;
 using CTe.Classes;
 using CTe.Classes.Servicos.Evento;
@@ -166,7 +167,7 @@ namespace CTe.Utils.Evento
 
             var caminhoXml = instanciaServico.DiretorioSalvarXml;
 
-            var arquivoSalvar = caminhoXml + @"\" + eventoCTe.infEvento.chCTe + "-ped-eve.xml";
+            var arquivoSalvar = Path.Combine(caminhoXml, eventoCTe.infEvento.chCTe + "-ped-eve.xml");
 
             FuncoesXml.ClasseParaArquivoXml(eventoCTe, arquivoSalvar);
         }

--- a/Shared.CTe.Utils/Evento/ExtretEnvEvento.cs
+++ b/Shared.CTe.Utils/Evento/ExtretEnvEvento.cs
@@ -31,6 +31,7 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 
+using System.IO;
 using CTe.Classes;
 using CTe.Classes.Servicos.Evento;
 using DFe.Utils;
@@ -68,7 +69,7 @@ namespace CTe.Utils.Evento
 
             var caminhoXml = instanciaServico.DiretorioSalvarXml;
 
-            var arquivoSalvar = caminhoXml + @"\" + retEnviCte.infEvento.chCTe + "-eve.xml";
+            var arquivoSalvar = Path.Combine(caminhoXml, retEnviCte.infEvento.chCTe + "-eve.xml");
 
             FuncoesXml.ClasseParaArquivoXml(retEnviCte, arquivoSalvar);
         }

--- a/Shared.CTe.Utils/Extencoes/ExtConsReciCTe.cs
+++ b/Shared.CTe.Utils/Extencoes/ExtConsReciCTe.cs
@@ -31,6 +31,7 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 using System;
+using System.IO;
 using System.Xml;
 using CTe.Classes;
 using CTe.Classes.Servicos.Recepcao.Retorno;
@@ -79,7 +80,7 @@ namespace CTe.Utils.Extencoes
 
             var caminhoXml = instanciaServico.DiretorioSalvarXml;
 
-            var arquivoSalvar = caminhoXml + @"\"+ consReciCTe.nRec + @"-ped-rec.xml";
+            var arquivoSalvar = Path.Combine(caminhoXml, consReciCTe.nRec + "-ped-rec.xml");
 
             FuncoesXml.ClasseParaArquivoXml(consReciCTe, arquivoSalvar);
         }
@@ -102,7 +103,7 @@ namespace CTe.Utils.Extencoes
 
             var caminhoXml = instanciaServico.DiretorioSalvarXml;
 
-            var arquivoSalvar = caminhoXml + @"\" + retConsReciCTe.nRec + @"-rec.xml";
+            var arquivoSalvar = Path.Combine(caminhoXml, retConsReciCTe.nRec + "-rec.xml");
 
             FuncoesXml.ClasseParaArquivoXml(retConsReciCTe, arquivoSalvar);
         }

--- a/Shared.CTe.Utils/Extencoes/ExtconsSitCTe.cs
+++ b/Shared.CTe.Utils/Extencoes/ExtconsSitCTe.cs
@@ -31,6 +31,7 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 using System;
+using System.IO;
 using System.Xml;
 using CTe.Classes;
 using CTe.Classes.Servicos.Consulta;
@@ -79,7 +80,7 @@ namespace CTe.Utils.Extencoes
 
             var caminhoXml = instanciaServico.DiretorioSalvarXml;
 
-            var arquivoSalvar = caminhoXml + @"\-ped-sit.xml";
+            var arquivoSalvar = Path.Combine(caminhoXml, "-ped-sit.xml");
 
             FuncoesXml.ClasseParaArquivoXml(statuServCte, arquivoSalvar);
         }

--- a/Shared.CTe.Utils/Extencoes/ExtconsStatServCte.cs
+++ b/Shared.CTe.Utils/Extencoes/ExtconsStatServCte.cs
@@ -31,6 +31,7 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 using System;
+using System.IO;
 using System.Xml;
 using CTe.Classes;
 using CTe.Classes.Servicos.Status;
@@ -78,8 +79,8 @@ namespace CTe.Utils.Extencoes
             if (instanciaServico.NaoSalvarXml()) return;
 
             var caminhoXml = instanciaServico.DiretorioSalvarXml;
-
-            var arquivoSalvar = caminhoXml + @"\" + DateTime.Now.ParaDataHoraString() + "-ped-sta.xml";
+            
+            var arquivoSalvar = Path.Combine(caminhoXml,  DateTime.Now.ParaDataHoraString() + "-ped-sta.xml");
 
             FuncoesXml.ClasseParaArquivoXml(statuServCte, arquivoSalvar);
         }

--- a/Shared.CTe.Utils/Extencoes/ExtinutCTe.cs
+++ b/Shared.CTe.Utils/Extencoes/ExtinutCTe.cs
@@ -31,6 +31,7 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 using System;
+using System.IO;
 using System.Xml;
 using CTe.Classes;
 using CTe.Classes.Servicos.Inutilizacao;
@@ -90,7 +91,7 @@ namespace CTe.Utils.Extencoes
 
             var caminhoXml = instanciaServico.DiretorioSalvarXml;
 
-            var arquivoSalvar = caminhoXml + @"\"+inutCTe.infInut.Id+ "-ped-inu.xml";
+            var arquivoSalvar = Path.Combine(caminhoXml, inutCTe.infInut.Id+ "-ped-inu.xml");
 
             FuncoesXml.ClasseParaArquivoXml(inutCTe, arquivoSalvar);
         }

--- a/Shared.CTe.Utils/Extencoes/ExtretConsSitCTe.cs
+++ b/Shared.CTe.Utils/Extencoes/ExtretConsSitCTe.cs
@@ -31,6 +31,7 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 
+using System.IO;
 using CTe.Classes;
 using CTe.Classes.Servicos.Consulta;
 using DFe.Utils;
@@ -68,7 +69,7 @@ namespace CTe.Utils.Extencoes
 
             var caminhoXml = configuracaoServico.DiretorioSalvarXml;
 
-            var arquivoSalvar = caminhoXml + @"\" + chave + "-sit.xml";
+            var arquivoSalvar = Path.Combine(caminhoXml, chave + "-sit.xml");
 
             FuncoesXml.ClasseParaArquivoXml(retConsSitCTe, arquivoSalvar);
         }

--- a/Shared.CTe.Utils/Extencoes/ExtretConsStatServCte.cs
+++ b/Shared.CTe.Utils/Extencoes/ExtretConsStatServCte.cs
@@ -31,6 +31,7 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 using System;
+using System.IO;
 using CTe.Classes;
 using CTe.Classes.Servicos.Status;
 using DFe.Utils;
@@ -47,7 +48,7 @@ namespace CTe.Utils.Extencoes
 
             var caminhoXml = instanciaServico.DiretorioSalvarXml;
 
-            var arquivoSalvar = caminhoXml + @"\" + DateTime.Now.ParaDataHoraString() + "-sta.xml";
+            var arquivoSalvar = Path.Combine(caminhoXml, DateTime.Now.ParaDataHoraString() + "-sta.xml");
 
             FuncoesXml.ClasseParaArquivoXml(retConsStatServCte, arquivoSalvar);
         }

--- a/Shared.CTe.Utils/Inutilizacao/ExtretInutCTe.cs
+++ b/Shared.CTe.Utils/Inutilizacao/ExtretInutCTe.cs
@@ -31,6 +31,7 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 
+using System.IO;
 using CTe.Classes;
 using CTe.Classes.Servicos.Inutilizacao;
 using DFe.Utils;
@@ -68,8 +69,8 @@ namespace CTe.Utils.Inutilizacao
             if (instanciaServico.NaoSalvarXml()) return;
 
             var caminhoXml = instanciaServico.DiretorioSalvarXml;
-
-            var arquivoSalvar = caminhoXml + @"\" + chaveNome + "-inu.xml";
+            
+            var arquivoSalvar = Path.Combine(caminhoXml, chaveNome + "-inu.xml");
 
             FuncoesXml.ClasseParaArquivoXml(retInutCTe, arquivoSalvar);
         }

--- a/Shared.CTe.Utils/Recepcao/ExtretEnviCTe.cs
+++ b/Shared.CTe.Utils/Recepcao/ExtretEnviCTe.cs
@@ -31,6 +31,7 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 
+using System.IO;
 using CTe.Classes;
 using CTe.Classes.Servicos.Recepcao;
 using DFe.Utils;
@@ -68,7 +69,7 @@ namespace CTe.Utils.Recepcao
 
             var caminhoXml = instanciaServico.DiretorioSalvarXml;
 
-            var arquivoSalvar = caminhoXml + @"\" + retEnviCte.infRec.nRec + "-rec.xml";
+            var arquivoSalvar = Path.Combine(caminhoXml, retEnviCte.infRec.nRec + "-rec.xml");
 
             FuncoesXml.ClasseParaArquivoXml(retEnviCte, arquivoSalvar);
         }


### PR DESCRIPTION
Correção para usar Path.Combine ao invés de concatenar os caminhos de arquivos.
#987 