### PR TITLE
Falta do número de série do certificado digital lança duas exceções, onde deveria ser lançado apenas uma. 

### DIFF
--- a/Shared.NFe.Utils/Assinatura/Assinador.cs
+++ b/Shared.NFe.Utils/Assinatura/Assinador.cs
@@ -64,7 +64,7 @@ namespace NFe.Utils.Assinatura
             finally
             {
                 if (!cfgServico.Certificado.ManterDadosEmCache)
-                    certificadoDigital.Reset();
+                    certificadoDigital?.Reset();
             }
         }
 


### PR DESCRIPTION
Caso o certificado não seja encontrado será lançado uma exceção notificando sua falta, porém será lançada outra exceção ('Referência de objeto não definida para uma instância de um objeto.') visto que não será possível aplicar o Reset() ao objeto 'certificadoDigital' que se encontra nulo.