### PR TITLE
IdCSC, suporte a números maiores que 32767 do Int16.

### DIFF
--- a/Shared.NFe.Utils/InformacoesSuplementares/ExtinfNFeSupl.cs
+++ b/Shared.NFe.Utils/InformacoesSuplementares/ExtinfNFeSupl.cs
@@ -474,7 +474,7 @@ namespace NFe.Utils.InformacoesSuplementares
             var ambiente = (int)nfe.infNFe.ide.tpAmb;
 
             //Identificador do CSC (Código de Segurança do Contribuinte no Banco de Dados da SEFAZ). Informar sem os zeros não significativos
-            var idCsc = Convert.ToInt16(cIdToken);
+            var idCsc = Convert.ToInt32(cIdToken);
 
             string dadosBase;
 

--- a/Shared.NFe.Utils/NFe/ExtNFe.cs
+++ b/Shared.NFe.Utils/NFe/ExtNFe.cs
@@ -149,7 +149,7 @@ namespace NFe.Utils.NFe
             var dadosChave = ChaveFiscal.ObterChave(estado, dataEHoraEmissao.LocalDateTime, cnpj, modeloDocumentoFiscal, serie, numeroDocumento, tipoEmissao, codigoNumerico);
 
             nfeLocal.infNFe.Id = "NFe" + dadosChave.Chave;
-            nfeLocal.infNFe.ide.cDV = Convert.ToInt16(dadosChave.DigitoVerificador);
+            nfeLocal.infNFe.ide.cDV = Convert.ToInt32(dadosChave.DigitoVerificador);
 
             Signature assinatura = null;
             if (_certificado == null)


### PR DESCRIPTION
Erro ocorre devido ao IdCSC for um número maior que o suportado pelo formato Int16, agora suportado pelo framework.