### PR TITLE
Removendo LocalDateTime ao montar os dados da chavea chave

### DIFF
--- a/Shared.NFe.Utils/NFe/ExtNFe.cs
+++ b/Shared.NFe.Utils/NFe/ExtNFe.cs
@@ -146,7 +146,7 @@ namespace NFe.Utils.NFe
             var numeroDocumento = nfeLocal.infNFe.ide.nNF;
             var serie = nfeLocal.infNFe.ide.serie;
 
-            var dadosChave = ChaveFiscal.ObterChave(estado, dataEHoraEmissao.LocalDateTime, cnpj, modeloDocumentoFiscal, serie, numeroDocumento, tipoEmissao, codigoNumerico);
+            var dadosChave = ChaveFiscal.ObterChave(estado, dataEHoraEmissao, cnpj, modeloDocumentoFiscal, serie, numeroDocumento, tipoEmissao, codigoNumerico);
 
             nfeLocal.infNFe.Id = "NFe" + dadosChave.Chave;
             nfeLocal.infNFe.ide.cDV = Convert.ToInt32(dadosChave.DigitoVerificador);


### PR DESCRIPTION
Pessoal tive o mesmo problema levantado no #570 .
Para o meu caso o cliente está em Cuiabá timezone -4:00 e o servidor está em São Paulo, timezone -3:00.
Na virada do mês, São Paulo vira o mês 1 hora antes de Cuiabá. 
O método que gera a chave da NFe utiliza a data para compor essa chave. Desse modo, a chave é gerada com informação do mês seguinte e, ao enviar para a SEFAZ, ocorre rejeição da nota.
Vi que Existia um PR tentando resolver o problema #670 mas não estava gerando a data correta.
Percebi que a data de emissão "dhemi" (dataEHoraEmissao), que é utilizada na geração da chave, estava sendo mapeada para a hora local do servidor através de "DateTimeOffset.LocalDateTime".
Removi isso "LocalDateTime" e a emissão está funcionando corretamente.
https://docs.microsoft.com/pt-br/dotnet/api/system.datetimeoffset.localdatetime?view=netframework-4.8
