### PR TITLE
Correção do datatype do campo "serie" da Occ

### DIFF
--- a/Shared.CTe.Classes/Informacoes/infCTeNormal/infModals/rodoviario/occ.cs
+++ b/Shared.CTe.Classes/Informacoes/infCTeNormal/infModals/rodoviario/occ.cs
@@ -39,7 +39,7 @@ namespace CTe.Classes.Informacoes.infCTeNormal.infModals.rodoviario
 {
     public class occ
     {
-        public short? serie { get; set; }
+        public string serie { get; set; }
         public bool serieSpecified {
             get { return serie.HasValue; }
         }


### PR DESCRIPTION
O parse para classe de alguns XMLs de Ctes esta gerando erros devido ao datatype do campo "serie" da Occ, pois conforme manual ( Manual_CTe_v3_00.pdf - pág.190) , o campo "serie" ( Série da OCC ) é do tipo carácter.

Conteúdo exemplo de parte específica do XML recebido pelo retDistDFeInt:

`<serie>U</serie>`
