### PR TITLE
Mudança do tipo do atributo verAplic de decimal para string

### DIFF
--- a/Shared.NFe.Classes/Servicos/DistribuicaoDFe/Schemas/infProt.cs
+++ b/Shared.NFe.Classes/Servicos/DistribuicaoDFe/Schemas/infProt.cs
@@ -46,7 +46,7 @@ namespace NFe.Classes.Servicos.DistribuicaoDFe.Schemas
 
         public byte tpAmb { get; set; }
 
-        public decimal verAplic { get; set; }
+        public string verAplic { get; set; }
 
         [XmlElement(DataType = "integer")]
         public string chNFe { get; set; }


### PR DESCRIPTION
Seguindo os seguintes arquivos xsd disponibilizados pela SEFAZ:
leiauteNFe_v4.00.xsd e tiposDistDFe_v1.01.xsd
Confirmei que o campo verAplic deve ser do tipo string.

Confirmação nos trechos abaixo:

Arquivo leiauteNFe_v4.00.xsd na linha 5557:
<xs:element name="verAplic" type="TVerAplic">
	<xs:annotation>
		<xs:documentation>Versão do Aplicativo que processou a NF-e</xs:documentation>
	</xs:annotation>
</xs:element>

Arquivo tiposDistDFe_v1.01.xsd na linha 132:
 <xs:simpleType name="TVerAplic">
    <xs:annotation>
      <xs:documentation>Tipo Versão do Aplicativo</xs:documentation>
    </xs:annotation>
    <xs:restriction base="TString">
      <xs:minLength value="1"/>
      <xs:maxLength value="20"/>
    </xs:restriction>
  </xs:simpleType>