### PR TITLE
Conserta erros na Validação do CTe

### DIFF
--- a/Shared.CTe.Classes/Informacoes/Impostos/ICMS/ICMS90.cs
+++ b/Shared.CTe.Classes/Informacoes/Impostos/ICMS/ICMS90.cs
@@ -44,18 +44,19 @@ namespace CTe.Classes.Informacoes.Impostos.ICMS
             CST = CST.ICMS90;
         }
 
-        private decimal _pRedBc;
+        private decimal? _pRedBc;
         private decimal _vBc;
         private decimal _pIcms;
         private decimal _vIcms;
         private decimal _vCred;
         public CST CST { get; set; }
 
-        public decimal pRedBC
+        public decimal? pRedBC
         {
-            get { return _pRedBc.Arredondar(2); }
-            set { _pRedBc = value.Arredondar(2); }
+            get { return _pRedBc?.Arredondar(2); }
+            set { _pRedBc = value?.Arredondar(2); }
         }
+        public bool pRedBCSpecified { get { return pRedBC.HasValue; } }
 
         public decimal vBC
         {

--- a/Shared.CTe.Classes/Informacoes/Impostos/ICMS/ICMSOutraUF.cs
+++ b/Shared.CTe.Classes/Informacoes/Impostos/ICMS/ICMSOutraUF.cs
@@ -44,17 +44,19 @@ namespace CTe.Classes.Informacoes.Impostos.ICMS
             CST = CST.ICMS90;
         }
 
-        private decimal _pRedBcOutraUf;
+        private decimal? _pRedBcOutraUf;
         private decimal _vBcOutraUf;
         private decimal _pIcmsOutraUf;
         private decimal _vIcmsOutraUf;
         public CST CST { get; set; }
 
-        public decimal pRedBCOutraUF
+        public decimal? pRedBCOutraUF
         {
             get { return _pRedBcOutraUf.Arredondar(2); }
             set { _pRedBcOutraUf = value.Arredondar(2); }
         }
+
+        public bool pRedBCOutraUFSpecified { get { return pRedBCOutraUF.HasValue; } }
 
         public decimal vBCOutraUF
         {

--- a/Shared.CTe.Classes/Informacoes/infCTeNormal/infDocumentos/infNFe.cs
+++ b/Shared.CTe.Classes/Informacoes/infCTeNormal/infDocumentos/infNFe.cs
@@ -40,7 +40,10 @@ namespace CTe.Classes.Informacoes.infCTeNormal.infDocumentos
 {
     public class infNFe
     {
+        [XmlElement(Order = 1)]
         public string chave { get; set; }
+
+        [XmlElement(Order = 2)]
         public string PIN { get; set; }
 
         [XmlIgnore]
@@ -49,7 +52,7 @@ namespace CTe.Classes.Informacoes.infCTeNormal.infDocumentos
         /// <summary>
         /// Proxy para dPrev no formato AAAA-MM-DD
         /// </summary>
-        [XmlElement(ElementName = "dPrev")]
+        [XmlElement(ElementName = "dPrev", Order = 3)]
         public string ProxyddPrev
         {
             get
@@ -63,10 +66,11 @@ namespace CTe.Classes.Informacoes.infCTeNormal.infDocumentos
             set { dPrev = DateTime.Parse(value); }
         }
 
-        [XmlElement("infUnidTransp")]
+        
+        [XmlElement("infUnidTransp", Order = 5)]
         public List<infUnidTransp> infUnidTransp;
 
-        [XmlElement("infUnidCarga")]
+        [XmlElement("infUnidCarga", Order = 4)]
         public List<infUnidCarga> infUnidCarga;
     }
 }


### PR DESCRIPTION
Ao aplicar algumas notas geradas a um validador da Sefaz RS, ocorreram alguns erros de validação. São eles:

- As tags pRedBCOutraUF e pRedBC, presentes nas classes icms90 e icmsOutraUF, são opcionais conforme o schema da cte, e não devem ser preenchidas se o valor for 0. Porém, os campos da classe eram de preenchimento obrigatório.
- Ao gerar uma CTe que continha NFes atreladas, caso o campo infUnidTransp fosse preenchido, a tag chave era jogada para baixo. Porém, no schema, a tag chave deve ser a primeira tag dentro de infNFe.

Realizei então a correção desses erros de validação, tornando os  pRed como opcionais e incluindo o parâmetro de ordem de maneira que a chave seja a primeira tag.

O esquema que eu utilizei se chama "Schemas XML CT-e - Pacote de Liberação 3.00a (ZIP) (Atualizado em 01/08/2019)" e está disponível em: 
http://www.cte.fazenda.gov.br/portal/listaConteudo.aspx?tipoConteudo=0xlG1bdBass=

O validador, por sua vez, se encontra em:
https://www.sefaz.rs.gov.br/Dfe/ValidadorXml/ValidaXml