### PR TITLE
Deixa Indicador ISS e indIncentivo nullable

### DIFF
--- a/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Municipal/ISSQN.cs
+++ b/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Municipal/ISSQN.cs
@@ -128,7 +128,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Municipal
         /// <summary>
         ///     U12 - Indicador da exigibilidade do ISS
         /// </summary>
-        public IndicadorISS indISS{ get; set; }
+        public IndicadorISS? indISS{ get; set; }
 
         /// <summary>
         ///     U13 - Código do serviço prestado dentro do município
@@ -153,7 +153,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Municipal
         /// <summary>
         ///     U17 - Indicador de incentivo Fiscal
         /// </summary>
-        public indIncentivo indIncentivo { get; set; }
+        public indIncentivo? indIncentivo { get; set; }
 
         public bool ShouldSerializevDeducao()
         {


### PR DESCRIPTION
Tive alguns problemas com as propriedades IndicadorISS e IndIncentivo da classe ISSQN. Na versão 2.0 da NFe não há esses dois indicadores. Se eu tentasse ignorá-los o xml não era gerado, pois atribuía-se 0 como valor default dos enums. 

As alterações realizadas foram tornar essas propriedades nullable.  

A imagem abaixo é o manual de preenchimento da versão 2.0 referente ao ISSQN. 

![image](https://user-images.githubusercontent.com/42043408/83187137-0e4ba100-a104-11ea-96ee-66cdb78263be.png)

Estou deixando o manual, a página é a 116.
[Manual_Integracao_Contribuinte_v_2.02a_2008_06_16 (1).pdf](https://github.com/ZeusAutomacao/DFe.NET/files/4697916/Manual_Integracao_Contribuinte_v_2.02a_2008_06_16.1.pdf)