### PR TITLE
Caso não seja preenchida a tag opcional nPeso nos dados da NF em um CT-e, o Zeus gera o XML com valor inválido.

### DIFF
--- a/Shared.CTe.Classes/Informacoes/infCTeNormal/infDocumentos/infNF.cs
+++ b/Shared.CTe.Classes/Informacoes/infCTeNormal/infDocumentos/infNF.cs
@@ -104,7 +104,7 @@ namespace CTe.Classes.Informacoes.infCTeNormal.infDocumentos
 
         public int nCFOP { get; set; }
 
-        public decimal nPeso
+        public decimal? nPeso
         {
             get { return _nPeso.Arredondar(3); }
             set { _nPeso = value.Arredondar(3); }
@@ -144,6 +144,6 @@ namespace CTe.Classes.Informacoes.infCTeNormal.infDocumentos
         private decimal _vSt;
         private decimal _vProd;
         private decimal _vNf;
-        private decimal _nPeso;
+        private decimal? _nPeso;
     }
 }


### PR DESCRIPTION
- Alteração para tornar a tag nPeso opcional, visto que o valor 0.000 não é válido no manual da receita federal.

![image](https://user-images.githubusercontent.com/21113262/60194271-5cc73000-980f-11e9-8e85-cfbc1bd9acd7.png)

- A tag nPeso utiliza a validação de xml TDec_1203Opc cujo o regex é o seguinte:
![image](https://user-images.githubusercontent.com/21113262/60194337-7ff1df80-980f-11e9-886d-1f1c4c9f9a07.png)

- Da maneira atual, o seguinte erro é apontado ao tentar emitir o CT-e:
"Erros da validação : The 'http://www.portalfiscal.inf.br/cte:nPeso' element is invalid - 
The value '0.000' is invalid according to its datatype 'http://www.portalfiscal.inf.br/cte:TDec_1203Opc' - The Pattern constraint failed."

Signed-off-by: eduardo.sikora <eduardo.sikora@viasoft.com.br>