### PR TITLE
- Criação da possibildiade de não utilizar o objeto global ConfiguracaoServico.Instancia para emissão de CTe.

### DIFF
--- a/CTe.AppTeste.NetCore/Program.cs
+++ b/CTe.AppTeste.NetCore/Program.cs
@@ -142,9 +142,11 @@ namespace CTe.AppTeste.NetCore
         {
             var configuracaoCertificado = new ConfiguracaoCertificado
             {
-                Arquivo = config.CertificadoDigital.CaminhoArquivo,
-                ManterDadosEmCache = config.CertificadoDigital.ManterEmCache,
-                Serial = config.CertificadoDigital.NumeroDeSerie
+                TipoCertificado = TipoCertificado.A1ByteArray,
+                ArrayBytesArquivo = GetArrayBytesCertificado(),
+                //ManterDadosEmCache = config.CertificadoDigital.ManterEmCache,
+                //Serial = config.CertificadoDigital.NumeroDeSerie
+                Senha = config.CertificadoDigital.Senha
             };
 
 
@@ -158,13 +160,36 @@ namespace CTe.AppTeste.NetCore
             ConfiguracaoServico.Instancia.DiretorioSalvarXml = config.DiretorioSalvarXml;
         }
 
+        private static ConfiguracaoServico MontarConfiguracoes(Configuracao config)
+        {
+            return new ConfiguracaoServico
+            {
+                ConfiguracaoCertificado =
+                {
+                    TipoCertificado = TipoCertificado.A1ByteArray,
+                    ArrayBytesArquivo = GetArrayBytesCertificado(),
+                    //Arquivo = config.CertificadoDigital.CaminhoArquivo,
+                    Senha = config.CertificadoDigital.Senha
+                },
+                TimeOut = config.ConfigWebService.TimeOut,
+                cUF = config.ConfigWebService.UfEmitente,
+                tpAmb = config.ConfigWebService.Ambiente,
+                VersaoLayout = config.ConfigWebService.Versao,
+                DiretorioSchemas = config.ConfigWebService.CaminhoSchemas,
+                IsSalvarXml = config.IsSalvarXml,
+                DiretorioSalvarXml = config.DiretorioSalvarXml
+            };
+        }
+
         private static async Task ConsultarStatusServico2()
         {
             var config = new ConfiguracaoDao().BuscarConfiguracao();
-            CarregarConfiguracoes(config);
+            //CarregarConfiguracoes(config);
+            
+            var configuracaoServico = MontarConfiguracoes(config);
 
             var statusServico = new StatusServico();
-            var retorno = await statusServico.ConsultaStatusAsync();
+            var retorno = await statusServico.ConsultaStatusAsync(configuracaoServico);
 
             OnSucessoSync(new RetornoEEnvio(retorno));
         }
@@ -215,10 +240,11 @@ namespace CTe.AppTeste.NetCore
 
 
             var config = new ConfiguracaoDao().BuscarConfiguracao();
-            CarregarConfiguracoes(config);
+            //CarregarConfiguracoes(config);
+            var configuracaoServico = MontarConfiguracoes(config);
 
             var servicoConsultaProtocolo = new ConsultaProtcoloServico();
-            var retorno = await servicoConsultaProtocolo.ConsultaProtocoloAsync(chave);
+            var retorno = await servicoConsultaProtocolo.ConsultaProtocoloAsync(chave, configuracaoServico);
 
 
             OnSucessoSync(new RetornoEEnvio(retorno));
@@ -265,7 +291,8 @@ namespace CTe.AppTeste.NetCore
         private static async Task InutilizacaoDeNumeracao()
         {
             var config = new ConfiguracaoDao().BuscarConfiguracao();
-            CarregarConfiguracoes(config);
+            //CarregarConfiguracoes(config);
+            var configuracaoServico = MontarConfiguracoes(config);
 
             var numeroInicial = int.Parse(RequisitarInput("Númeração Inicial"));
             var numeroFinal = int.Parse(RequisitarInput("Númeração Final"));
@@ -282,7 +309,7 @@ namespace CTe.AppTeste.NetCore
             );
 
             var statusServico = new InutilizacaoServico(configInutilizar);
-            var retorno = await statusServico.InutilizarAsync();
+            var retorno = await statusServico.InutilizarAsync(configuracaoServico);
 
             OnSucessoSync(new RetornoEEnvio(retorno));
         }
@@ -290,12 +317,13 @@ namespace CTe.AppTeste.NetCore
         private static async Task ConsultaPorNumeroRecibo()
         {
             var config = new ConfiguracaoDao().BuscarConfiguracao();
-            CarregarConfiguracoes(config);
+            //CarregarConfiguracoes(config);
+            var configuracaoServico = MontarConfiguracoes(config);
 
             var numeroRecibo = RequisitarInput("Número Recibo");
 
             var consultaReciboServico = new ConsultaReciboServico(numeroRecibo);
-            var retorno = await consultaReciboServico.ConsultarAsync();
+            var retorno = await consultaReciboServico.ConsultarAsync(configuracaoServico);
 
             OnSucessoSync(new RetornoEEnvio(retorno));
         }
@@ -303,8 +331,9 @@ namespace CTe.AppTeste.NetCore
         private static async Task EventoCancelarCTe()
         {
             var config = new ConfiguracaoDao().BuscarConfiguracao();
-            CarregarConfiguracoes(config);
-
+            //CarregarConfiguracoes(config);
+            var configuracaoServico = MontarConfiguracoes(config);
+            
             var caminho = BuscarArquivoXml();
 
             // aqui estou fazendo um load no lote de ct-e
@@ -318,7 +347,7 @@ namespace CTe.AppTeste.NetCore
             var justificativa = RequisitarInput("Justificativa mínimo 15 digitos vlw");
 
             var servico = new EventoCancelamento(cte, sequenciaEvento, protocolo, justificativa);
-            var retorno = await servico.CancelarAsync();
+            var retorno = await servico.CancelarAsync(configuracaoServico);
 
             OnSucessoSync(new RetornoEEnvio(retorno));
         }
@@ -326,8 +355,9 @@ namespace CTe.AppTeste.NetCore
         private static async Task EventoDesacordoCTe()
         {
             var config = new ConfiguracaoDao().BuscarConfiguracao();
-            CarregarConfiguracoes(config);
-
+            //CarregarConfiguracoes(config);
+            var configuracaoServico = MontarConfiguracoes(config);
+            
             var cnpj = RequisitarInput("CNPJ Tomador");
             var chave = RequisitarInput("Chave CTe");
             var sequenciaEvento = int.Parse(RequisitarInput("Sequencia Evento"));
@@ -335,7 +365,7 @@ namespace CTe.AppTeste.NetCore
             var obs = RequisitarInput("Observação (mínimo 15 digitos)");
 
             var servico = new EventoDesacordo(sequenciaEvento, chave, cnpj, indPres, obs);
-            var retorno = await servico.DiscordarAsync();
+            var retorno = await servico.DiscordarAsync(configuracaoServico);
 
             OnSucessoSync(new RetornoEEnvio(retorno));
         }
@@ -343,7 +373,8 @@ namespace CTe.AppTeste.NetCore
         private static async Task CartaCorrecao()
         {
             var config = new ConfiguracaoDao().BuscarConfiguracao();
-            CarregarConfiguracoes(config);
+            //CarregarConfiguracoes(config);
+            var configuracaoServico = MontarConfiguracoes(config);
 
             var caminho = BuscarArquivoXml();
 
@@ -375,7 +406,7 @@ namespace CTe.AppTeste.NetCore
             };
 
             var servico = new EventoCartaCorrecao(cte, sequenciaEvento, correcoes);
-            var retorno = await servico.AdicionarCorrecoesAsync();
+            var retorno = await servico.AdicionarCorrecoesAsync(configuracaoServico);
 
             OnSucessoSync(new RetornoEEnvio(retorno));
         }
@@ -383,7 +414,8 @@ namespace CTe.AppTeste.NetCore
         private static async Task CriarEnviarCTe2e3()
         {
             var config = new ConfiguracaoDao().BuscarConfiguracao();
-            CarregarConfiguracoes(config);
+            //CarregarConfiguracoes(config);
+            var configuracaoServico = MontarConfiguracoes(config);
 
             #region infCte
             
@@ -392,7 +424,7 @@ namespace CTe.AppTeste.NetCore
                 infCte = new infCte
                 {
                     versao = config.ConfigWebService.Versao,
-                    ide = new ide
+                    ide = new ide(configuracaoServico)
                     {
                         cUF = config.Empresa.SiglaUf,
                         cCT = GetRandom(),
@@ -610,7 +642,7 @@ namespace CTe.AppTeste.NetCore
             // servicoRecepcao.AntesDeEnviar += AntesEnviarLoteCte;
 
             var retornoEnvio =
-                await servicoRecepcao.CTeRecepcaoAsync(int.Parse(numeroLote), new List<CteEletronico> {cteEletronico});
+                await servicoRecepcao.CTeRecepcaoAsync(int.Parse(numeroLote), new List<CteEletronico> {cteEletronico}, configuracaoServico);
 
             OnSucessoSync(new RetornoEEnvio(retornoEnvio));
 
@@ -633,7 +665,8 @@ namespace CTe.AppTeste.NetCore
         private static async Task CriarEnviarCTeConsultaReciboAutomatico2e3()
         {
             var config = new ConfiguracaoDao().BuscarConfiguracao();
-            CarregarConfiguracoes(config);
+            //CarregarConfiguracoes(config);
+            var configuracaoServico = MontarConfiguracoes(config);
 
             #region infCte
             
@@ -642,7 +675,7 @@ namespace CTe.AppTeste.NetCore
                 infCte = new infCte
                 {
                     versao = config.ConfigWebService.Versao,
-                    ide = new ide
+                    ide = new ide(configuracaoServico)
                     {
                         cUF = config.Empresa.SiglaUf,
                         cCT = GetRandom(),
@@ -843,7 +876,7 @@ namespace CTe.AppTeste.NetCore
 
             var servico = new ServicoEnviarCte();
 
-            var retorno = await servico.EnviarAsync(Convert.ToInt32(numeroLote), cteEletronico);
+            var retorno = await servico.EnviarAsync(Convert.ToInt32(numeroLote), cteEletronico);//, configuracaoServico);
 
             var xmlRetorno = string.Empty;
 
@@ -862,7 +895,8 @@ namespace CTe.AppTeste.NetCore
         private static async Task DistribuicaoDFe()
         {
             var config = new ConfiguracaoDao().BuscarConfiguracao();
-            CarregarConfiguracoes(config);
+            //CarregarConfiguracoes(config);
+            var configuracaoServico = MontarConfiguracoes(config);
 
             #region CTeDistribuicaoDFe
 
@@ -887,7 +921,7 @@ namespace CTe.AppTeste.NetCore
 
             var servicoCTe = new ServicoCTeDistribuicaoDFe();
             var retornoCTeDistDFe =
-                await servicoCTe.CTeDistDFeInteresseAsync(config.Empresa.SiglaUf.ToString(), cnpj, ultNSU, nsu);
+                await servicoCTe.CTeDistDFeInteresseAsync(config.Empresa.SiglaUf.ToString(), cnpj, ultNSU, nsu, configuracaoServico);
 
             OnSucessoSync(new RetornoEEnvio(retornoCTeDistDFe.EnvioStr, retornoCTeDistDFe.RetornoStr));
 
@@ -906,6 +940,14 @@ namespace CTe.AppTeste.NetCore
                 // Handle and throw if fatal exception here; don't just ignore them
                 return xml;
             }
+        }
+
+        private static byte[] GetArrayBytesCertificado()
+        {
+            throw new  Exception("Coloque aqui a string do seu certificado, ou modifique " +
+                                 "o tipo de certificado nas configurações desta classe.");
+            return Convert.FromBase64String(
+                "String do Certificado em base64");
         }
     }
 }

--- a/Shared.CTe.Classes/ConfiguracaoServico.cs
+++ b/Shared.CTe.Classes/ConfiguracaoServico.cs
@@ -49,7 +49,7 @@ namespace CTe.Classes
         private static readonly object SyncRoot = new object();
         private string _diretorioSchemas;
 
-        private ConfiguracaoServico()
+        public ConfiguracaoServico()
         {
             ConfiguracaoCertificado = new ConfiguracaoCertificado();
             TipoEmissao = tpEmis.teNormal;

--- a/Shared.CTe.Classes/Informacoes/Identificacao/ide.cs
+++ b/Shared.CTe.Classes/Informacoes/Identificacao/ide.cs
@@ -45,8 +45,19 @@ namespace CTe.Classes.Informacoes.Identificacao
 {
     public class ide
     {
-        [XmlIgnore]
-        private readonly ConfiguracaoServico _configuracaoServico = ConfiguracaoServico.Instancia;
+
+        public ide(ConfiguracaoServico configuracaoServico = null)
+        {
+            _configuracaoServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
+        }
+        
+        public ide()
+        {
+            
+        }
+
+        [XmlIgnore] 
+        private ConfiguracaoServico _configuracaoServico;
 
         /// <summary>
         ///     B02 - Código da UF do emitente do Documento Fiscal. Utilizar a Tabela do IBGE.
@@ -95,6 +106,8 @@ namespace CTe.Classes.Informacoes.Identificacao
         {
             get
             {
+                if (_configuracaoServico == null)
+                    _configuracaoServico = ConfiguracaoServico.Instancia;
                 switch (_configuracaoServico.VersaoLayout)
                 {
                     case versao.ve200:

--- a/Shared.CTe.Classes/Servicos/Evento/infEventoEnv.cs
+++ b/Shared.CTe.Classes/Servicos/Evento/infEventoEnv.cs
@@ -43,9 +43,17 @@ namespace CTe.Classes.Servicos.Evento
 {
     public class infEventoEnv
     {
+        public infEventoEnv(ConfiguracaoServico configuracaoServico = null)
+        {
+            _configuracaoServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
+        }
+
+        public infEventoEnv()
+        {
+        }
 
         [XmlIgnore]
-        private readonly ConfiguracaoServico _configuracaoServico = ConfiguracaoServico.Instancia;
+        private ConfiguracaoServico _configuracaoServico;
 
         /// <summary>
         ///     HP07 - Grupo de informações do registro do Evento
@@ -84,6 +92,8 @@ namespace CTe.Classes.Servicos.Evento
         {
             get
             {
+                if (_configuracaoServico == null)
+                    _configuracaoServico = ConfiguracaoServico.Instancia;
                 switch (_configuracaoServico.VersaoLayout)
                 {
                     case versao.ve200:

--- a/Shared.CTe.Servicos/ConsultaProtocolo/ConsultaProtcoloServico.cs
+++ b/Shared.CTe.Servicos/ConsultaProtocolo/ConsultaProtcoloServico.cs
@@ -32,6 +32,7 @@
 /********************************************************************************/
 
 using System.Threading.Tasks;
+using CTe.Classes;
 using CTe.Classes.Servicos.Consulta;
 using CTe.Servicos.Factory;
 using CTe.Utils.Extencoes;
@@ -40,32 +41,32 @@ namespace CTe.Servicos.ConsultaProtocolo
 {
     public class ConsultaProtcoloServico
     {
-        public retConsSitCTe ConsultaProtocolo(string chave)
+        public retConsSitCTe ConsultaProtocolo(string chave, ConfiguracaoServico configuracaoServico = null)
         {
-            var consSitCTe = ClassesFactory.CriarconsSitCTe(chave);
-            consSitCTe.ValidarSchema();
-            consSitCTe.SalvarXmlEmDisco();
+            var consSitCTe = ClassesFactory.CriarconsSitCTe(chave, configuracaoServico);
+            consSitCTe.ValidarSchema(configuracaoServico);
+            consSitCTe.SalvarXmlEmDisco(configuracaoServico);
 
-            var webService = WsdlFactory.CriaWsdlConsultaProtocolo();
+            var webService = WsdlFactory.CriaWsdlConsultaProtocolo(configuracaoServico);
             var retornoXml = webService.cteConsultaCT(consSitCTe.CriaRequestWs());
 
             var retorno = retConsSitCTe.LoadXml(retornoXml.OuterXml, consSitCTe);
-            retorno.SalvarXmlEmDisco(chave);
+            retorno.SalvarXmlEmDisco(chave, configuracaoServico);
 
             return retorno;
         }
 
-        public async Task<retConsSitCTe> ConsultaProtocoloAsync(string chave)
+        public async Task<retConsSitCTe> ConsultaProtocoloAsync(string chave, ConfiguracaoServico configuracaoServico = null)
         {
-            var consSitCTe = ClassesFactory.CriarconsSitCTe(chave);
-            consSitCTe.ValidarSchema();
-            consSitCTe.SalvarXmlEmDisco();
+            var consSitCTe = ClassesFactory.CriarconsSitCTe(chave, configuracaoServico);
+            consSitCTe.ValidarSchema(configuracaoServico);
+            consSitCTe.SalvarXmlEmDisco(configuracaoServico);
 
-            var webService = WsdlFactory.CriaWsdlConsultaProtocolo();
+            var webService = WsdlFactory.CriaWsdlConsultaProtocolo(configuracaoServico);
             var retornoXml = await webService.cteConsultaCTAsync(consSitCTe.CriaRequestWs());
 
             var retorno = retConsSitCTe.LoadXml(retornoXml.OuterXml, consSitCTe);
-            retorno.SalvarXmlEmDisco(chave);
+            retorno.SalvarXmlEmDisco(chave, configuracaoServico);
 
             return retorno;
         }

--- a/Shared.CTe.Servicos/ConsultaRecibo/ConsultaReciboServico.cs
+++ b/Shared.CTe.Servicos/ConsultaRecibo/ConsultaReciboServico.cs
@@ -32,6 +32,7 @@
 /********************************************************************************/
 
 using System.Threading.Tasks;
+using CTe.Classes;
 using CTe.Classes.Servicos.Recepcao.Retorno;
 using CTe.Servicos.Factory;
 using CTe.Utils.Extencoes;
@@ -47,32 +48,32 @@ namespace CTe.Servicos.ConsultaRecibo
             _recibo = recibo;
         }
 
-        public retConsReciCTe Consultar()
+        public retConsReciCTe Consultar(ConfiguracaoServico configuracaoServico = null)
         {
-            var consReciCTe = ClassesFactory.CriaConsReciCTe(_recibo);
-            consReciCTe.ValidarSchema();
-            consReciCTe.SalvarXmlEmDisco();
+            var consReciCTe = ClassesFactory.CriaConsReciCTe(_recibo, configuracaoServico);
+            consReciCTe.ValidarSchema(configuracaoServico);
+            consReciCTe.SalvarXmlEmDisco(configuracaoServico);
 
-            var webService = WsdlFactory.CriaWsdlCteRetRecepcao();
+            var webService = WsdlFactory.CriaWsdlCteRetRecepcao(configuracaoServico);
             var retornoXml = webService.cteRetRecepcao(consReciCTe.CriaRequestWs());
 
             var retorno = retConsReciCTe.LoadXml(retornoXml.OuterXml, consReciCTe);
-            retorno.SalvarXmlEmDisco();
+            retorno.SalvarXmlEmDisco(configuracaoServico);
 
             return retorno;
         }
 
-        public async Task<retConsReciCTe> ConsultarAsync()
+        public async Task<retConsReciCTe> ConsultarAsync(ConfiguracaoServico configuracaoServico = null)
         {
-            var consReciCTe = ClassesFactory.CriaConsReciCTe(_recibo);
-            consReciCTe.ValidarSchema();
-            consReciCTe.SalvarXmlEmDisco();
+            var consReciCTe = ClassesFactory.CriaConsReciCTe(_recibo, configuracaoServico);
+            consReciCTe.ValidarSchema(configuracaoServico);
+            consReciCTe.SalvarXmlEmDisco(configuracaoServico);
 
-            var webService = WsdlFactory.CriaWsdlCteRetRecepcao();
+            var webService = WsdlFactory.CriaWsdlCteRetRecepcao(configuracaoServico);
             var retornoXml = await webService.cteRetRecepcaoAsync(consReciCTe.CriaRequestWs());
 
             var retorno = retConsReciCTe.LoadXml(retornoXml.OuterXml, consReciCTe);
-            retorno.SalvarXmlEmDisco();
+            retorno.SalvarXmlEmDisco(configuracaoServico);
 
             return retorno;
         }

--- a/Shared.CTe.Servicos/ConsultaStatus/StatusServico.cs
+++ b/Shared.CTe.Servicos/ConsultaStatus/StatusServico.cs
@@ -32,7 +32,7 @@
 /********************************************************************************/
 
 using System.Threading.Tasks;
-using CTe.Classes.Servicos;
+using CTe.Classes;
 using CTe.Classes.Servicos.Status;
 using CTe.Servicos.Factory;
 using CTe.Utils.Extencoes;
@@ -41,32 +41,32 @@ namespace CTe.Servicos.ConsultaStatus
 {
     public class StatusServico
     {
-        public retConsStatServCte ConsultaStatus()
+        public retConsStatServCte ConsultaStatus(ConfiguracaoServico configuracaoServico = null)
         {
-            var consStatServCte = ClassesFactory.CriaConsStatServCte();
-            consStatServCte.ValidarSchema();
-            consStatServCte.SalvarXmlEmDisco();
+            var consStatServCte = ClassesFactory.CriaConsStatServCte(configuracaoServico);
+            consStatServCte.ValidarSchema(configuracaoServico);
+            consStatServCte.SalvarXmlEmDisco(configuracaoServico);
 
-            var webService = WsdlFactory.CriaWsdlCteStatusServico();
+            var webService = WsdlFactory.CriaWsdlCteStatusServico(configuracaoServico);
             var retornoXml = webService.cteStatusServicoCT(consStatServCte.CriaRequestWs());
 
             var retorno = retConsStatServCte.LoadXml(retornoXml.OuterXml, consStatServCte);
-            retorno.SalvarXmlEmDisco();
+            retorno.SalvarXmlEmDisco(configuracaoServico);
 
             return retorno;
         }
 
-        public async Task<retConsStatServCte> ConsultaStatusAsync()
+        public async Task<retConsStatServCte> ConsultaStatusAsync(ConfiguracaoServico configuracaoServico = null)
         {
-            var consStatServCte = ClassesFactory.CriaConsStatServCte();
-            consStatServCte.ValidarSchema();
-            consStatServCte.SalvarXmlEmDisco();
+            var consStatServCte = ClassesFactory.CriaConsStatServCte(configuracaoServico);
+            consStatServCte.ValidarSchema(configuracaoServico);
+            consStatServCte.SalvarXmlEmDisco(configuracaoServico);
 
-            var webService = WsdlFactory.CriaWsdlCteStatusServico();
+            var webService = WsdlFactory.CriaWsdlCteStatusServico(configuracaoServico);
             var retornoXml = await webService.cteStatusServicoCTAsync(consStatServCte.CriaRequestWs());
 
             var retorno = retConsStatServCte.LoadXml(retornoXml.OuterXml, consStatServCte);
-            retorno.SalvarXmlEmDisco();
+            retorno.SalvarXmlEmDisco(configuracaoServico);
 
             return retorno;
         }

--- a/Shared.CTe.Servicos/DistribuicaoDFe/ServicoCTeDistribuicaoDFe.cs
+++ b/Shared.CTe.Servicos/DistribuicaoDFe/ServicoCTeDistribuicaoDFe.cs
@@ -59,12 +59,14 @@ namespace CTe.Servicos.DistribuicaoDFe
         /// <param name="documento">CNPJ/CPF do interessado no DF-e</param>
         /// <param name="ultNSU">Último NSU recebido pelo Interessado</param>
         /// <param name="nSU">Número Sequencial Único</param>
+        /// <param name="configuracaoServico"></param>
         /// <returns>Retorna um objeto da classe CTeDistDFeInteresse com os documentos de interesse do CNPJ/CPF pesquisado</returns>
-        public RetornoCteDistDFeInt CTeDistDFeInteresse(string ufAutor, string documento, string ultNSU = "0", string nSU = "0")
+        public RetornoCteDistDFeInt CTeDistDFeInteresse(string ufAutor, string documento, string ultNSU = "0", string nSU = "0", ConfiguracaoServico configuracaoServico = null)
         {
+            var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
             distDFeInt pedDistDFeInt;
             XmlDocument dadosConsulta;
-            var ws = InicializaCTeDistDFeInteresse(documento, ultNSU, nSU, out pedDistDFeInt, out dadosConsulta);
+            var ws = InicializaCTeDistDFeInteresse(documento, ultNSU, nSU, out pedDistDFeInt, out dadosConsulta, configServico);
 
             XmlNode retorno = ws.Execute(dadosConsulta);
 
@@ -72,7 +74,7 @@ namespace CTe.Servicos.DistribuicaoDFe
 
             var retConsulta = new retDistDFeInt().CarregarDeXmlString(retornoXmlString);
 
-            SalvarArquivoXml(DateTime.Now.ParaDataHoraString() + "-distDFeInt.xml", retornoXmlString);
+            SalvarArquivoXml(DateTime.Now.ParaDataHoraString() + "-distDFeInt.xml", retornoXmlString, configServico);
 
             #region Obtém um retDistDFeInt de cada evento e salva em arquivo
 
@@ -98,7 +100,7 @@ namespace CTe.Servicos.DistribuicaoDFe
                     if (chCTe == string.Empty)
                         chCTe = DateTime.Now.ParaDataHoraString() + "_SEMCHAVE";
 
-                    SalvarArquivoXml(chCTe + "-" + schema[0] + ".xml", conteudo);
+                    SalvarArquivoXml(chCTe + "-" + schema[0] + ".xml", conteudo, configServico);
                 }
             }
 
@@ -107,11 +109,12 @@ namespace CTe.Servicos.DistribuicaoDFe
             return new RetornoCteDistDFeInt(pedDistDFeInt.ObterXmlString(), retConsulta.ObterXmlString(), retornoXmlString, retConsulta);
         }
 
-        public async Task<RetornoCteDistDFeInt> CTeDistDFeInteresseAsync(string ufAutor, string documento, string ultNSU = "0", string nSU = "0")
+        public async Task<RetornoCteDistDFeInt> CTeDistDFeInteresseAsync(string ufAutor, string documento, string ultNSU = "0", string nSU = "0", ConfiguracaoServico configuracaoServico = null)
         {
+            var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
             distDFeInt pedDistDFeInt;
             XmlDocument dadosConsulta;
-            var ws = InicializaCTeDistDFeInteresse(documento, ultNSU, nSU, out pedDistDFeInt, out dadosConsulta);
+            var ws = InicializaCTeDistDFeInteresse(documento, ultNSU, nSU, out pedDistDFeInt, out dadosConsulta, configServico);
 
             XmlNode retorno = await ws.ExecuteAsync(dadosConsulta);
 
@@ -119,7 +122,7 @@ namespace CTe.Servicos.DistribuicaoDFe
 
             var retConsulta = new retDistDFeInt().CarregarDeXmlString(retornoXmlString);
 
-            SalvarArquivoXml(DateTime.Now.ParaDataHoraString() + "-distDFeInt.xml", retornoXmlString);
+            SalvarArquivoXml(DateTime.Now.ParaDataHoraString() + "-distDFeInt.xml", retornoXmlString, configServico);
 
             #region Obtém um retDistDFeInt de cada evento e salva em arquivo
 
@@ -145,7 +148,7 @@ namespace CTe.Servicos.DistribuicaoDFe
                     if (chCTe == string.Empty)
                         chCTe = DateTime.Now.ParaDataHoraString() + "_SEMCHAVE";
 
-                    SalvarArquivoXml(chCTe + "-" + schema[0] + ".xml", conteudo);
+                    SalvarArquivoXml(chCTe + "-" + schema[0] + ".xml", conteudo, configServico);
                 }
             }
 
@@ -155,13 +158,13 @@ namespace CTe.Servicos.DistribuicaoDFe
         }
 
         private CTeDistDFeInteresse InicializaCTeDistDFeInteresse(string documento, string ultNSU, string nSU,
-            out distDFeInt pedDistDFeInt, out XmlDocument dadosConsulta)
+            out distDFeInt pedDistDFeInt, out XmlDocument dadosConsulta, ConfiguracaoServico configuracaoServico)
         {
-            var versaoServico = ConfiguracaoServico.Instancia.VersaoLayout;
+            var versaoServico = configuracaoServico.VersaoLayout;
 
             #region Cria o objeto wdsl para consulta
 
-            var ws = WsdlFactory.CriaWsdlCTeDistDFeInteresse();
+            var ws = WsdlFactory.CriaWsdlCTeDistDFeInteresse(configuracaoServico);
 
             #endregion
 
@@ -170,8 +173,8 @@ namespace CTe.Servicos.DistribuicaoDFe
             pedDistDFeInt = new distDFeInt
             {
                 versao = "1.00",
-                tpAmb = ConfiguracaoServico.Instancia.tpAmb,
-                cUFAutor = ConfiguracaoServico.Instancia.cUF
+                tpAmb = configuracaoServico.tpAmb,
+                cUFAutor = configuracaoServico.cUF
             };
 
             if (documento.Length == 11)
@@ -190,7 +193,7 @@ namespace CTe.Servicos.DistribuicaoDFe
 
             #endregion
 
-            pedDistDFeInt.ValidaSchema();
+            pedDistDFeInt.ValidaSchema(configuracaoServico);
 
             var xmlConsulta = pedDistDFeInt.ObterXmlString();
 
@@ -199,16 +202,16 @@ namespace CTe.Servicos.DistribuicaoDFe
 
             string path = DateTime.Now.ParaDataHoraString() + "-ped-DistDFeInt.xml";
 
-            SalvarArquivoXml(path, xmlConsulta);
+            SalvarArquivoXml(path, xmlConsulta, configuracaoServico);
             return ws;
         }
 
-        private void SalvarArquivoXml(string nomeArquivo, string xmlString)
+        private void SalvarArquivoXml(string nomeArquivo, string xmlString, ConfiguracaoServico configuracaoServico)
         {
-            if (!ConfiguracaoServico.Instancia.IsSalvarXml) return;
+            if (!configuracaoServico.IsSalvarXml) return;
             string path = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
 
-            var dir = string.IsNullOrEmpty(ConfiguracaoServico.Instancia.DiretorioSalvarXml) ? path : ConfiguracaoServico.Instancia.DiretorioSalvarXml;
+            var dir = string.IsNullOrEmpty(configuracaoServico.DiretorioSalvarXml) ? path : configuracaoServico.DiretorioSalvarXml;
             var stw = new StreamWriter(dir + @"\" + nomeArquivo);
             stw.WriteLine(xmlString);
             stw.Close();

--- a/Shared.CTe.Servicos/Enderecos/Helpers/UrlHelper.cs
+++ b/Shared.CTe.Servicos/Enderecos/Helpers/UrlHelper.cs
@@ -41,36 +41,36 @@ namespace CTe.Servicos.Enderecos.Helpers
 {
     public class UrlHelper
     {
-        public static UrlCTe ObterUrlServico()
+        public static UrlCTe ObterUrlServico(ConfiguracaoServico configuracaoServico = null)
         {
-            var configuracaoServico = ConfiguracaoServico.Instancia;
+            var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
 
-            switch (configuracaoServico.tpAmb)
+            switch (configServico.tpAmb)
             {
                 case TipoAmbiente.Homologacao:
-                    if (configuracaoServico.TipoEmissao == tpEmis.teSVCRS)
+                    if (configServico.TipoEmissao == tpEmis.teSVCRS)
                     {
                         return UrlHomologacaoSvrs();
                     }
 
-                    if (configuracaoServico.TipoEmissao == tpEmis.teSVCSP)
+                    if (configServico.TipoEmissao == tpEmis.teSVCSP)
                     {
                         return UrlHomologacaoSvcsp();
                     }
 
-                    return UrlHomologacao();
+                    return UrlHomologacao(configServico);
                 case TipoAmbiente.Producao:
-                    if (configuracaoServico.TipoEmissao == tpEmis.teSVCRS)
+                    if (configServico.TipoEmissao == tpEmis.teSVCRS)
                     {
                         return UrlProducaoSvrs();
                     }
 
-                    if (configuracaoServico.TipoEmissao == tpEmis.teSVCSP)
+                    if (configServico.TipoEmissao == tpEmis.teSVCSP)
                     {
                         return UrlProducaoSvcsp();
                     }
 
-                    return UrlProducao();
+                    return UrlProducao(configServico);
             }
 
             throw new InvalidOperationException("Tipo Ambiente inválido");
@@ -126,10 +126,8 @@ namespace CTe.Servicos.Enderecos.Helpers
             };
         }
 
-        private static UrlCTe UrlProducao()
+        private static UrlCTe UrlProducao(ConfiguracaoServico configuracaoServico)
         {
-            var configuracaoServico = ConfiguracaoServico.Instancia;
-
             switch (configuracaoServico.cUF)
             {
                 case Estado.MT:
@@ -256,10 +254,8 @@ namespace CTe.Servicos.Enderecos.Helpers
 
         }
 
-        private static UrlCTe UrlHomologacao()
+        private static UrlCTe UrlHomologacao(ConfiguracaoServico configuracaoServico)
         {
-            var configuracaoServico = ConfiguracaoServico.Instancia;
-
             switch (configuracaoServico.cUF)
             {
                 case Estado.MT:

--- a/Shared.CTe.Servicos/EnviarCte/ServicoEnviarCte.cs
+++ b/Shared.CTe.Servicos/EnviarCte/ServicoEnviarCte.cs
@@ -11,11 +11,13 @@ namespace CTe.Servicos.EnviarCte
 {
     public class ServicoEnviarCte
     {
-        public RetornoEnviarCte Enviar(int lote, Classes.CTe cte)
+        public RetornoEnviarCte Enviar(int lote, Classes.CTe cte, ConfiguracaoServico configuracaoServico = null)
         {
+            var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
+            
             ServicoCTeRecepcao servicoRecepcao = new ServicoCTeRecepcao();
 
-            retEnviCte retEnviCte = servicoRecepcao.CTeRecepcao(lote, new List<Classes.CTe> {cte});
+            retEnviCte retEnviCte = servicoRecepcao.CTeRecepcao(lote, new List<Classes.CTe> {cte}, configServico);
 
             if (retEnviCte.cStat != 103)
             {
@@ -24,7 +26,7 @@ namespace CTe.Servicos.EnviarCte
 
             ConsultaReciboServico servicoConsultaRecibo = new ConsultaReciboServico(retEnviCte.infRec.nRec);
 
-            retConsReciCTe retConsReciCTe = servicoConsultaRecibo.Consultar();
+            retConsReciCTe retConsReciCTe = servicoConsultaRecibo.Consultar(configServico);
 
 
             cteProc cteProc = null;
@@ -39,21 +41,22 @@ namespace CTe.Servicos.EnviarCte
                 cteProc = new cteProc
                 {
                     CTe = cte,
-                    versao = ConfiguracaoServico.Instancia.VersaoLayout,
+                    versao = configServico.VersaoLayout,
                     protCTe = retConsReciCTe.protCTe[0]
                 };
             }
 
-            cteProc.SalvarXmlEmDisco();
+            cteProc.SalvarXmlEmDisco(configServico);
 
             return new RetornoEnviarCte(retEnviCte, retConsReciCTe, cteProc);
         }
 
-        public async Task<RetornoEnviarCte> EnviarAsync(int lote, Classes.CTe cte)
+        public async Task<RetornoEnviarCte> EnviarAsync(int lote, Classes.CTe cte, ConfiguracaoServico configuracaoServico = null)
         {
+            var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
             ServicoCTeRecepcao servicoRecepcao = new ServicoCTeRecepcao();
 
-            retEnviCte retEnviCte = await servicoRecepcao.CTeRecepcaoAsync(lote, new List<Classes.CTe> { cte });
+            retEnviCte retEnviCte = await servicoRecepcao.CTeRecepcaoAsync(lote, new List<Classes.CTe> { cte }, configServico);
 
             if (retEnviCte.cStat != 103)
             {
@@ -62,7 +65,7 @@ namespace CTe.Servicos.EnviarCte
 
             ConsultaReciboServico servicoConsultaRecibo = new ConsultaReciboServico(retEnviCte.infRec.nRec);
 
-            retConsReciCTe retConsReciCTe = await servicoConsultaRecibo.ConsultarAsync();
+            retConsReciCTe retConsReciCTe = await servicoConsultaRecibo.ConsultarAsync(configServico);
 
 
             cteProc cteProc = null;
@@ -77,12 +80,12 @@ namespace CTe.Servicos.EnviarCte
                 cteProc = new cteProc
                 {
                     CTe = cte,
-                    versao = ConfiguracaoServico.Instancia.VersaoLayout,
+                    versao = configServico.VersaoLayout,
                     protCTe = retConsReciCTe.protCTe[0]
                 };
             }
 
-            cteProc.SalvarXmlEmDisco();
+            cteProc.SalvarXmlEmDisco(configServico);
 
             return new RetornoEnviarCte(retEnviCte, retConsReciCTe, cteProc);
         }

--- a/Shared.CTe.Servicos/Eventos/Contratos/IServicoController.cs
+++ b/Shared.CTe.Servicos/Eventos/Contratos/IServicoController.cs
@@ -32,6 +32,7 @@
 /********************************************************************************/
 
 using System.Threading.Tasks;
+using CTe.Classes;
 using CTe.Classes.Servicos.Evento;
 using CTe.Classes.Servicos.Evento.Flags;
 using CteEletronico = CTe.Classes.CTe;
@@ -40,9 +41,9 @@ namespace CTe.Servicos.Eventos.Contratos
 {
     public interface IServicoController
     {
-        retEventoCTe Executar(CteEletronico cte, int sequenciaEvento, EventoContainer container, CTeTipoEvento evento);
+        retEventoCTe Executar(CteEletronico cte, int sequenciaEvento, EventoContainer container, CTeTipoEvento evento, ConfiguracaoServico configuracaoServico = null);
 
         Task<retEventoCTe> ExecutarAsync(CteEletronico cte, int sequenciaEvento, EventoContainer container,
-            CTeTipoEvento cTeTipoEvento);
+            CTeTipoEvento cTeTipoEvento, ConfiguracaoServico configuracaoServico = null);
     }
 }

--- a/Shared.CTe.Servicos/Eventos/EventoCancelamento.cs
+++ b/Shared.CTe.Servicos/Eventos/EventoCancelamento.cs
@@ -32,6 +32,7 @@
 /********************************************************************************/
 
 using System.Threading.Tasks;
+using CTe.Classes;
 using CTe.Classes.Servicos.Evento;
 using CTe.Classes.Servicos.Evento.Flags;
 using CTe.Servicos.Factory;
@@ -54,20 +55,20 @@ namespace CTe.Servicos.Eventos
             _justificativa = justificativa;
         }
 
-        public retEventoCTe Cancelar()
+        public retEventoCTe Cancelar(ConfiguracaoServico configuracaoServico = null)
         {
             var eventoCancelar = ClassesFactory.CriaEvCancCTe(_justificativa, _numeroProtocolo);
 
-            var retorno = new ServicoController().Executar(_cte, _sequenciaEvento, eventoCancelar, CTeTipoEvento.Cancelamento);
+            var retorno = new ServicoController().Executar(_cte, _sequenciaEvento, eventoCancelar, CTeTipoEvento.Cancelamento, configuracaoServico);
 
             return retorno;
         }
 
-        public async Task<retEventoCTe> CancelarAsync()
+        public async Task<retEventoCTe> CancelarAsync(ConfiguracaoServico configuracaoServico = null)
         {
             var eventoCancelar = ClassesFactory.CriaEvCancCTe(_justificativa, _numeroProtocolo);
 
-            var retorno = await new ServicoController().ExecutarAsync(_cte, _sequenciaEvento, eventoCancelar, CTeTipoEvento.Cancelamento);
+            var retorno = await new ServicoController().ExecutarAsync(_cte, _sequenciaEvento, eventoCancelar, CTeTipoEvento.Cancelamento, configuracaoServico);
 
             return retorno;
         }

--- a/Shared.CTe.Servicos/Eventos/EventoCartaCorrecao.cs
+++ b/Shared.CTe.Servicos/Eventos/EventoCartaCorrecao.cs
@@ -33,6 +33,7 @@
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using CTe.Classes;
 using CTe.Classes.Servicos.Evento;
 using CTe.Classes.Servicos.Evento.Flags;
 using CTe.Servicos.Factory;
@@ -54,20 +55,20 @@ namespace CTe.Servicos.Eventos
             _infCorrecaos = infCorrecaos;
         }
 
-        public retEventoCTe AdicionarCorrecoes()
+        public retEventoCTe AdicionarCorrecoes(ConfiguracaoServico configuracaoServico = null)
         {
             var eventoCorrecao = ClassesFactory.CriaEvCCeCTe(_infCorrecaos);
 
-            var retorno = new ServicoController().Executar(_cte, _sequenciaEvento, eventoCorrecao, CTeTipoEvento.CartaCorrecao);
+            var retorno = new ServicoController().Executar(_cte, _sequenciaEvento, eventoCorrecao, CTeTipoEvento.CartaCorrecao, configuracaoServico);
 
             return retorno;
         }
 
-        public async Task<retEventoCTe> AdicionarCorrecoesAsync()
+        public async Task<retEventoCTe> AdicionarCorrecoesAsync(ConfiguracaoServico configuracaoServico = null)
         {
             var eventoCorrecao = ClassesFactory.CriaEvCCeCTe(_infCorrecaos);
 
-            var retorno = await new ServicoController().ExecutarAsync(_cte, _sequenciaEvento, eventoCorrecao, CTeTipoEvento.CartaCorrecao);
+            var retorno = await new ServicoController().ExecutarAsync(_cte, _sequenciaEvento, eventoCorrecao, CTeTipoEvento.CartaCorrecao, configuracaoServico);
 
             return retorno;
         }

--- a/Shared.CTe.Servicos/Eventos/EventoDesacordo.cs
+++ b/Shared.CTe.Servicos/Eventos/EventoDesacordo.cs
@@ -32,6 +32,7 @@
 /********************************************************************************/
 
 using System.Threading.Tasks;
+using CTe.Classes;
 using CTe.Classes.Servicos.Evento;
 using CTe.Classes.Servicos.Evento.Flags;
 using CTe.Servicos.Factory;
@@ -55,20 +56,20 @@ namespace CTe.Servicos.Eventos
             _observacao = observacao;
         }
 
-        public retEventoCTe Discordar()
+        public retEventoCTe Discordar(ConfiguracaoServico configuracaoServico = null)
         {
             var eventoDiscordar = ClassesFactory.CriaEvPrestDesacordo(_indicadorDesacordo, _observacao);
 
-            var retorno = new ServicoController().Executar(CTeTipoEvento.Desacordo, _sequenciaEvento, _chave, _cnpj, eventoDiscordar);
+            var retorno = new ServicoController().Executar(CTeTipoEvento.Desacordo, _sequenciaEvento, _chave, _cnpj, eventoDiscordar, configuracaoServico);
 
             return retorno;
         }
 
-        public async Task<retEventoCTe> DiscordarAsync()
+        public async Task<retEventoCTe> DiscordarAsync(ConfiguracaoServico configuracaoServico = null)
         {
             var eventoDiscordar = ClassesFactory.CriaEvPrestDesacordo(_indicadorDesacordo, _observacao);
 
-            var retorno = await new ServicoController().ExecutarAsync(CTeTipoEvento.Desacordo, _sequenciaEvento, _chave, _cnpj, eventoDiscordar);
+            var retorno = await new ServicoController().ExecutarAsync(CTeTipoEvento.Desacordo, _sequenciaEvento, _chave, _cnpj, eventoDiscordar, configuracaoServico);
 
             return retorno;
         }

--- a/Shared.CTe.Servicos/Eventos/FactoryEvento.cs
+++ b/Shared.CTe.Servicos/Eventos/FactoryEvento.cs
@@ -44,14 +44,14 @@ namespace CTe.Servicos.Eventos
     public class FactoryEvento
     {
         //Vou manter para evitar quebra de código pois a classe e o metodo são publicos
-        public static eventoCTe CriaEvento(CTeEletronico cte, CTeTipoEvento cTeTipoEvento, int sequenciaEvento, EventoContainer container)
+        public static eventoCTe CriaEvento(CTeEletronico cte, CTeTipoEvento cTeTipoEvento, int sequenciaEvento, EventoContainer container, ConfiguracaoServico configuracaoServico = null)
         {
-            return CriaEvento(cTeTipoEvento, sequenciaEvento, cte.Chave(), cte.infCte.emit.CNPJ, container);
+            return CriaEvento(cTeTipoEvento, sequenciaEvento, cte.Chave(), cte.infCte.emit.CNPJ, container, configuracaoServico);
         }
 
-        public static eventoCTe CriaEvento(CTeTipoEvento cTeTipoEvento, int sequenciaEvento, string chave, string cnpj, EventoContainer container)
+        public static eventoCTe CriaEvento(CTeTipoEvento cTeTipoEvento, int sequenciaEvento, string chave, string cnpj, EventoContainer container, ConfiguracaoServico configuracaoServico = null)
         {
-            var configuracaoServico = ConfiguracaoServico.Instancia;
+            var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
 
             var id = new StringBuilder("ID");
             id.Append((int)cTeTipoEvento);
@@ -60,19 +60,19 @@ namespace CTe.Servicos.Eventos
 
             return new eventoCTe
             {
-                versao = configuracaoServico.VersaoLayout,
-                infEvento = new infEventoEnv
+                versao = configServico.VersaoLayout,
+                infEvento = new infEventoEnv(configServico)
                 {
-                    tpAmb = configuracaoServico.tpAmb,
+                    tpAmb = configServico.tpAmb,
                     CNPJ = cnpj,
-                    cOrgao = configuracaoServico.cUF,
+                    cOrgao = configServico.cUF,
                     chCTe = chave,
                     dhEvento = DateTime.Now,
                     nSeqEvento = sequenciaEvento,
                     tpEvento = cTeTipoEvento,
                     detEvento = new detEvento
                     {
-                        versaoEvento = configuracaoServico.VersaoLayout,
+                        versaoEvento = configServico.VersaoLayout,
                         EventoContainer = container
                     },
                     Id = id.ToString()

--- a/Shared.CTe.Servicos/Eventos/ServicoController.cs
+++ b/Shared.CTe.Servicos/Eventos/ServicoController.cs
@@ -32,6 +32,7 @@
 /********************************************************************************/
 
 using System.Threading.Tasks;
+using CTe.Classes;
 using CTe.Classes.Servicos.Evento;
 using CTe.Classes.Servicos.Evento.Flags;
 using CTe.Servicos.Eventos.Contratos;
@@ -44,44 +45,44 @@ namespace CTe.Servicos.Eventos
 {
     public class ServicoController : IServicoController
     {
-        public retEventoCTe Executar(CteEletronico cte, int sequenciaEvento, EventoContainer container, CTeTipoEvento cTeTipoEvento)
+        public retEventoCTe Executar(CteEletronico cte, int sequenciaEvento, EventoContainer container, CTeTipoEvento cTeTipoEvento, ConfiguracaoServico configuracaoServico = null)
         {
-            return Executar(cTeTipoEvento, sequenciaEvento, cte.Chave(), cte.infCte.emit.CNPJ, container);
+            return Executar(cTeTipoEvento, sequenciaEvento, cte.Chave(), cte.infCte.emit.CNPJ, container, configuracaoServico);
         }
 
-        public async Task<retEventoCTe> ExecutarAsync(CteEletronico cte, int sequenciaEvento, EventoContainer container, CTeTipoEvento cTeTipoEvento)
+        public async Task<retEventoCTe> ExecutarAsync(CteEletronico cte, int sequenciaEvento, EventoContainer container, CTeTipoEvento cTeTipoEvento, ConfiguracaoServico configuracaoServico = null)
         {
-            return await ExecutarAsync(cTeTipoEvento, sequenciaEvento, cte.Chave(), cte.infCte.emit.CNPJ, container);
+            return await ExecutarAsync(cTeTipoEvento, sequenciaEvento, cte.Chave(), cte.infCte.emit.CNPJ, container, configuracaoServico);
         }
 
-        public retEventoCTe Executar(CTeTipoEvento cTeTipoEvento, int sequenciaEvento, string chave, string cnpj, EventoContainer container)
+        public retEventoCTe Executar(CTeTipoEvento cTeTipoEvento, int sequenciaEvento, string chave, string cnpj, EventoContainer container, ConfiguracaoServico configuracaoServico = null)
         {
-            var evento = FactoryEvento.CriaEvento(cTeTipoEvento,sequenciaEvento,chave,cnpj,container);
-            evento.Assina();
-            evento.ValidarSchema();
-            evento.SalvarXmlEmDisco();
+            var evento = FactoryEvento.CriaEvento(cTeTipoEvento, sequenciaEvento, chave, cnpj, container, configuracaoServico);
+            evento.Assina(configuracaoServico);
+            evento.ValidarSchema(configuracaoServico);
+            evento.SalvarXmlEmDisco(configuracaoServico);
 
-            var webService = WsdlFactory.CriaWsdlCteEvento();
+            var webService = WsdlFactory.CriaWsdlCteEvento(configuracaoServico);
             var retornoXml = webService.cteRecepcaoEvento(evento.CriaXmlRequestWs());
 
             var retorno = retEventoCTe.LoadXml(retornoXml.OuterXml, evento);
-            retorno.SalvarXmlEmDisco();
+            retorno.SalvarXmlEmDisco(configuracaoServico);
 
             return retorno;
         }
 
-        public async Task<retEventoCTe> ExecutarAsync(CTeTipoEvento cTeTipoEvento, int sequenciaEvento, string chave, string cnpj, EventoContainer container)
+        public async Task<retEventoCTe> ExecutarAsync(CTeTipoEvento cTeTipoEvento, int sequenciaEvento, string chave, string cnpj, EventoContainer container, ConfiguracaoServico configuracaoServico = null)
         {
-            var evento = FactoryEvento.CriaEvento(cTeTipoEvento,sequenciaEvento,chave,cnpj,container);
-            evento.Assina();
-            evento.ValidarSchema();
-            evento.SalvarXmlEmDisco();
+            var evento = FactoryEvento.CriaEvento(cTeTipoEvento, sequenciaEvento, chave, cnpj, container, configuracaoServico);
+            evento.Assina(configuracaoServico);
+            evento.ValidarSchema(configuracaoServico);
+            evento.SalvarXmlEmDisco(configuracaoServico);
 
-            var webService = WsdlFactory.CriaWsdlCteEvento();
+            var webService = WsdlFactory.CriaWsdlCteEvento(configuracaoServico);
             var retornoXml = await webService.cteRecepcaoEventoAsync(evento.CriaXmlRequestWs());
 
             var retorno = retEventoCTe.LoadXml(retornoXml.OuterXml, evento);
-            retorno.SalvarXmlEmDisco();
+            retorno.SalvarXmlEmDisco(configuracaoServico);
 
             return retorno;
         }

--- a/Shared.CTe.Servicos/Factory/ClassesFactory.cs
+++ b/Shared.CTe.Servicos/Factory/ClassesFactory.cs
@@ -49,37 +49,37 @@ namespace CTe.Servicos.Factory
 {
     public class ClassesFactory
     {
-        public static consStatServCte CriaConsStatServCte()
+        public static consStatServCte CriaConsStatServCte(ConfiguracaoServico configuracaoServico = null)
         {
-            var configuracaoServico = ConfiguracaoServico.Instancia;
+            var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
 
             return new consStatServCte
             {
-                versao = configuracaoServico.VersaoLayout,
-                tpAmb = configuracaoServico.tpAmb
+                versao = configServico.VersaoLayout,
+                tpAmb = configServico.tpAmb
             };
         }
 
-        public static consSitCTe CriarconsSitCTe(string chave)
+        public static consSitCTe CriarconsSitCTe(string chave, ConfiguracaoServico configuracaoServico = null)
         {
-            var configuracaoServico = ConfiguracaoServico.Instancia;
+            var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
 
             return new consSitCTe
             {
-                tpAmb = configuracaoServico.tpAmb,
-                versao = configuracaoServico.VersaoLayout,
+                tpAmb = configServico.tpAmb,
+                versao = configServico.VersaoLayout,
                 chCTe = chave
             };
         }
 
-        public static inutCTe CriaInutCTe(ConfigInutiliza configInutiliza)
+        public static inutCTe CriaInutCTe(ConfigInutiliza configInutiliza, ConfiguracaoServico configuracaoServico = null)
         {
             if (configInutiliza == null) throw new ArgumentNullException("Preciso de uma configuração de inutilização");
 
-            var configuracaoServico = ConfiguracaoServico.Instancia;
+            var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
 
             var id = new StringBuilder("ID");
-            id.Append(configuracaoServico.cUF.GetCodigoIbgeEmString());
+            id.Append(configServico.cUF.GetCodigoIbgeEmString());
             id.Append(configInutiliza.Cnpj);
             id.Append((byte) configInutiliza.ModeloDocumento);
             id.Append(configInutiliza.Serie.ToString("D3"));
@@ -88,12 +88,12 @@ namespace CTe.Servicos.Factory
 
             return new inutCTe
             {
-                versao = configuracaoServico.VersaoLayout,
+                versao = configServico.VersaoLayout,
                 infInut = new infInutEnv
                 {
                     Id = id.ToString(),
-                    tpAmb = configuracaoServico.tpAmb,
-                    cUF = configuracaoServico.cUF,
+                    tpAmb = configServico.tpAmb,
+                    cUF = configServico.cUF,
                     CNPJ = configInutiliza.Cnpj,
                     ano = configInutiliza.Ano,
                     nCTIni = configInutiliza.NumeroInicial,
@@ -105,14 +105,14 @@ namespace CTe.Servicos.Factory
             };
         }
 
-        public static consReciCTe CriaConsReciCTe(string recibo)
+        public static consReciCTe CriaConsReciCTe(string recibo, ConfiguracaoServico configuracaoServico = null)
         {
-            var configuracaoServico = ConfiguracaoServico.Instancia;
+            var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
 
             return new consReciCTe
             {
-                tpAmb = configuracaoServico.tpAmb,
-                versao = configuracaoServico.VersaoLayout,
+                tpAmb = configServico.tpAmb,
+                versao = configServico.VersaoLayout,
                 nRec = recibo
             };
         }
@@ -143,11 +143,11 @@ namespace CTe.Servicos.Factory
             };
         }
 
-        public static enviCTe CriaEnviCTe(int lote, List<CTeEletronica> cteEletronicoList)
+        public static enviCTe CriaEnviCTe(int lote, List<CTeEletronica> cteEletronicoList, ConfiguracaoServico configuracaoServico = null)
         {
-            var configuracaoServico = ConfiguracaoServico.Instancia;
-
-            return new enviCTe(configuracaoServico.VersaoLayout, lote, cteEletronicoList);
+            var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
+            
+            return new enviCTe(configServico.VersaoLayout, lote, cteEletronicoList);
         }
     }
 }

--- a/Shared.CTe.Servicos/Factory/WsdlFactory.cs
+++ b/Shared.CTe.Servicos/Factory/WsdlFactory.cs
@@ -48,79 +48,79 @@ namespace CTe.Servicos.Factory
 {
     public class WsdlFactory
     {
-        public static CteStatusServico CriaWsdlCteStatusServico()
+        public static CteStatusServico CriaWsdlCteStatusServico(ConfiguracaoServico configuracaoServico = null)
         {
-            var url = UrlHelper.ObterUrlServico().CteStatusServico;
+            var url = UrlHelper.ObterUrlServico(configuracaoServico).CteStatusServico;
 
-            var configuracaoWsdl = CriaConfiguracao(url);
+            var configuracaoWsdl = CriaConfiguracao(url, configuracaoServico);
 
             return new CteStatusServico(configuracaoWsdl);
         }
 
-        public static CteConsulta CriaWsdlConsultaProtocolo()
+        public static CteConsulta CriaWsdlConsultaProtocolo(ConfiguracaoServico configuracaoServico = null)
         {
-            var url = UrlHelper.ObterUrlServico().CteConsulta;
+            var url = UrlHelper.ObterUrlServico(configuracaoServico).CteConsulta;
 
-            var configuracaoWsdl = CriaConfiguracao(url);
+            var configuracaoWsdl = CriaConfiguracao(url, configuracaoServico);
 
             return new CteConsulta(configuracaoWsdl);
         }
 
-        public static CteInutilizacao CriaWsdlCteInutilizacao()
+        public static CteInutilizacao CriaWsdlCteInutilizacao(ConfiguracaoServico configuracaoServico = null)
         {
-            var url = UrlHelper.ObterUrlServico().CteInutilizacao;
+            var url = UrlHelper.ObterUrlServico(configuracaoServico).CteInutilizacao;
 
-            var configuracaoWsdl = CriaConfiguracao(url);
+            var configuracaoWsdl = CriaConfiguracao(url, configuracaoServico);
 
             return new CteInutilizacao(configuracaoWsdl);
         }
 
-        public static CteRetRecepcao CriaWsdlCteRetRecepcao()
+        public static CteRetRecepcao CriaWsdlCteRetRecepcao(ConfiguracaoServico configuracaoServico = null)
         {
-            var url = UrlHelper.ObterUrlServico().CteRetRecepcao;
+            var url = UrlHelper.ObterUrlServico(configuracaoServico).CteRetRecepcao;
 
-            var configuracaoWsdl = CriaConfiguracao(url);
+            var configuracaoWsdl = CriaConfiguracao(url, configuracaoServico);
 
             return new CteRetRecepcao(configuracaoWsdl);
         }
 
-        public static CteRecepcao CriaWsdlCteRecepcao()
+        public static CteRecepcao CriaWsdlCteRecepcao(ConfiguracaoServico configuracaoServico = null)
         {
-            var url = UrlHelper.ObterUrlServico().CteRecepcao;
+            var url = UrlHelper.ObterUrlServico(configuracaoServico).CteRecepcao;
 
-            var configuracaoWsdl = CriaConfiguracao(url);
+            var configuracaoWsdl = CriaConfiguracao(url, configuracaoServico);
 
             return new CteRecepcao(configuracaoWsdl);
         }
 
-        public static CteRecepcaoEvento CriaWsdlCteEvento()
+        public static CteRecepcaoEvento CriaWsdlCteEvento(ConfiguracaoServico configuracaoServico = null)
         {
-            var url = UrlHelper.ObterUrlServico().CteRecepcaoEvento;
+            var url = UrlHelper.ObterUrlServico(configuracaoServico).CteRecepcaoEvento;
 
-            var configuracaoWsdl = CriaConfiguracao(url);
+            var configuracaoWsdl = CriaConfiguracao(url, configuracaoServico);
 
             return new CteRecepcaoEvento(configuracaoWsdl);
         }
 
 
-        public static CTeDistDFeInteresse CriaWsdlCTeDistDFeInteresse()
+        public static CTeDistDFeInteresse CriaWsdlCTeDistDFeInteresse(ConfiguracaoServico configuracaoServico = null)
         {
-            var url = UrlHelper.ObterUrlServico().CTeDistribuicaoDFe ;
+            var url = UrlHelper.ObterUrlServico(configuracaoServico).CTeDistribuicaoDFe;
 
-            var configuracaoWsdl = CriaConfiguracao(url);
+            var configuracaoWsdl = CriaConfiguracao(url, configuracaoServico);
 
             return new CTeDistDFeInteresse(configuracaoWsdl);
         }
 
 
-        private static WsdlConfiguracao CriaConfiguracao(string url)
+        private static WsdlConfiguracao CriaConfiguracao(string url, ConfiguracaoServico configuracaoServico = null)
         {
-            var configuracaoServico = ConfiguracaoServico.Instancia;
+            var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
 
-            var codigoEstado = configuracaoServico.cUF.GetCodigoIbgeEmString();
-            var certificadoDigital = configuracaoServico.X509Certificate2;
-            var versaoEmString = configuracaoServico.VersaoLayout.GetString();
-            var timeOut = configuracaoServico.TimeOut;
+            var codigoEstado = configServico.cUF.GetCodigoIbgeEmString();
+            var certificadoDigital = configServico.X509Certificate2;
+            var versaoEmString = configServico.VersaoLayout.GetString();
+            var timeOut = configServico.TimeOut;
 
             return new WsdlConfiguracao
             {

--- a/Shared.CTe.Servicos/Inutilizacao/InutilizacaoServico.cs
+++ b/Shared.CTe.Servicos/Inutilizacao/InutilizacaoServico.cs
@@ -33,6 +33,7 @@
 
 using System;
 using System.Threading.Tasks;
+using CTe.Classes;
 using CTe.Classes.Servicos.Inutilizacao;
 using CTe.Servicos.Factory;
 using CTe.Utils.Extencoes;
@@ -75,34 +76,34 @@ namespace CTe.Servicos.Inutilizacao
             _configInutiliza = configInutiliza;
         }
 
-        public retInutCTe Inutilizar()
+        public retInutCTe Inutilizar(ConfiguracaoServico configuracaoServico = null)
         {
-            var inutCte = ClassesFactory.CriaInutCTe(_configInutiliza);
-            inutCte.Assinar();
-            inutCte.ValidarShcema();
-            inutCte.SalvarXmlEmDisco();
+            var inutCte = ClassesFactory.CriaInutCTe(_configInutiliza, configuracaoServico);
+            inutCte.Assinar(configuracaoServico);
+            inutCte.ValidarShcema(configuracaoServico);
+            inutCte.SalvarXmlEmDisco(configuracaoServico);
 
-            var webService = WsdlFactory.CriaWsdlCteInutilizacao();
+            var webService = WsdlFactory.CriaWsdlCteInutilizacao(configuracaoServico);
             var retornoXml = webService.cteInutilizacaoCT(inutCte.CriaRequestWs());
 
             var retorno = retInutCTe.LoadXml(retornoXml.OuterXml, inutCte);
-            retorno.SalvarXmlEmDisco(inutCte.infInut.Id.Substring(2));
+            retorno.SalvarXmlEmDisco(inutCte.infInut.Id.Substring(2), configuracaoServico);
 
             return retorno;
         }
 
-        public async Task<retInutCTe> InutilizarAsync()
+        public async Task<retInutCTe> InutilizarAsync(ConfiguracaoServico configuracaoServico = null)
         {
-            var inutCte = ClassesFactory.CriaInutCTe(_configInutiliza);
-            inutCte.Assinar();
-            inutCte.ValidarShcema();
-            inutCte.SalvarXmlEmDisco();
+            var inutCte = ClassesFactory.CriaInutCTe(_configInutiliza, configuracaoServico);
+            inutCte.Assinar(configuracaoServico);
+            inutCte.ValidarShcema(configuracaoServico);
+            inutCte.SalvarXmlEmDisco(configuracaoServico);
 
-            var webService = WsdlFactory.CriaWsdlCteInutilizacao();
+            var webService = WsdlFactory.CriaWsdlCteInutilizacao(configuracaoServico);
             var retornoXml = await webService.cteInutilizacaoCTAsync(inutCte.CriaRequestWs());
 
             var retorno = retInutCTe.LoadXml(retornoXml.OuterXml, inutCte);
-            retorno.SalvarXmlEmDisco(inutCte.infInut.Id.Substring(2));
+            retorno.SalvarXmlEmDisco(inutCte.infInut.Id.Substring(2), configuracaoServico);
 
             return retorno;
         }

--- a/Shared.CTe.Servicos/Recepcao/ServicoCTeRecepcao.cs
+++ b/Shared.CTe.Servicos/Recepcao/ServicoCTeRecepcao.cs
@@ -48,43 +48,43 @@ namespace CTe.Servicos.Recepcao
     {
         public event EventHandler<AntesEnviarRecepcao> AntesDeEnviar;
 
-        public retEnviCte CTeRecepcao(int lote, List<CTeEletronico> cteEletronicosList)
+        public retEnviCte CTeRecepcao(int lote, List<CTeEletronico> cteEletronicosList, ConfiguracaoServico configuracaoServico = null)
         {
-            var enviCte = PreparaEnvioCTe(lote, cteEletronicosList);
+            var enviCte = PreparaEnvioCTe(lote, cteEletronicosList, configuracaoServico);
 
-            var webService = WsdlFactory.CriaWsdlCteRecepcao();
+            var webService = WsdlFactory.CriaWsdlCteRecepcao(configuracaoServico);
 
             OnAntesDeEnviar(enviCte);
 
-            var retornoXml = webService.cteRecepcaoLote(enviCte.CriaRequestWs());
+            var retornoXml = webService.cteRecepcaoLote(enviCte.CriaRequestWs(configuracaoServico));
 
             var retorno = retEnviCte.LoadXml(retornoXml.OuterXml, enviCte);
-            retorno.SalvarXmlEmDisco();
+            retorno.SalvarXmlEmDisco(configuracaoServico);
 
             return retorno;
         }
 
-        public async Task<retEnviCte> CTeRecepcaoAsync(int lote, List<CTeEletronico> cteEletronicosList)
+        public async Task<retEnviCte> CTeRecepcaoAsync(int lote, List<CTeEletronico> cteEletronicosList, ConfiguracaoServico configuracaoServico = null)
         {
-            var enviCte = PreparaEnvioCTe(lote, cteEletronicosList);
+            var enviCte = PreparaEnvioCTe(lote, cteEletronicosList, configuracaoServico);
 
-            var webService = WsdlFactory.CriaWsdlCteRecepcao();
+            var webService = WsdlFactory.CriaWsdlCteRecepcao(configuracaoServico);
 
             OnAntesDeEnviar(enviCte);
 
-            var retornoXml = await webService.cteRecepcaoLoteAsync(enviCte.CriaRequestWs());
+            var retornoXml = await webService.cteRecepcaoLoteAsync(enviCte.CriaRequestWs(configuracaoServico));
 
             var retorno = retEnviCte.LoadXml(retornoXml.OuterXml, enviCte);
-            retorno.SalvarXmlEmDisco();
+            retorno.SalvarXmlEmDisco(configuracaoServico);
 
             return retorno;
         }
 
-        private static enviCTe PreparaEnvioCTe(int lote, List<CTeEletronico> cteEletronicosList)
+        private static enviCTe PreparaEnvioCTe(int lote, List<CTeEletronico> cteEletronicosList, ConfiguracaoServico configuracaoServico = null)
         {
-            var instanciaConfiguracao = ConfiguracaoServico.Instancia;
+            var instanciaConfiguracao = configuracaoServico ?? ConfiguracaoServico.Instancia;
 
-            var enviCte = ClassesFactory.CriaEnviCTe(lote, cteEletronicosList);
+            var enviCte = ClassesFactory.CriaEnviCTe(lote, cteEletronicosList, instanciaConfiguracao);
 
             if (instanciaConfiguracao.tpAmb == TipoAmbiente.Homologacao)
             {
@@ -101,13 +101,13 @@ namespace CTe.Servicos.Recepcao
             foreach (var cte in enviCte.CTe)
             {
                 cte.infCte.ide.tpEmis = instanciaConfiguracao.TipoEmissao;
-                cte.Assina();
-                cte.ValidaSchema();
-                cte.SalvarXmlEmDisco();
+                cte.Assina(instanciaConfiguracao);
+                cte.ValidaSchema(instanciaConfiguracao);
+                cte.SalvarXmlEmDisco(instanciaConfiguracao);
             }
 
-            enviCte.ValidaSchema();
-            enviCte.SalvarXmlEmDisco();
+            enviCte.ValidaSchema(instanciaConfiguracao);
+            enviCte.SalvarXmlEmDisco(instanciaConfiguracao);
             return enviCte;
         }
 

--- a/Shared.CTe.Utils/CTe/ExCteProc.cs
+++ b/Shared.CTe.Utils/CTe/ExCteProc.cs
@@ -83,11 +83,11 @@ namespace CTe.Utils.CTe
             FuncoesXml.ClasseParaArquivoXml(cteProc, arquivoXml);
         }
 
-        public static void SalvarXmlEmDisco(this cteProc cteProc)
+        public static void SalvarXmlEmDisco(this cteProc cteProc, ConfiguracaoServico configuracaoServico = null)
         {
             if (cteProc == null) return;
 
-            var instanciaServico = ConfiguracaoServico.Instancia;
+            var instanciaServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
 
             if (instanciaServico.NaoSalvarXml()) return;
 

--- a/Shared.CTe.Utils/CTe/ExtCTe.cs
+++ b/Shared.CTe.Utils/CTe/ExtCTe.cs
@@ -84,8 +84,9 @@ namespace CTe.Utils.CTe
         ///     Gera id, cdv, assina e faz alguns ajustes nos dados da classe CTe antes de utilizá-la
         /// </summary>
         /// <param name="cte"></param>
+        /// <param name="configuracaoServico"></param>
         /// <returns>Retorna um objeto CTe devidamente tradado</returns>
-        public static void ValidaSchema(this CteEletronica cte)
+        public static void ValidaSchema(this CteEletronica cte, ConfiguracaoServico configuracaoServico = null)
         {
             if (cte == null) throw new ArgumentNullException("cte");
 
@@ -94,10 +95,10 @@ namespace CTe.Utils.CTe
             switch (cte.infCte.versao)
             {
                 case versao.ve200:
-                    Validador.Valida(xmlValidacao, "cte_v2.00.xsd");
+                    Validador.Valida(xmlValidacao, "cte_v2.00.xsd", configuracaoServico);
                     break;
                 case versao.ve300:
-                    Validador.Valida(xmlValidacao, "cte_v3.00.xsd");
+                    Validador.Valida(xmlValidacao, "cte_v3.00.xsd", configuracaoServico);
                     break;
                 default:
                     throw new InvalidOperationException("Nos achamos um erro na hora de validar o schema, " +
@@ -114,68 +115,68 @@ namespace CTe.Utils.CTe
                     case versaoModal.veM200:
                         if (cte.infCte.infCTeNorm.infModal.ContainerModal.GetType() == typeof(aereo))
                         {
-                            Validador.Valida(xmlModal, "cteModalAereo_v2.00.xsd");
+                            Validador.Valida(xmlModal, "cteModalAereo_v2.00.xsd", configuracaoServico);
                         }
 
                         if (cte.infCte.infCTeNorm.infModal.ContainerModal.GetType() == typeof(aquav))
                         {
-                            Validador.Valida(xmlModal, "cteModalAquaviario_v2.00.xsd");
+                            Validador.Valida(xmlModal, "cteModalAquaviario_v2.00.xsd", configuracaoServico);
                         }
 
                         if (cte.infCte.infCTeNorm.infModal.ContainerModal.GetType() == typeof(duto))
                         {
-                            Validador.Valida(xmlModal, "cteModalDutoviario_v2.00.xsd");
+                            Validador.Valida(xmlModal, "cteModalDutoviario_v2.00.xsd", configuracaoServico);
                         }
 
                         if (cte.infCte.infCTeNorm.infModal.ContainerModal.GetType() == typeof(ferrov))
                         {
-                            Validador.Valida(xmlModal, "cteModalFerroviario_v2.00.xsd");
+                            Validador.Valida(xmlModal, "cteModalFerroviario_v2.00.xsd", configuracaoServico);
                         }
 
                         if (cte.infCte.infCTeNorm.infModal.ContainerModal.GetType() == typeof(rodo))
                         {
-                            Validador.Valida(xmlModal, "cteModalRodoviario_v2.00.xsd");
+                            Validador.Valida(xmlModal, "cteModalRodoviario_v2.00.xsd", configuracaoServico);
                         }
 
                         if (cte.infCte.infCTeNorm.infModal.ContainerModal.GetType() == typeof(multimodal))
                         {
-                            Validador.Valida(xmlModal, "cteMultimodal_v2.00.xsd");
+                            Validador.Valida(xmlModal, "cteMultimodal_v2.00.xsd", configuracaoServico);
                         }
                         break;
                     case versaoModal.veM300:
                         if (cte.infCte.infCTeNorm.infModal.ContainerModal.GetType() == typeof(aereo))
                         {
-                            Validador.Valida(xmlModal, "cteModalAereo_v3.00.xsd");
+                            Validador.Valida(xmlModal, "cteModalAereo_v3.00.xsd", configuracaoServico);
                         }
 
                         if (cte.infCte.infCTeNorm.infModal.ContainerModal.GetType() == typeof(aquav))
                         {
-                            Validador.Valida(xmlModal, "cteModalAquaviario_v3.00.xsd");
+                            Validador.Valida(xmlModal, "cteModalAquaviario_v3.00.xsd", configuracaoServico);
                         }
 
                         if (cte.infCte.infCTeNorm.infModal.ContainerModal.GetType() == typeof(duto))
                         {
-                            Validador.Valida(xmlModal, "cteModalDutoviario_v3.00.xsd");
+                            Validador.Valida(xmlModal, "cteModalDutoviario_v3.00.xsd", configuracaoServico);
                         }
 
                         if (cte.infCte.infCTeNorm.infModal.ContainerModal.GetType() == typeof(ferrov))
                         {
-                            Validador.Valida(xmlModal, "cteModalFerroviario_v3.00.xsd");
+                            Validador.Valida(xmlModal, "cteModalFerroviario_v3.00.xsd", configuracaoServico);
                         }
 
                         if (cte.infCte.infCTeNorm.infModal.ContainerModal.GetType() == typeof(rodo))
                         {
-                            Validador.Valida(xmlModal, "cteModalRodoviario_v3.00.xsd");
+                            Validador.Valida(xmlModal, "cteModalRodoviario_v3.00.xsd", configuracaoServico);
                         }
 
                         if (cte.infCte.infCTeNorm.infModal.ContainerModal.GetType() == typeof(multimodal))
                         {
-                            Validador.Valida(xmlModal, "cteMultimodal_v3.00.xsd");
+                            Validador.Valida(xmlModal, "cteMultimodal_v3.00.xsd", configuracaoServico);
                         }
 
                         if (cte.infCte.infCTeNorm.infModal.ContainerModal.GetType() == typeof(rodoOS))
                         {
-                            Validador.Valida(xmlModal, "cteModalRodoviarioOS_v.3.00.xsd");
+                            Validador.Valida(xmlModal, "cteModalRodoviarioOS_v.3.00.xsd", configuracaoServico);
                         }
                         break;
                     default:
@@ -190,12 +191,13 @@ namespace CTe.Utils.CTe
         ///     Assina um objeto CTe
         /// </summary>
         /// <param name="cte"></param>
+        /// <param name="configuracaoServico"></param>
         /// <returns>Retorna um objeto do tipo CTe assinado</returns>
-        public static void Assina(this CteEletronica cte)
+        public static void Assina(this CteEletronica cte, ConfiguracaoServico configuracaoServico = null)
         {
             if (cte == null) throw new ArgumentNullException("cte");
 
-            var configuracaoServico = ConfiguracaoServico.Instancia;
+            var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
 
             var modeloDocumentoFiscal = cte.infCte.ide.mod;
             var tipoEmissao = (int)cte.infCte.ide.tpEmis;
@@ -209,10 +211,10 @@ namespace CTe.Utils.CTe
             var dadosChave = ChaveFiscal.ObterChave(estado, dataEHoraEmissao, cnpj, modeloDocumentoFiscal, serie, numeroDocumento, tipoEmissao, codigoNumerico);
 
             cte.infCte.Id = "CTe" + dadosChave.Chave;
-            cte.infCte.versao = configuracaoServico.VersaoLayout;
+            cte.infCte.versao = configServico.VersaoLayout;
             cte.infCte.ide.cDV = dadosChave.DigitoVerificador;
 
-            var assinatura = AssinaturaDigital.Assina(cte, cte.infCte.Id, configuracaoServico.X509Certificate2);
+            var assinatura = AssinaturaDigital.Assina(cte, cte.infCte.Id, configServico.X509Certificate2);
 
             cte.Signature = assinatura;
         }
@@ -223,9 +225,9 @@ namespace CTe.Utils.CTe
             return chave;
         }
 
-        public static void SalvarXmlEmDisco(this CteEletronica cte)
+        public static void SalvarXmlEmDisco(this CteEletronica cte, ConfiguracaoServico configuracaoServico = null)
         {
-            var instanciaServico = ConfiguracaoServico.Instancia;
+            var instanciaServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
 
             if (instanciaServico.NaoSalvarXml()) return;
 

--- a/Shared.CTe.Utils/CTe/ExtEnvCte.cs
+++ b/Shared.CTe.Utils/CTe/ExtEnvCte.cs
@@ -45,17 +45,17 @@ namespace CTe.Utils.CTe
 {
     public static class ExtEnvCte
     {
-        public static void ValidaSchema(this enviCTe enviCTe)
+        public static void ValidaSchema(this enviCTe enviCTe, ConfiguracaoServico configuracaoServico = null)
         {
             var xmlValidacao = enviCTe.ObterXmlString();
 
             switch (enviCTe.versao)
             {
                 case versao.ve200:
-                    Validador.Valida(xmlValidacao, "enviCTe_v2.00.xsd");
+                    Validador.Valida(xmlValidacao, "enviCTe_v2.00.xsd", configuracaoServico);
                     break;
                 case versao.ve300:
-                    Validador.Valida(xmlValidacao, "enviCTe_v3.00.xsd");
+                    Validador.Valida(xmlValidacao, "enviCTe_v3.00.xsd", configuracaoServico);
                     break;
                 default:
                     throw new InvalidOperationException("Nos achamos um erro na hora de validar o schema, " +
@@ -74,9 +74,9 @@ namespace CTe.Utils.CTe
             return FuncoesXml.ClasseParaXmlString(pedEnvio);
         }
 
-        public static void SalvarXmlEmDisco(this enviCTe enviCte)
+        public static void SalvarXmlEmDisco(this enviCTe enviCte, ConfiguracaoServico configuracaoServico = null)
         {
-            var instanciaServico = ConfiguracaoServico.Instancia;
+            var instanciaServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
 
             if (instanciaServico.NaoSalvarXml()) return;
 
@@ -87,13 +87,15 @@ namespace CTe.Utils.CTe
             FuncoesXml.ClasseParaArquivoXml(enviCte, arquivoSalvar);
         }
 
-        public static XmlDocument CriaRequestWs(this enviCTe enviCTe)
+        public static XmlDocument CriaRequestWs(this enviCTe enviCTe, ConfiguracaoServico configuracaoServico = null)
         {
             var request = new XmlDocument();
 
             var xml = enviCTe.ObterXmlString();
+            
+            var instanciaServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
 
-            if (ConfiguracaoServico.Instancia.cUF == Estado.PR)
+            if (instanciaServico.cUF == Estado.PR)
                 //Caso o lote seja enviado para o PR, colocar o namespace nos elementos <CTe> do lote, pois o serviço do PR o exige, conforme https://github.com/adeniltonbs/Zeus.Net.NFe.NFCe/issues/456
                 xml = xml.Replace("<CTe>", "<CTe xmlns=\"http://www.portalfiscal.inf.br/cte\">");
 

--- a/Shared.CTe.Utils/DistribuicaoDFe/ExtdistDFeInt.cs
+++ b/Shared.CTe.Utils/DistribuicaoDFe/ExtdistDFeInt.cs
@@ -52,18 +52,18 @@ namespace CTe.Utils.DistribuicaoDFe
             return FuncoesXml.ClasseParaXmlString(pedDistDFeInt);
         }
 
-        public static void ValidaSchema(this distDFeInt pedDistDFeInt)
+        public static void ValidaSchema(this distDFeInt pedDistDFeInt, ConfiguracaoServico configuracaoServico = null)
         {
             var xmlValidacao = pedDistDFeInt.ObterXmlString();
             
 
             if (pedDistDFeInt.versao.Equals("1.00"))
             {
-                Validador.Valida(xmlValidacao, "retDistDFeInt_v1.00.xsd");
+                Validador.Valida(xmlValidacao, "retDistDFeInt_v1.00.xsd", configuracaoServico);
             }
             else if (pedDistDFeInt.versao.Equals("1.10"))
             {
-                Validador.Valida(xmlValidacao, "retDistDFeInt_v1.10.xsd");
+                Validador.Valida(xmlValidacao, "retDistDFeInt_v1.10.xsd", configuracaoServico);
             }
             else
             {
@@ -74,9 +74,9 @@ namespace CTe.Utils.DistribuicaoDFe
         }
 
 
-        public static void SalvarXmlEmDisco(this distDFeInt pedDistDFeInt, string arquivoSalvar)
+        public static void SalvarXmlEmDisco(this distDFeInt pedDistDFeInt, string arquivoSalvar, ConfiguracaoServico configuracaoServico = null)
         {
-            var instanciaServico = ConfiguracaoServico.Instancia;
+            var instanciaServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
 
             if (instanciaServico.NaoSalvarXml()) return;
 

--- a/Shared.CTe.Utils/Evento/Extevento.cs
+++ b/Shared.CTe.Utils/Evento/Extevento.cs
@@ -60,27 +60,29 @@ namespace CTe.Utils.Evento
         ///     Assina um objeto evento
         /// </summary>
         /// <param name="eventoCTe"></param>
+        /// <param name="configuracaoServico"></param>
         /// <returns>Retorna um objeto do tipo evento assinado</returns>
-        public static void Assina(this eventoCTe eventoCTe)
+        public static void Assina(this eventoCTe eventoCTe, ConfiguracaoServico configuracaoServico = null)
         {
+            var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
             if (eventoCTe.infEvento.Id == null)
                 throw new Exception("Não é possível assinar um objeto evento sem sua respectiva Id!");
 
             eventoCTe.Signature = AssinaturaDigital.Assina(eventoCTe, eventoCTe.infEvento.Id,
-                ConfiguracaoServico.Instancia.X509Certificate2);
+                configServico.X509Certificate2);
         }
 
-        public static void ValidarSchema(this eventoCTe eventoCTe)
+        public static void ValidarSchema(this eventoCTe eventoCTe, ConfiguracaoServico configuracaoServico = null)
         {
             var xmlEvento = eventoCTe.ObterXmlString();
 
             switch (eventoCTe.versao)
             {
                 case versao.ve200:
-                    Validador.Valida(xmlEvento, "eventoCTe_v2.00.xsd");
+                    Validador.Valida(xmlEvento, "eventoCTe_v2.00.xsd", configuracaoServico);
                     break;
                 case versao.ve300:
-                    Validador.Valida(xmlEvento, "eventoCTe_v3.00.xsd");
+                    Validador.Valida(xmlEvento, "eventoCTe_v3.00.xsd", configuracaoServico);
                     break;
                 default:
                     throw new InvalidOperationException("Nos achamos um erro na hora de validar o schema, " +
@@ -88,10 +90,10 @@ namespace CTe.Utils.Evento
                                                    "versão 2.00 é 3.00");
             }
 
-            ValidarSchemaEventoContainer(eventoCTe.infEvento.detEvento.EventoContainer, eventoCTe.versao);
+            ValidarSchemaEventoContainer(eventoCTe.infEvento.detEvento.EventoContainer, eventoCTe.versao, configuracaoServico);
         }
 
-        private static void ValidarSchemaEventoContainer(EventoContainer container, versao versao)
+        private static void ValidarSchemaEventoContainer(EventoContainer container, versao versao, ConfiguracaoServico configuracaoServico = null)
         {
             if (container.GetType() == typeof(evCancCTe))
             {
@@ -102,10 +104,10 @@ namespace CTe.Utils.Evento
                 switch (versao)
                 {
                     case versao.ve200:
-                        Validador.Valida(xmlEventoCancelamento, "evCancCTe_v2.00.xsd");
+                        Validador.Valida(xmlEventoCancelamento, "evCancCTe_v2.00.xsd", configuracaoServico);
                         break;
                     case versao.ve300:
-                        Validador.Valida(xmlEventoCancelamento, "evCancCTe_v3.00.xsd");
+                        Validador.Valida(xmlEventoCancelamento, "evCancCTe_v3.00.xsd", configuracaoServico);
                         break;
                     default:
                         throw new InvalidOperationException("Nos achamos um erro na hora de validar o schema, " +
@@ -125,10 +127,10 @@ namespace CTe.Utils.Evento
                 switch (versao)
                 {
                     case versao.ve200:
-                        Validador.Valida(xmlEventoCCe, "evCCeCTe_v2.00.xsd");
+                        Validador.Valida(xmlEventoCCe, "evCCeCTe_v2.00.xsd", configuracaoServico);
                         break;
                     case versao.ve300:
-                        Validador.Valida(xmlEventoCCe, "evCCeCTe_v3.00.xsd");
+                        Validador.Valida(xmlEventoCCe, "evCCeCTe_v3.00.xsd", configuracaoServico);
                         break;
                     default:
                         throw new InvalidOperationException("Nos achamos um erro na hora de validar o schema, " +
@@ -146,10 +148,10 @@ namespace CTe.Utils.Evento
                 switch (versao)
                 {
                     case versao.ve200:
-                        Validador.Valida(xmlEventoCCe, "evPrestDesacordo_v2.00.xsd");
+                        Validador.Valida(xmlEventoCCe, "evPrestDesacordo_v2.00.xsd", configuracaoServico);
                         break;
                     case versao.ve300:
-                        Validador.Valida(xmlEventoCCe, "evPrestDesacordo_v3.00.xsd");
+                        Validador.Valida(xmlEventoCCe, "evPrestDesacordo_v3.00.xsd", configuracaoServico);
                         break;
                     default:
                         throw new InvalidOperationException("Nos achamos um erro na hora de validar o schema, " +
@@ -159,9 +161,9 @@ namespace CTe.Utils.Evento
             }
         }
 
-        public static void SalvarXmlEmDisco(this eventoCTe eventoCTe)
+        public static void SalvarXmlEmDisco(this eventoCTe eventoCTe, ConfiguracaoServico configuracaoServico = null)
         {
-            var instanciaServico = ConfiguracaoServico.Instancia;
+            var instanciaServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
 
             if (instanciaServico.NaoSalvarXml()) return;
 

--- a/Shared.CTe.Utils/Evento/ExtretEnvEvento.cs
+++ b/Shared.CTe.Utils/Evento/ExtretEnvEvento.cs
@@ -61,9 +61,9 @@ namespace CTe.Utils.Evento
             return FuncoesXml.ClasseParaXmlString(retEnvEvento);
         }
 
-        public static void SalvarXmlEmDisco(this retEventoCTe retEnviCte)
+        public static void SalvarXmlEmDisco(this retEventoCTe retEnviCte, ConfiguracaoServico configuracaoServico = null)
         {
-            var instanciaServico = ConfiguracaoServico.Instancia;
+            var instanciaServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
 
             if (instanciaServico.NaoSalvarXml()) return;
 

--- a/Shared.CTe.Utils/Extencoes/ExtConsReciCTe.cs
+++ b/Shared.CTe.Utils/Extencoes/ExtConsReciCTe.cs
@@ -43,17 +43,17 @@ namespace CTe.Utils.Extencoes
 {
     public static class ExtConsReciCTe
     {
-        public static void ValidarSchema(this consReciCTe consReciCTe)
+        public static void ValidarSchema(this consReciCTe consReciCTe, ConfiguracaoServico configuracaoServico = null)
         {
             var xmlValidacao = consReciCTe.ObterXmlString();
 
             switch (consReciCTe.versao)
             {
                 case versao.ve200:
-                    Validador.Valida(xmlValidacao, "consReciCTe_v2.00.xsd");
+                    Validador.Valida(xmlValidacao, "consReciCTe_v2.00.xsd", configuracaoServico);
                     break;
                 case versao.ve300:
-                    Validador.Valida(xmlValidacao, "consReciCTe_v3.00.xsd");
+                    Validador.Valida(xmlValidacao, "consReciCTe_v3.00.xsd", configuracaoServico);
                     break;
                 default:
                     throw new InvalidOperationException("Nos achamos um erro na hora de validar o schema, " +
@@ -72,9 +72,9 @@ namespace CTe.Utils.Extencoes
             return FuncoesXml.ClasseParaXmlString(consReciCTe);
         }
 
-        public static void SalvarXmlEmDisco(this consReciCTe consReciCTe)
+        public static void SalvarXmlEmDisco(this consReciCTe consReciCTe, ConfiguracaoServico configuracaoServico = null)
         {
-            var instanciaServico = ConfiguracaoServico.Instancia;
+            var instanciaServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
 
             if (instanciaServico.NaoSalvarXml()) return;
 
@@ -95,9 +95,9 @@ namespace CTe.Utils.Extencoes
 
 
         // Salvar Retorno de Envio de Recibo
-        public static void SalvarXmlEmDisco(this retConsReciCTe retConsReciCTe)
+        public static void SalvarXmlEmDisco(this retConsReciCTe retConsReciCTe, ConfiguracaoServico configuracaoServico = null)
         {
-            var instanciaServico = ConfiguracaoServico.Instancia;
+            var instanciaServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
 
             if (instanciaServico.NaoSalvarXml()) return;
 

--- a/Shared.CTe.Utils/Extencoes/ExtconsSitCTe.cs
+++ b/Shared.CTe.Utils/Extencoes/ExtconsSitCTe.cs
@@ -44,17 +44,17 @@ namespace CTe.Utils.Extencoes
     public static class ExtconsSitCTe
     {
 
-        public static void ValidarSchema(this consSitCTe consSitCTe)
+        public static void ValidarSchema(this consSitCTe consSitCTe, ConfiguracaoServico configuracaoServico = null)
         {
             var xmlValidacao = consSitCTe.ObterXmlString();
 
             switch (consSitCTe.versao)
             {
                 case versao.ve200:
-                    Validador.Valida(xmlValidacao, "consSitCTe_v2.00.xsd");
+                    Validador.Valida(xmlValidacao, "consSitCTe_v2.00.xsd", configuracaoServico);
                     break;
                 case versao.ve300:
-                    Validador.Valida(xmlValidacao, "consSitCTe_v3.00.xsd");
+                    Validador.Valida(xmlValidacao, "consSitCTe_v3.00.xsd", configuracaoServico);
                     break;
                 default: throw new InvalidOperationException("Nos achamos um erro na hora de validar o schema, " +
                                                         "a versão está inválida, somente é permitido " +
@@ -72,9 +72,9 @@ namespace CTe.Utils.Extencoes
             return FuncoesXml.ClasseParaXmlString(pedConsulta);
         }
 
-        public static void SalvarXmlEmDisco(this consSitCTe statuServCte)
+        public static void SalvarXmlEmDisco(this consSitCTe statuServCte, ConfiguracaoServico configuracaoServico = null)
         {
-            var instanciaServico = ConfiguracaoServico.Instancia;
+            var instanciaServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
 
             if (instanciaServico.NaoSalvarXml()) return;
 

--- a/Shared.CTe.Utils/Extencoes/ExtconsStatServCte.cs
+++ b/Shared.CTe.Utils/Extencoes/ExtconsStatServCte.cs
@@ -43,17 +43,17 @@ namespace CTe.Utils.Extencoes
 {
     public static class ExtconsStatServCte
     {
-        public static void ValidarSchema(this consStatServCte consStatServCte)
+        public static void ValidarSchema(this consStatServCte consStatServCte, ConfiguracaoServico configuracaoServico = null)
         {
             var xmlValidacao = consStatServCte.ObterXmlString();
 
             switch (consStatServCte.versao)
             {
                 case versao.ve200:
-                    Validador.Valida(xmlValidacao, "consStatServCTe_v2.00.xsd");
+                    Validador.Valida(xmlValidacao, "consStatServCTe_v2.00.xsd", configuracaoServico);
                     break;
                 case versao.ve300:
-                    Validador.Valida(xmlValidacao, "consStatServCTe_v3.00.xsd");
+                    Validador.Valida(xmlValidacao, "consStatServCTe_v3.00.xsd", configuracaoServico);
                     break;
                 default:
                     throw new InvalidOperationException("Nos achamos um erro na hora de validar o schema, " +
@@ -72,9 +72,9 @@ namespace CTe.Utils.Extencoes
             return FuncoesXml.ClasseParaXmlString(pedStatus);
         }
 
-        public static void SalvarXmlEmDisco(this consStatServCte statuServCte)
+        public static void SalvarXmlEmDisco(this consStatServCte statuServCte, ConfiguracaoServico configuracaoServico = null)
         {
-            var instanciaServico = ConfiguracaoServico.Instancia;
+            var instanciaServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
 
             if (instanciaServico.NaoSalvarXml()) return;
 

--- a/Shared.CTe.Utils/Extencoes/ExtinutCTe.cs
+++ b/Shared.CTe.Utils/Extencoes/ExtinutCTe.cs
@@ -44,12 +44,12 @@ namespace CTe.Utils.Extencoes
 {
     public static class ExtinutCTe
     {
-        public static void Assinar(this inutCTe inutCTe)
+        public static void Assinar(this inutCTe inutCTe, ConfiguracaoServico configuracaoServico = null)
         {
-            var configuracaoServico = ConfiguracaoServico.Instancia;
+            var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
 
             inutCTe.Signature = AssinaturaDigital.Assina(inutCTe, inutCTe.infInut.Id,
-                configuracaoServico.X509Certificate2);
+                configServico.X509Certificate2);
         }
 
 
@@ -63,7 +63,7 @@ namespace CTe.Utils.Extencoes
             return FuncoesXml.ClasseParaXmlString(pedInutilizacao);
         }
 
-        public static void ValidarShcema(this inutCTe inutCTe)
+        public static void ValidarShcema(this inutCTe inutCTe, ConfiguracaoServico configuracaoServico = null)
         {
 
             var xmlValidacao = inutCTe.ObterXmlString();
@@ -71,10 +71,10 @@ namespace CTe.Utils.Extencoes
             switch (inutCTe.versao)
             {
                 case versao.ve200:
-                    Validador.Valida(xmlValidacao, "inutCTe_v2.00.xsd");
+                    Validador.Valida(xmlValidacao, "inutCTe_v2.00.xsd", configuracaoServico);
                     break;
                 case versao.ve300:
-                    Validador.Valida(xmlValidacao, "inutCTe_v3.00.xsd");
+                    Validador.Valida(xmlValidacao, "inutCTe_v3.00.xsd", configuracaoServico);
                     break;
                 default:
                     throw new InvalidOperationException("Nos achamos um erro na hora de validar o schema, " +
@@ -83,9 +83,9 @@ namespace CTe.Utils.Extencoes
             }
         }
 
-        public static void SalvarXmlEmDisco(this inutCTe inutCTe)
+        public static void SalvarXmlEmDisco(this inutCTe inutCTe, ConfiguracaoServico configuracaoServico = null)
         {
-            var instanciaServico = ConfiguracaoServico.Instancia;
+            var instanciaServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
 
             if (instanciaServico.NaoSalvarXml()) return;
 

--- a/Shared.CTe.Utils/Extencoes/ExtretConsSitCTe.cs
+++ b/Shared.CTe.Utils/Extencoes/ExtretConsSitCTe.cs
@@ -61,13 +61,13 @@ namespace CTe.Utils.Extencoes
             return FuncoesXml.ClasseParaXmlString(retConsSitCTe);
         }
 
-        public static void SalvarXmlEmDisco(this retConsSitCTe retConsSitCTe, string chave)
+        public static void SalvarXmlEmDisco(this retConsSitCTe retConsSitCTe, string chave, ConfiguracaoServico configuracaoServico = null)
         {
-            var configuracaoServico = ConfiguracaoServico.Instancia;
+            var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
 
-            if (configuracaoServico.NaoSalvarXml()) return;
+            if (configServico.NaoSalvarXml()) return;
 
-            var caminhoXml = configuracaoServico.DiretorioSalvarXml;
+            var caminhoXml = configServico.DiretorioSalvarXml;
 
             var arquivoSalvar = Path.Combine(caminhoXml, chave + "-sit.xml");
 

--- a/Shared.CTe.Utils/Extencoes/ExtretConsStatServCte.cs
+++ b/Shared.CTe.Utils/Extencoes/ExtretConsStatServCte.cs
@@ -40,9 +40,9 @@ namespace CTe.Utils.Extencoes
 {
     public static class ExtretConsStatServCte
     {
-        public static void SalvarXmlEmDisco(this retConsStatServCte retConsStatServCte)
+        public static void SalvarXmlEmDisco(this retConsStatServCte retConsStatServCte, ConfiguracaoServico configuracaoServico = null)
         {
-            var instanciaServico = ConfiguracaoServico.Instancia;
+            var instanciaServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
 
             if (instanciaServico.NaoSalvarXml()) return;
 

--- a/Shared.CTe.Utils/Inutilizacao/ExtretInutCTe.cs
+++ b/Shared.CTe.Utils/Inutilizacao/ExtretInutCTe.cs
@@ -62,9 +62,9 @@ namespace CTe.Utils.Inutilizacao
         }
 
         
-        public static void SalvarXmlEmDisco(this retInutCTe retInutCTe, string chaveNome)
+        public static void SalvarXmlEmDisco(this retInutCTe retInutCTe, string chaveNome, ConfiguracaoServico configuracaoServico = null)
         {
-            var instanciaServico = ConfiguracaoServico.Instancia;
+            var instanciaServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
 
             if (instanciaServico.NaoSalvarXml()) return;
 

--- a/Shared.CTe.Utils/Recepcao/ExtretEnviCTe.cs
+++ b/Shared.CTe.Utils/Recepcao/ExtretEnviCTe.cs
@@ -61,9 +61,9 @@ namespace CTe.Utils.Recepcao
             return FuncoesXml.ClasseParaXmlString(retEnviCte);
         }
 
-        public static void SalvarXmlEmDisco(this retEnviCte retEnviCte)
+        public static void SalvarXmlEmDisco(this retEnviCte retEnviCte, ConfiguracaoServico configuracaoServico = null)
         {
-            var instanciaServico = ConfiguracaoServico.Instancia;
+            var instanciaServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
 
             if (instanciaServico.NaoSalvarXml()) return;
 

--- a/Shared.CTe.Utils/Validacao/Validador.cs
+++ b/Shared.CTe.Utils/Validacao/Validador.cs
@@ -41,9 +41,9 @@ namespace CTe.Utils.Validacao
 {
     public static class Validador
     {
-        public static void Valida(string xml, string schema)
+        public static void Valida(string xml, string schema, ConfiguracaoServico configuracaoServico = null)
         {
-            var servicoInstancia = ConfiguracaoServico.Instancia;
+            var servicoInstancia = configuracaoServico ?? ConfiguracaoServico.Instancia;
 
             var pathSchema = servicoInstancia.DiretorioSchemas;
 

--- a/Shared.NFe.Utils/Assinatura/Assinador.cs
+++ b/Shared.NFe.Utils/Assinatura/Assinador.cs
@@ -49,12 +49,11 @@ namespace NFe.Utils.Assinatura
         /// <typeparam name="T">Tipo do objeto a ser assinado</typeparam>
         /// <param name="objeto">Objeto a ser assinado</param>
         /// <param name="id">Id para URI do objeto <see cref="Signature"/></param>
-        /// <param name="cfgServico">Configuração do serviço</param>
+        /// <param name="configuracaoServico">Configuração do serviço</param>
         /// <returns>Retorna um objeto do tipo Classes.Assinatura.Signature, contendo a assinatura do objeto passado como parâmetro</returns>
-        public static Signature ObterAssinatura<T>(T objeto, string id, ConfiguracaoServico cfgServico = null) where T : class
+        public static Signature ObterAssinatura<T>(T objeto, string id, ConfiguracaoServico configuracaoServico = null) where T : class
         {
-            if (cfgServico == null)
-                cfgServico = ConfiguracaoServico.Instancia;
+            var cfgServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
 
             X509Certificate2 certificadoDigital = null;
             try


### PR DESCRIPTION
- Alteração necessária para utilização do Zeus CTe em uma estrutura de serviço de envio de CTe na nuvem, onde vários clientes usam o mesmo serviço, logo um objeto global de configuração poderia gerar conflito caso dois usuários de duas empresas diferentes realizem alguma ação em paralelo.

- Criada possibilidade de não usar o objeto global ConfiguracaoServico.Instancia, para tal, basta criar um objeto ConfiguracaoServico e passar via parâmetro para as funções do CTe.
- Refatorada todas as classes que precisavam do ConfiguracaoServico.Instancia.
- Agora é verificado se o parâmetro utilizado é null ou não. Se for, utiliza o ConfiguracaoServico.Instancia.
- Devido a arquitetura atual, caso deseje utilziar este parâmetro, é necessário criar o ojeto "ide" e o objeto "infEventoEnv" passando o objeto de configuração no construtor.

Signed-off-by: eduardo.sikora <eduardo.sikora@viasoft.com.br>