### PR TITLE
Define .NET Core 2.1 como versão minina para os projetos NFe.AppTeste

### DIFF
--- a/CTe.Dacte.Fast/DacteFrCte.cs
+++ b/CTe.Dacte.Fast/DacteFrCte.cs
@@ -64,6 +64,13 @@ namespace CTe.Dacte.Fast
             Relatorio.GetDataSource("cteProc").Enabled = true;            
         }
 
+        /// <summary>
+        /// Obtem o objeto Report para ser acoplado em outras aplicações
+        /// </summary>
+        public Report GetReport() {
+            return Relatorio;
+        }
+
         public void Configurar(ConfiguracaoDacte config)
         {
             Relatorio.SetParameterValue("DoocumentoCancelado", config.DocumentoCancelado);

--- a/CTe.Dacte.Fast/DacteFrCte.cs
+++ b/CTe.Dacte.Fast/DacteFrCte.cs
@@ -126,20 +126,24 @@ namespace CTe.Dacte.Fast
         /// Converte o DACTe para PDF e salva-o no caminho/arquivo indicado
         /// </summary>
         /// <param name="arquivo">Caminho/arquivo onde deve ser salvo o PDF do DACTe</param>
-        public void ExportarPdf(string arquivo)
-        {
+        /// <param name="progress">Padrão True. Mostra a barra de progresso de geração do PDF. </param>
+        public void ExportarPdf(string arquivo, bool progress = true) {
+            FastReport.Utils.Config.ReportSettings.ShowProgress = progress;
             Relatorio.Prepare();
-            Relatorio.Export(new PDFExport(), arquivo);
+            var varPDFExport = new PDFExport() { ShowProgress = progress };
+            Relatorio.Export(varPDFExport, arquivo);
         }
 
         /// <summary>
         /// Converte o DACTe para PDF e copia para o stream
         /// </summary>
         /// <param name="outputStream">Variável do tipo Stream para output</param>
-        public void ExportarPdf(Stream outputStream)
-        {
+        /// <param name="progress">Padrão True. Mostra a barra de progresso de geração do PDF. </param>
+        public void ExportarPdf(Stream outputStream, bool progress = true) {
+            FastReport.Utils.Config.ReportSettings.ShowProgress = progress;
             Relatorio.Prepare();
-            Relatorio.Export(new PDFExport(), outputStream);
+            var varPDFExport = new PDFExport() { ShowProgress = progress };
+            Relatorio.Export(varPDFExport, outputStream);
             outputStream.Position = 0;
         }
     }

--- a/CTe.Dacte.Fast/DacteFrEvento.cs
+++ b/CTe.Dacte.Fast/DacteFrEvento.cs
@@ -67,6 +67,14 @@ namespace CTe.Dacte.Fast
             Relatorio.GetDataSource("procEventoCTe").Enabled = true;
         }
 
+        /// <summary>
+        /// Obtem o objeto Report para ser acoplado em outras aplicações
+        /// </summary>
+        public Report GetReport() {
+            return Relatorio;
+        }
+
+
         public void Configurar(string desenvolvedor = "")
         {
             Relatorio.SetParameterValue("Desenvolvedor", desenvolvedor);

--- a/CTe.Dacte.Fast/DacteFrEvento.cs
+++ b/CTe.Dacte.Fast/DacteFrEvento.cs
@@ -119,10 +119,12 @@ namespace CTe.Dacte.Fast
         /// Converte o DAMDFe para PDF e salva-o no caminho/arquivo indicado
         /// </summary>
         /// <param name="arquivo">Caminho/arquivo onde deve ser salvo o PDF do DAMDFe</param>
-        public void ExportarPdf(string arquivo)
-        {
+        /// <param name="progress">Padrão True. Mostra a barra de progresso de geração do PDF. </param>
+        public void ExportarPdf(string arquivo, bool progress = true) {
+            FastReport.Utils.Config.ReportSettings.ShowProgress = progress;
             Relatorio.Prepare();
-            Relatorio.Export(new PDFExport(), arquivo);
+            var varPDFExport = new PDFExport() { ShowProgress = progress };
+            Relatorio.Export(varPDFExport, arquivo);
         }
     }
 }

--- a/MDFe.Damdfe.Fast/DamdfeFrMDFe.cs
+++ b/MDFe.Damdfe.Fast/DamdfeFrMDFe.cs
@@ -65,6 +65,13 @@ namespace MDFe.Damdfe.Fast
             Relatorio.GetDataSource("MDFeProcMDFe").Enabled = true;            
         }
 
+        /// <summary>
+        /// Obtem o objeto Report para ser acoplado em outras aplicações
+        /// </summary>
+        public Report GetReport() {
+            return Relatorio;
+        }
+
         public void Configurar(ConfiguracaoDamdfe config)
         {
             Relatorio.SetParameterValue("DoocumentoCancelado", config.DocumentoCancelado);

--- a/MDFe.Damdfe.Fast/DamdfeFrMDFe.cs
+++ b/MDFe.Damdfe.Fast/DamdfeFrMDFe.cs
@@ -116,20 +116,24 @@ namespace MDFe.Damdfe.Fast
         /// Converte o DAMDFe para PDF e salva-o no caminho/arquivo indicado
         /// </summary>
         /// <param name="arquivo">Caminho/arquivo onde deve ser salvo o PDF do DAMDFe</param>
-        public void ExportarPdf(string arquivo)
-        {
+        /// <param name="progress">Padrão True. Mostra a barra de progresso de geração do PDF. </param>
+        public void ExportarPdf(string arquivo, bool progress = true) {
+            FastReport.Utils.Config.ReportSettings.ShowProgress = progress;
             Relatorio.Prepare();
-            Relatorio.Export(new PDFExport(), arquivo);
+            var varPDFExport = new PDFExport() { ShowProgress = progress };
+            Relatorio.Export(varPDFExport, arquivo);
         }
 
         /// <summary>
         /// Converte o DAMDFe para PDF e copia para o stream
         /// </summary>
         /// <param name="outputStream">Variável do tipo Stream para output</param>
-        public void ExportarPdf(Stream outputStream)
-        {
+        /// <param name="progress">Padrão True. Mostra a barra de progresso de geração do PDF. </param>
+        public void ExportarPdf(Stream outputStream, bool progress = true) {
+            FastReport.Utils.Config.ReportSettings.ShowProgress = progress;
             Relatorio.Prepare();
-            Relatorio.Export(new PDFExport(), outputStream);
+            var varPDFExport = new PDFExport() { ShowProgress = progress };
+            Relatorio.Export(varPDFExport, outputStream);
             outputStream.Position = 0;
         }
     }

--- a/NFe.AppTeste.NetCore/NFe.AppTeste.NetCore.csproj
+++ b/NFe.AppTeste.NetCore/NFe.AppTeste.NetCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/NFe.Danfe.AppTeste.NetCore/NFe.Danfe.AppTeste.NetCore.csproj
+++ b/NFe.Danfe.AppTeste.NetCore/NFe.Danfe.AppTeste.NetCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/NFe.Danfe.Fast/DanfeBase.cs
+++ b/NFe.Danfe.Fast/DanfeBase.cs
@@ -89,5 +89,12 @@ namespace NFe.Danfe.Fast
             Relatorio.Export(new PDFExport(), outputStream);
             outputStream.Position = 0;
         }
+
+        /// <summary>
+        /// Obtem o objeto Report para ser acoplado em outras aplicações
+        /// </summary>
+        public Report GetReport() {
+            return Relatorio;
+        }
     }
 }

--- a/NFe.Danfe.Fast/DanfeBase.cs
+++ b/NFe.Danfe.Fast/DanfeBase.cs
@@ -77,16 +77,19 @@ namespace NFe.Danfe.Fast
         /// Converte o DANFE para PDF e salva-o no caminho/arquivo indicado
         /// </summary>
         /// <param name="arquivo">Caminho/arquivo onde deve ser salvo o PDF do DANFE</param>
-        public void ExportarPdf(string arquivo)
-        {
+        /// <param name="progress">Padrão True. Mostra a barra de progresso de geração do PDF. </param>
+        public void ExportarPdf(string arquivo, bool progress = true) {
+            FastReport.Utils.Config.ReportSettings.ShowProgress = progress;
             Relatorio.Prepare();
-            Relatorio.Export(new PDFExport(), arquivo);
+            var varPDFExport = new PDFExport() { ShowProgress = progress };
+            Relatorio.Export(varPDFExport, arquivo);
         }
 
-        public void ExportarPdf(Stream outputStream)
-        {
+        public void ExportarPdf(Stream outputStream, bool progress = true) {
+            FastReport.Utils.Config.ReportSettings.ShowProgress = progress;
             Relatorio.Prepare();
-            Relatorio.Export(new PDFExport(), outputStream);
+            var varPDFExport = new PDFExport() { ShowProgress = progress };
+            Relatorio.Export(varPDFExport, outputStream);
             outputStream.Position = 0;
         }
 

--- a/Shared.DFe.Utils/FuncoesXml.cs
+++ b/Shared.DFe.Utils/FuncoesXml.cs
@@ -46,6 +46,7 @@ namespace DFe.Utils
 
         // https://github.com/ZeusAutomacao/DFe.NET/issues/610
         private static readonly Hashtable CacheSerializers = new Hashtable();
+        private static readonly object cacheLock = new object();
 
         /// <summary>
         ///     Serializa a classe passada para uma string no form
@@ -224,16 +225,18 @@ namespace DFe.Utils
         // https://github.com/ZeusAutomacao/DFe.NET/issues/610
         private static XmlSerializer BuscarNoCache(string chave, Type type)
         {
-            if (CacheSerializers.Contains(chave))
+            lock (cacheLock)
             {
-                return (XmlSerializer)CacheSerializers[chave];
+                if (CacheSerializers.Contains(chave))
+                {
+                    return (XmlSerializer)CacheSerializers[chave];
+                }
+
+                var ser = XmlSerializer.FromTypes(new[] { type })[0];
+                CacheSerializers.Add(chave, ser);
+
+                return ser;
             }
-
-
-            var ser = XmlSerializer.FromTypes(new[] { type })[0];
-            CacheSerializers.Add(chave, ser);
-
-            return ser;
         }
     }
 }

--- a/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Municipal/ISSQN.cs
+++ b/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Municipal/ISSQN.cs
@@ -128,7 +128,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Municipal
         /// <summary>
         ///     U12 - Indicador da exigibilidade do ISS
         /// </summary>
-        public IndicadorISS indISS{ get; set; }
+        public IndicadorISS? indISS { get; set; }
 
         /// <summary>
         ///     U13 - Código do serviço prestado dentro do município
@@ -153,7 +153,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Municipal
         /// <summary>
         ///     U17 - Indicador de incentivo Fiscal
         /// </summary>
-        public indIncentivo indIncentivo { get; set; }
+        /// 
+        public indIncentivo? indIncentivo { get; set; }
 
         public bool ShouldSerializevDeducao()
         {

--- a/Shared.NFe.Danfe.Base/IDanfe.cs
+++ b/Shared.NFe.Danfe.Base/IDanfe.cs
@@ -48,8 +48,9 @@ namespace NFe.Danfe.Base
         /// Converte o DANFE para PDF e salva-o no caminho/arquivo indicado
         /// </summary>
         /// <param name="arquivo">Caminho/arquivo onde deve ser salvo o PDF do DANFE</param>
-        void ExportarPdf(string arquivo);
+        /// <param name="progress">Padrão True. Mostra a barra de progresso de geração do PDF. </param>
+        void ExportarPdf(string arquivo, bool progress = true);
 
-        void ExportarPdf(Stream outputStream);
+        void ExportarPdf(Stream outputStream, bool progress = true);
     }
 }

--- a/Zeus NFe.sln
+++ b/Zeus NFe.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28803.352
+# Visual Studio 15
+VisualStudioVersion = 15.0.27703.2042
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NFe.Classes", "NFe.Classes\NFe.Classes.csproj", "{29CA1DA2-440D-484B-951A-CF1B2EB27984}"
 EndProject


### PR DESCRIPTION
Define .NET Core 2.1 como versão mínima para os projetos NFe.AppTeste.NetCore e NFe.Danfe.App.Teste.NetCore.
Os outros projetos em NetCore já usavam .NET Core 2.1 como padrão.

Cria função para o obter o objeto [Report] do FastReport para que seja acoplado em outros projetos para visualização do DANFE, DACTE e DAMFE via componente do FastReport instalado em formulários.