### PR TITLE
Fix/danilo 1119

### DIFF
--- a/NFe.Danfe.AppTeste.NetCore/Program.cs
+++ b/NFe.Danfe.AppTeste.NetCore/Program.cs
@@ -48,6 +48,7 @@ namespace NFe.Danfe.AppTeste.NetCore
                     Console.WriteLine("4  - Gerar Danfe(Evento) PDF");
                     Console.WriteLine("5  - Gerar Danfe(Evento) HTML");
                     Console.WriteLine("6  - Gerar Danfe(Evento) Image PNG");
+                    Console.WriteLine("10  - Teste Performance Danfe HTML");
                     Console.WriteLine($"98 - Carrega logo especifica para configuração");
                     Console.WriteLine($"99 - Carrega Configuracoes do arquivo {ArquivoConfiguracao}");
 
@@ -78,6 +79,9 @@ namespace NFe.Danfe.AppTeste.NetCore
                         case 6:
                             await GerarDanfeEventoPng();
                             break;
+                        case 10:
+                            await TestePerformanceDanfeHtml();
+                            break;
                         case 98:
                             await CarregarLogoConfiguracao();
                             break;
@@ -101,7 +105,7 @@ namespace NFe.Danfe.AppTeste.NetCore
             string path = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
 
             try
-            
+
             {
                 _configuracoes = !File.Exists(path + ArquivoConfiguracao)
                                 ? new ConfiguracaoConsole()
@@ -122,7 +126,7 @@ namespace NFe.Danfe.AppTeste.NetCore
 
             {
                 _configuracoes.ConfiguracaoDanfeNfe.Logomarca = !File.Exists(path)
-                                ? null
+                                ? throw new Exception("Logo não encontrada")
                                 : File.ReadAllBytes(path);
             }
             catch (Exception ex)
@@ -143,18 +147,15 @@ namespace NFe.Danfe.AppTeste.NetCore
             //busca arquivo xml
             string xml = Funcoes.BuscarArquivoXml(caminho);
 
-            using (MemoryStream stream = new MemoryStream()) // Create a stream for the report
+            try
             {
-                try
-                {
-                    var report = GeraClasseDanfeFrNFe(xml);
-                    byte[] bytes = report.ExportarPdf();
-                    Funcoes.SalvaArquivoGerado(caminho, ".pdf", bytes);
-                }
-                catch (Exception ex)
-                {
-                    throw ex;
-                }
+                var report = GeraClasseDanfeFrNFe(xml);
+                byte[] bytes = report.ExportarPdf();
+                Funcoes.SalvaArquivoGerado(caminho, ".pdf", bytes);
+            }
+            catch (Exception ex)
+            {
+                throw ex;
             }
         }
 
@@ -166,18 +167,15 @@ namespace NFe.Danfe.AppTeste.NetCore
             //busca arquivo xml
             string xml = Funcoes.BuscarArquivoXml(caminho);
 
-            using (MemoryStream stream = new MemoryStream()) // Create a stream for the report
+            try
             {
-                try
-                {
-                    var report = GeraClasseDanfeFrNFe(xml);
-                    byte[] bytes = report.ExportarHtml();
-                    Funcoes.SalvaArquivoGerado(caminho, ".html", bytes);
-                }
-                catch (Exception ex)
-                {
-                    throw ex;
-                }
+                var report = GeraClasseDanfeFrNFe(xml);
+                byte[] bytes = report.ExportarHtml();
+                Funcoes.SalvaArquivoGerado(caminho, ".html", bytes);
+            }
+            catch (Exception ex)
+            {
+                throw ex;
             }
         }
 
@@ -189,13 +187,49 @@ namespace NFe.Danfe.AppTeste.NetCore
             //busca arquivo xml
             string xml = Funcoes.BuscarArquivoXml(caminho);
 
+            try
+            {
+                var report = GeraClasseDanfeFrNFe(xml);
+                byte[] bytes = report.ExportarPng();
+                Funcoes.SalvaArquivoGerado(caminho, ".png", bytes);
+            }
+            catch (Exception ex)
+            {
+                throw ex;
+            }
+        }
+
+        private static async Task TestePerformanceDanfeHtml()
+        {
+            Console.WriteLine(@"Digite o caminho do .xml (ex: C:\arquivos\35199227357619000192550010090001111381546999.xml):");
+            string caminho = Console.ReadLine();
+
+            Console.WriteLine(@"Quantidade de relatorios: (ex: 1000)");
+            long quantidade = long.Parse(Console.ReadLine());
+
+            Console.WriteLine(@"Salva Arquivos ?: (true = SIM, false = NAO)");
+            bool salvaarquivos = bool.Parse(Console.ReadLine());
+
+            //busca arquivo xml
+            string xml = Funcoes.BuscarArquivoXml(caminho);
+
             using (MemoryStream stream = new MemoryStream()) // Create a stream for the report
             {
                 try
                 {
-                    var report = GeraClasseDanfeFrNFe(xml);
-                    byte[] bytes = report.ExportarPng();
-                    Funcoes.SalvaArquivoGerado(caminho, ".png", bytes);
+                    for (int i = 1; i <= quantidade; i++)
+                    {
+                        Console.Write("\n" + i);
+                        //no futuro é interessante calcular o tempo dos metodos abaixo... por enquanto é só visual.
+                        var report = GeraClasseDanfeFrNFe(xml);
+                        byte[] bytes = report.ExportarHtml();
+                        if (salvaarquivos)
+                        {
+                            Funcoes.SalvaArquivoGerado(caminho, ".html", bytes);
+                        }
+
+                        Console.WriteLine("...OK");
+                    }
                 }
                 catch (Exception ex)
                 {

--- a/NFe.Danfe.AppTeste.NetCore/Program.cs
+++ b/NFe.Danfe.AppTeste.NetCore/Program.cs
@@ -48,6 +48,7 @@ namespace NFe.Danfe.AppTeste.NetCore
                     Console.WriteLine("4  - Gerar Danfe(Evento) PDF");
                     Console.WriteLine("5  - Gerar Danfe(Evento) HTML");
                     Console.WriteLine("6  - Gerar Danfe(Evento) Image PNG");
+                    Console.WriteLine($"98 - Carrega logo especifica para configuração");
                     Console.WriteLine($"99 - Carrega Configuracoes do arquivo {ArquivoConfiguracao}");
 
                     string option = Console.ReadLine();
@@ -77,6 +78,9 @@ namespace NFe.Danfe.AppTeste.NetCore
                         case 6:
                             await GerarDanfeEventoPng();
                             break;
+                        case 98:
+                            await CarregarLogoConfiguracao();
+                            break;
                         case 99:
                             await CarregarConfiguracao();
                             break;
@@ -102,6 +106,24 @@ namespace NFe.Danfe.AppTeste.NetCore
                 _configuracoes = !File.Exists(path + ArquivoConfiguracao)
                                 ? new ConfiguracaoConsole()
                                 : FuncoesXml.ArquivoXmlParaClasse<ConfiguracaoConsole>(path + ArquivoConfiguracao);
+            }
+            catch (Exception ex)
+            {
+                throw ex;
+            }
+        }
+
+        private static async Task CarregarLogoConfiguracao()
+        {
+            Console.WriteLine(@"Digite o caminho da logo (ex: C:\arquivos\logo.png):");
+            string path = Console.ReadLine();
+
+            try
+
+            {
+                _configuracoes.ConfiguracaoDanfeNfe.Logomarca = !File.Exists(path)
+                                ? null
+                                : File.ReadAllBytes(path);
             }
             catch (Exception ex)
             {

--- a/NFe.Danfe.Fast.Standard/NFe/NFeEvento.frx
+++ b/NFe.Danfe.Fast.Standard/NFe/NFeEvento.frx
@@ -1,7 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Report ScriptLanguage="CSharp" ReferencedAssemblies="System.dll&#13;&#10;System.Drawing.dll&#13;&#10;System.Windows.Forms.dll&#13;&#10;System.Data.dll&#13;&#10;System.Xml.dll&#13;&#10;NFe.Classes.Standard.dll&#13;&#10;NFe.Utils.Standard.dll&#13;&#10;DFe.Classes.Standard.dll" ReportInfo.Created="12/16/2016 10:44:33" ReportInfo.Modified="08/15/2018 13:57:20" ReportInfo.CreatorVersion="2017.4.1.0">
-  <ScriptText>
-using System;
+  <ScriptText>using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/NFe.Danfe.Fast.Standard/NFe/NFeRetrato.frx
+++ b/NFe.Danfe.Fast.Standard/NFe/NFeRetrato.frx
@@ -1,466 +1,549 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Report ScriptLanguage="CSharp" ReferencedAssemblies="System.dll&#13;&#10;System.Drawing.dll&#13;&#10;System.Windows.Forms.dll&#13;&#10;System.Data.dll&#13;&#10;System.Xml.dll&#13;&#10;System.Core.dll&#13;&#10;System.Linq.dll&#13;&#10;System.Runtime.dll&#13;&#10;System.Runtime.Extensions.dll&#13;&#10;System.Runtime.Serialization.dll&#13;&#10;System.Text.RegularExpressions.dll&#13;&#10;NFe.Classes.Standard.dll&#13;&#10;NFe.Utils.Standard.dll&#13;&#10;NFe.Danfe.Base.Standard.dll&#13;&#10;NFe.Danfe.Fast.Standard.dll" ReportInfo.Created="10/11/2017 22:21:42" ReportInfo.Modified="09/03/2019 13:51:42" ReportInfo.CreatorVersion="2017.4.3.0">
-  <ScriptText>
-    using System;
-    using System.IO;
-    using System.Collections;
-    using System.Collections.Generic;
-    using System.ComponentModel;
-    using System.Windows.Forms;
-    using System.Drawing;
-    using System.Data;
-    using System.Linq;
-    using System.Text.RegularExpressions;
-    using FastReport;
-    using FastReport.Data;
-    using FastReport.Dialog;
-    using FastReport.Barcode;
-    using FastReport.Table;
-    using FastReport.Utils;
-    using NFe.Classes.Informacoes.Identificacao.Tipos;
-    using NFe.Classes.Informacoes.Detalhe.Tributacao;
-    using NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual.Tipos;
-    using NFe.Classes.Informacoes.Detalhe.Tributacao.Federal.Tipos;
-    using NFe.Utils.Tributacao.Estadual;
-    using NFe.Classes.Informacoes.Transporte;
-    using NFe.Classes.Protocolo;
-    using NFe.Classes.Informacoes.Emitente;
-    using NFe.Utils;
-    using NFe.Danfe.Base.NFe;
+<Report ScriptLanguage="CSharp" ReferencedAssemblies="System.dll&#13;&#10;System.Drawing.dll&#13;&#10;System.Windows.Forms.dll&#13;&#10;System.Data.dll&#13;&#10;System.Xml.dll&#13;&#10;System.Core.dll&#13;&#10;System.Linq.dll&#13;&#10;System.Runtime.dll&#13;&#10;System.Runtime.Extensions.dll&#13;&#10;System.Runtime.Serialization.dll&#13;&#10;System.Text.RegularExpressions.dll&#13;&#10;NFe.Classes.Standard.dll&#13;&#10;NFe.Utils.Standard.dll&#13;&#10;NFe.Danfe.Base.Standard.dll&#13;&#10;NFe.Danfe.Fast.Standard.dll" ReportInfo.Created="10/11/2017 22:21:42" ReportInfo.Modified="06/15/2020 10:48:21" ReportInfo.CreatorVersion="2017.4.1.0">
+  <ScriptText>using System;
+using System.IO;
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Windows.Forms;
+using System.Drawing;
+using System.Data;
+using System.Linq;
+using System.Text.RegularExpressions;
+using FastReport;
+using FastReport.Data;
+using FastReport.Dialog;
+using FastReport.Barcode;
+using FastReport.Table;
+using FastReport.Utils;
+using NFe.Classes.Informacoes.Identificacao.Tipos;
+using NFe.Classes.Informacoes.Detalhe.Tributacao;
+using NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual.Tipos;
+using NFe.Classes.Informacoes.Detalhe.Tributacao.Federal.Tipos;
+using NFe.Utils.Tributacao.Estadual;
+using NFe.Classes.Informacoes.Transporte;
+using NFe.Classes.Protocolo;
+using NFe.Classes.Informacoes.Emitente;
+using NFe.Utils;
+using NFe.Danfe.Base.NFe;
 
-    namespace FastReport
-    {
-    public class ReportScript
-    {
-    private const int LINHAS_DADOS_ADICIONAIS = 7;
-
+namespace FastReport
+{        
+  public class ReportScript
+  {    
     private void Emitente_BeforePrint(object sender, EventArgs e)
     {
-    var chave = Substring(((String)Report.GetColumnValue(&quot;NFe.NFe.infNFe.Id&quot;)), 3);
-    TextChaveAcesso.Text = Regex.Replace(chave, &quot;.{4}&quot;, &quot;$0 &quot;);
-    BarcodeChave.Text = chave;
-    poEmitLogo.Image = ObterLogo();
+      var chave = Substring(((String)Report.GetColumnValue(&quot;NFe.NFe.infNFe.Id&quot;)), 3);
+      TextChaveAcesso.Text = Regex.Replace(chave, &quot;.{4}&quot;, &quot;$0 &quot;); 
+      BarcodeChave.Text = chave;
+      poEmitLogo.Image = ObterLogo();
+      
+      var contigenciaId = (string)Report.GetParameterValue(&quot;ContingenciaID&quot;);
+      BarCodeContigencia.Visible = !string.IsNullOrEmpty(contigenciaId);
+      if(BarCodeContigencia.Visible) BarCodeContigencia.Text = contigenciaId;
+      DadosISSQN.Visible = !(bool)Report.GetParameterValue(&quot;ImprimirISSQN&quot;);
+      prodRow.AutoSize = (bool)Report.GetParameterValue(&quot;DuasLinhas&quot;);
+      if(prodRow.AutoSize == false) prodNomeCell.WordWrap = false;
+      
+      //Trato o campo de Frete 
+      switch((int)((ModalidadeFrete)Report.GetColumnValue(&quot;NFe.NFe.infNFe.transp.modFrete&quot;)))
+      {
+        case 0: Memo92.Text = &quot;0 - Emit/Remet&quot;; break;
+        case 1: Memo92.Text = &quot;1 - Destinatário&quot;; break;
+        case 2: Memo92.Text = &quot;2 - Terceiros&quot;; break;
+        case 3: Memo92.Text = &quot;3 - Prop Remetente&quot;; break;
+        case 4: Memo92.Text = &quot;4 - Prop Destinatário&quot;; break;
+        case 9: Memo92.Text = &quot;9 - Sem Frete&quot;; break;
+      } 
+      
+      var vol = Report.GetDataSource(&quot;NFe.NFe.infNFe.transp.vol&quot;);
+      vol.Init();
+      int qtdeVol = 0; 
+       
+      int volumes = 0;
+      decimal pesoL = 0;
+      decimal pesoB = 0;
+      while (vol.HasMoreRows)
+      {      
+        Memo106.Text = ((String)Report.GetColumnValue(&quot;NFe.NFe.infNFe.transp.vol.esp&quot;));
+        Memo108.Text = ((String)Report.GetColumnValue(&quot;NFe.NFe.infNFe.transp.vol.marca&quot;));
+        Memo110.Text = ((String)Report.GetColumnValue(&quot;NFe.NFe.infNFe.transp.vol.nVol&quot;));
+                                                                                              
+        volumes += ((Nullable&lt;int&gt;)Report.GetColumnValue(&quot;NFe.NFe.infNFe.transp.vol.qVol&quot;)) ?? 0;
+        pesoL += ((Nullable&lt;decimal&gt;)Report.GetColumnValue(&quot;NFe.NFe.infNFe.transp.vol.pesoL&quot;)) ?? 0M;
+        pesoB += ((Nullable&lt;decimal&gt;)Report.GetColumnValue(&quot;NFe.NFe.infNFe.transp.vol.pesoB&quot;)) ?? 0M;   
+        qtdeVol++; 
+        vol.Next();
+      }
+           
+      if (qtdeVol &gt;= 1)
+      {
+        if (qtdeVol &gt; 1)
+        {
+          Memo106.Text = &quot;VOLUMES&quot;;
+          Memo108.Text = &quot;&quot;;
+          Memo110.Text = &quot;&quot;;
+        }
+        
+        Memo104.Text = volumes.ToString();
+        Memo112.Text = FormatNumber(pesoB,3) + &quot; KG&quot;;
+        Memo114.Text = FormatNumber(pesoL,3) + &quot; KG&quot;;
+      }  
+           
+      if(Engine.FinalPass)
+      { 
+        var vBC = ((Nullable&lt;decimal&gt;)Report.GetColumnValue(&quot;NFe.NFe.infNFe.total.ISSQNtot.vBC&quot;)) ?? 0;
+        var vISS = ((Nullable&lt;decimal&gt;)Report.GetColumnValue(&quot;NFe.NFe.infNFe.total.ISSQNtot.vISS&quot;)) ?? 0;
+        var vServ = ((Nullable&lt;decimal&gt;)Report.GetColumnValue(&quot;NFe.NFe.infNFe.total.ISSQNtot.vServ&quot;)) ?? 0;
+             
+        DadosISSQN.Visible = !(vBC == 0 &amp;&amp; vISS == 0 &amp;&amp; vServ == 0);
+        
+        var retiradaCPF = (string)Report.GetColumnValue(&quot;NFe.NFe.infNFe.retirada.CPF&quot;);
+        var retiradaCNPJ = (string)Report.GetColumnValue(&quot;NFe.NFe.infNFe.retirada.CNPJ&quot;);
+        var retiradaEndereco = (string)Report.GetColumnValue(&quot;NFe.NFe.infNFe.retirada.xLgr&quot;);
+        var retiradaNro = (string)Report.GetColumnValue(&quot;NFe.NFe.infNFe.retirada.nro&quot;);
+        var retiradaBairro = (string)Report.GetColumnValue(&quot;NFe.NFe.infNFe.retirada.xBairro&quot;);
+        var retiradaMunicipio = (string)Report.GetColumnValue(&quot;NFe.NFe.infNFe.retirada.xMun&quot;);
+        var retiradaUf = (string)Report.GetColumnValue(&quot;NFe.NFe.infNFe.retirada.UF&quot;);
+        
+        LocalRetirada.Visible = !string.IsNullOrEmpty(retiradaCPF) || !string.IsNullOrEmpty(retiradaCNPJ) ||
+          !string.IsNullOrEmpty(retiradaEndereco) || !string.IsNullOrEmpty(retiradaNro) ||
+          !string.IsNullOrEmpty(retiradaBairro) || !string.IsNullOrEmpty(retiradaMunicipio) ||
+          !string.IsNullOrEmpty(retiradaUf);
+        
+        var entregaCPF = (string)Report.GetColumnValue(&quot;NFe.NFe.infNFe.entrega.CPF&quot;);
+        var entregaCNPJ = (string)Report.GetColumnValue(&quot;NFe.NFe.infNFe.entrega.CNPJ&quot;);
+        var entregaEndereco = (string)Report.GetColumnValue(&quot;NFe.NFe.infNFe.entrega.xLgr&quot;);
+        var entregaNro = (string)Report.GetColumnValue(&quot;[NFe.NFe.infNFe.entrega.nro]&quot;);
+        var entregaBairro = (string)Report.GetColumnValue(&quot;NFe.NFe.infNFe.entrega.xBairro&quot;);
+        var entregaMunicipio = (string)Report.GetColumnValue(&quot;NFe.NFe.infNFe.entrega.xMun&quot;);
+        var entregaUf = (string)Report.GetColumnValue(&quot;NFe.NFe.infNFe.entrega.UF&quot;);
+        
+        LocalEntrega.Visible = !string.IsNullOrEmpty(entregaCPF) || !string.IsNullOrEmpty(entregaCNPJ) ||
+          !string.IsNullOrEmpty(entregaEndereco) || !string.IsNullOrEmpty(entregaNro) ||
+          !string.IsNullOrEmpty(entregaBairro) || !string.IsNullOrEmpty(entregaMunicipio) ||
+          !string.IsNullOrEmpty(entregaUf);
+        
+        
+        var indPagto =   (IndicadorPagamento?)Report.GetColumnValue(&quot;NFe.NFe.infNFe.ide.indPag&quot;);
+        var fatnFat = (string)Report.GetColumnValue(&quot;NFe.NFe.infNFe.cobr.fat.nFat&quot;); 
+        var fatvOrig = ((Nullable&lt;decimal&gt;)Report.GetColumnValue(&quot;NFe.NFe.infNFe.cobr.fat.vOrig&quot;)) ?? 0M;
+        var fatvDesc = ((Nullable&lt;decimal&gt;)Report.GetColumnValue(&quot;NFe.NFe.infNFe.cobr.fat.vDesc&quot;)) ?? 0M;
+        var fatvLiq = ((Nullable&lt;decimal&gt;)Report.GetColumnValue(&quot;NFe.NFe.infNFe.cobr.fat.vLiq&quot;)) ?? 0M;
+        
+        Fatura.Visible = (bool)Report.GetParameterValue(&quot;ExibeCampoFatura&quot;);   
+        MemoFatura.Visible  = !string.IsNullOrEmpty(fatnFat);
+        if(MemoFatura.Visible) MemoFatura.Text = string.Format(&quot;Número: {0} - Valor Original: {1:c} - Valor Desconto: {2:c} - ValorLíquido: {3:c}&quot;,
+            fatnFat, fatvOrig, fatvDesc, fatvLiq);
+        
+        switch(indPagto)
+        {
+          case IndicadorPagamento.ipVista:
+            Memo146.Text = &quot;PAGAMENTO À VISTA&quot;;
+            break;
+          
+          case IndicadorPagamento.ipPrazo:
+            Memo146.Text = &quot;PAGAMENTO A PRAZO&quot;;
+            break;
+          
+          case IndicadorPagamento.ipOutras:
+            Memo146.Text = &quot;OUTROS&quot;;
+	  break;
+	  }
+	  }
 
-    var contigenciaId = (string)Report.GetParameterValue(&quot;ContingenciaID&quot;);
-    BarCodeContigencia.Visible = !string.IsNullOrEmpty(contigenciaId);
-    if(BarCodeContigencia.Visible) BarCodeContigencia.Text = contigenciaId;
-    DadosISSQN.Visible = !(bool)Report.GetParameterValue(&quot;ImprimirISSQN&quot;);
-    prodRow.AutoSize = (bool)Report.GetParameterValue(&quot;DuasLinhas&quot;);
-    if(prodRow.AutoSize == false) prodNomeCell.WordWrap = false;
+	  string infAdicionais = (string)Report.GetColumnValue(&quot;NFe.NFe.infNFe.infAdic.infCpl&quot;) + Environment.NewLine + (string)Report.GetColumnValue(&quot;NFe.NFe.infNFe.infAdic.infAdFisco&quot;);
 
-    //Trato o campo de Frete
-    switch((int)((ModalidadeFrete)Report.GetColumnValue(&quot;NFe.NFe.infNFe.transp.modFrete&quot;)))
-    {
-    case 0: Memo92.Text = &quot;0 - Emit/Remet&quot;; break;
-    case 1: Memo92.Text = &quot;1 - Destinatário&quot;; break;
-    case 2: Memo92.Text = &quot;2 - Terceiros&quot;; break;
-    case 3: Memo92.Text = &quot;3 - Prop Remetente&quot;; break;
-    case 4: Memo92.Text = &quot;4 - Prop Destinatário&quot;; break;
-    case 9: Memo92.Text = &quot;9 - Sem Frete&quot;; break;
+	  infAdicionais = infAdicionais.Replace(&quot;[&quot;,&quot;[\&quot;[&quot;).Replace(&quot;]&quot;,&quot;]\&quot;]&quot;);
+
+	  if((bool)Report.GetParameterValue(&quot;QuebrarLinhasObservacao&quot;))
+	  {
+	    infAdicionais = infAdicionais.Replace(&quot;;&quot;, Environment.NewLine);
+	  }
+
+	  TextInfAdicionais.Text = infAdicionais;
+	  //memContInfAdicionais.Text = string.Empty;
+
+	  //string[] lines = infAdicionais.Split(new string[]{ Environment.NewLine, &quot;\n&quot; }, StringSplitOptions.None);
+	  //pgContDadosAdicionais.Visible = lines.Length &gt; LINHAS_DADOS_ADICIONAIS;
+
+	  //if(pgContDadosAdicionais.Visible)
+	  //{
+	  //  TextInfAdicionais.Text = string.Join(Environment.NewLine, lines.Take(LINHAS_DADOS_ADICIONAIS-1).ToArray());
+	  //  memContInfAdicionais.Text = string.Join(Environment.NewLine, lines.Skip(LINHAS_DADOS_ADICIONAIS-1).ToArray());
+	  //}
+	  }
+
+	  private void DadosProdutos_BeforePrint(object sender, EventArgs e)
+	  {
+	  var icmsBasico = (ICMSBasico)Report.GetColumnValue(&quot;NFe.NFe.infNFe.det.imposto.ICMS.TipoICMS&quot;);
+	  var ipiBasico = (IPIBasico)Report.GetColumnValue(&quot;NFe.NFe.infNFe.det.imposto.IPI.TipoIPI&quot;);
+
+	  if (icmsBasico != null)
+	  {
+	      var orig = icmsBasico.GetIcmsOrig();
+	      if ((CRT)(Report.GetColumnValue(&quot;NFe.NFe.infNFe.emit.CRT&quot;)) == CRT.SimplesNacional)
+	      {
+	        prodOriginCell.Text = orig.OrigemMercadoriaParaString()+icmsBasico.GetIcmsCsosn().CsosnicmsParaString();
+	      }
+	      else
+	      {
+	        prodOriginCell.Text = orig.OrigemMercadoriaParaString() + icmsBasico.GetIcmsCst().CsticmsParaString();
+	      }
+
+	      prodBcCell.Text = FormatNumber(icmsBasico.GetIcmsBcValue(), 2);
+	      prodICMSCell.Text = FormatNumber(icmsBasico.GetIcmsValue(), 2);
+	      prodAlqICMSCell.Text = FormatNumber(icmsBasico.GetIcmsPercent(),2);
+	  }
+
+
+	  if(ipiBasico != null)
+	  {
+	    prodIPICell.Text = FormatNumber(ipiBasico.GetIpiValue(),2);
+	    prodAlqIPICell.Text = FormatNumber(ipiBasico.GetIpiPercent(),2);
+	  }
+	  else
+	  {
+	    prodIPICell.Text = &quot;0,00&quot;;
+        prodAlqIPICell.Text = &quot;0,00&quot;;
+      }
+      
+      var imprimirUnidQtdeValor = (ImprimirUnidQtdeValor)Report.GetParameterValue(&quot;ImprimirUnidQtdeValor&quot;);
+      var imprimirDescPorc = (bool)Report.GetParameterValue(&quot;ImprimirDescPorc&quot;);              
+      var imprimirTotalLiquido = (bool)Report.GetParameterValue(&quot;ImprimirTotalLiquido&quot;);
+      
+      var uCom = ((String)Report.GetColumnValue(&quot;NFe.NFe.infNFe.det.prod.uCom&quot;));
+      var uTrib = ((String)Report.GetColumnValue(&quot;NFe.NFe.infNFe.det.prod.uTrib&quot;));
+      
+      var qCom = ((Decimal)Report.GetColumnValue(&quot;NFe.NFe.infNFe.det.prod.qCom&quot;));
+      var qTrib = ((Decimal)Report.GetColumnValue(&quot;NFe.NFe.infNFe.det.prod.qTrib&quot;));
+      
+      var vUnCom = ((Decimal)Report.GetColumnValue(&quot;NFe.NFe.infNFe.det.prod.vUnCom&quot;));
+      var vUnTrib = ((Decimal)Report.GetColumnValue(&quot;NFe.NFe.infNFe.det.prod.vUnTrib&quot;));
+      
+      var vProd = ((Decimal)Report.GetColumnValue(&quot;NFe.NFe.infNFe.det.prod.vProd&quot;));
+      var vDesc = (((Nullable&lt;Decimal&gt;)Report.GetColumnValue(&quot;NFe.NFe.infNFe.det.prod.vDesc&quot;)) ?? 0);
+      
+      if(imprimirTotalLiquido) vProd = vProd - vDesc;      
+      if(vDesc &gt; 0 &amp;&amp; imprimirDescPorc)
+      {
+        vDesc = ((vDesc*100)/(vUnCom*qCom));
+      }    
+      
+      prodValorCell.Text = FormatNumber(vProd,2);
+      prodDescontoCell.Text = FormatNumber(vDesc, 2);
+      
+      var decimaisQuantidadeItem = (int)Report.GetParameterValue(&quot;DecimaisQuantidadeItem&quot;);
+      var decimaisValorUnitario = (int)Report.GetParameterValue(&quot;DecimaisValorUnitario&quot;);
+      
+      switch(imprimirUnidQtdeValor)
+      {
+        case ImprimirUnidQtdeValor.Comercial:
+          prodUnidadeCell.Text = uCom;
+          prodQtdCell.Text = FormatNumber(qCom, decimaisQuantidadeItem);
+          prodValorUnitarioCell.Text = FormatNumber(vUnCom, decimaisValorUnitario);
+          break;
+        
+        case ImprimirUnidQtdeValor.Tributavel:
+          prodUnidadeCell.Text = uTrib;
+          prodQtdCell.Text = FormatNumber(qTrib, decimaisQuantidadeItem);
+          prodValorUnitarioCell.Text = FormatNumber(vUnTrib, decimaisValorUnitario);
+          break;
+        
+        case ImprimirUnidQtdeValor.Ambos:
+          
+          var qTribFormatado = FormatNumber(qTrib, decimaisQuantidadeItem);
+          var qComFormatado = FormatNumber(qCom, decimaisQuantidadeItem);
+          var vUnComFormatado = FormatNumber(vUnCom, decimaisValorUnitario);
+          var vUnTribFormatado = FormatNumber(vUnTrib, decimaisValorUnitario);
+          
+          prodUnidadeCell.Text = string.Format(&quot;{0}{2}{1}&quot;, uCom, uTrib, Environment.NewLine);
+          prodQtdCell.Text = string.Format(&quot;{0}{2}{1}&quot;, qComFormatado, qTribFormatado, Environment.NewLine);
+          prodValorUnitarioCell.Text = string.Format(&quot;{0}{2}{1}&quot;, vUnComFormatado, vUnTribFormatado, Environment.NewLine);
+          break;
+      }
     }
-
-    var vol = Report.GetDataSource(&quot;NFe.NFe.infNFe.transp.vol&quot;);
-    vol.Init();
-    int qtdeVol = 0;
-
-    int volumes = 0;
-    decimal pesoL = 0;
-    decimal pesoB = 0;
-    while (vol.HasMoreRows)
-    {
-    Memo106.Text = ((String)Report.GetColumnValue(&quot;NFe.NFe.infNFe.transp.vol.esp&quot;));
-    Memo108.Text = ((String)Report.GetColumnValue(&quot;NFe.NFe.infNFe.transp.vol.marca&quot;));
-    Memo110.Text = ((String)Report.GetColumnValue(&quot;NFe.NFe.infNFe.transp.vol.nVol&quot;));
-
-    volumes += ((Nullable&lt;int&gt;)Report.GetColumnValue(&quot;NFe.NFe.infNFe.transp.vol.qVol&quot;)) ?? 0;
-    pesoL += ((Nullable&lt;decimal&gt;)Report.GetColumnValue(&quot;NFe.NFe.infNFe.transp.vol.pesoL&quot;)) ?? 0M;
-    pesoB += ((Nullable&lt;decimal&gt;)Report.GetColumnValue(&quot;NFe.NFe.infNFe.transp.vol.pesoB&quot;)) ?? 0M;
-    qtdeVol++;
-    vol.Next();
-    }
-
-    if (qtdeVol &gt;= 1)
-    {
-    if (qtdeVol &gt; 1)
-    {
-    Memo106.Text = &quot;VOLUMES&quot;;
-    Memo108.Text = &quot;&quot;;
-    Memo110.Text = &quot;&quot;;
-    }
-
-    Memo104.Text = volumes.ToString();
-    Memo112.Text = FormatNumber(pesoB,3) + &quot; KG&quot;;
-    Memo114.Text = FormatNumber(pesoL,3) + &quot; KG&quot;;
-    }
-
-    if(Engine.FinalPass)
-    {
-    var vBC = ((Nullable&lt;decimal&gt;)Report.GetColumnValue(&quot;NFe.NFe.infNFe.total.ISSQNtot.vBC&quot;)) ?? 0;
-    var vISS = ((Nullable&lt;decimal&gt;)Report.GetColumnValue(&quot;NFe.NFe.infNFe.total.ISSQNtot.vISS&quot;)) ?? 0;
-    var vServ = ((Nullable&lt;decimal&gt;)Report.GetColumnValue(&quot;NFe.NFe.infNFe.total.ISSQNtot.vServ&quot;)) ?? 0;
-
-    DadosISSQN.Visible = !(vBC == 0 &amp;&amp; vISS == 0 &amp;&amp; vServ == 0);
-
-    var retiradaCPF = (string)Report.GetColumnValue(&quot;NFe.NFe.infNFe.retirada.CPF&quot;);
-    var retiradaCNPJ = (string)Report.GetColumnValue(&quot;NFe.NFe.infNFe.retirada.CNPJ&quot;);
-    var retiradaEndereco = (string)Report.GetColumnValue(&quot;NFe.NFe.infNFe.retirada.xLgr&quot;);
-    var retiradaNro = (string)Report.GetColumnValue(&quot;NFe.NFe.infNFe.retirada.nro&quot;);
-    var retiradaBairro = (string)Report.GetColumnValue(&quot;NFe.NFe.infNFe.retirada.xBairro&quot;);
-    var retiradaMunicipio = (string)Report.GetColumnValue(&quot;NFe.NFe.infNFe.retirada.xMun&quot;);
-    var retiradaUf = (string)Report.GetColumnValue(&quot;NFe.NFe.infNFe.retirada.UF&quot;);
-
-    LocalRetirada.Visible = !string.IsNullOrEmpty(retiradaCPF) || !string.IsNullOrEmpty(retiradaCNPJ) ||
-    !string.IsNullOrEmpty(retiradaEndereco) || !string.IsNullOrEmpty(retiradaNro) ||
-    !string.IsNullOrEmpty(retiradaBairro) || !string.IsNullOrEmpty(retiradaMunicipio) ||
-    !string.IsNullOrEmpty(retiradaUf);
-
-    var entregaCPF = (string)Report.GetColumnValue(&quot;NFe.NFe.infNFe.entrega.CPF&quot;);
-    var entregaCNPJ = (string)Report.GetColumnValue(&quot;NFe.NFe.infNFe.entrega.CNPJ&quot;);
-    var entregaEndereco = (string)Report.GetColumnValue(&quot;NFe.NFe.infNFe.entrega.xLgr&quot;);
-    var entregaNro = (string)Report.GetColumnValue(&quot;[NFe.NFe.infNFe.entrega.nro]&quot;);
-    var entregaBairro = (string)Report.GetColumnValue(&quot;NFe.NFe.infNFe.entrega.xBairro&quot;);
-    var entregaMunicipio = (string)Report.GetColumnValue(&quot;NFe.NFe.infNFe.entrega.xMun&quot;);
-    var entregaUf = (string)Report.GetColumnValue(&quot;NFe.NFe.infNFe.entrega.UF&quot;);
-
-    LocalEntrega.Visible = !string.IsNullOrEmpty(entregaCPF) || !string.IsNullOrEmpty(entregaCNPJ) ||
-    !string.IsNullOrEmpty(entregaEndereco) || !string.IsNullOrEmpty(entregaNro) ||
-    !string.IsNullOrEmpty(entregaBairro) || !string.IsNullOrEmpty(entregaMunicipio) ||
-    !string.IsNullOrEmpty(entregaUf);
-
-
-    var indPagto =   (IndicadorPagamento?)Report.GetColumnValue(&quot;NFe.NFe.infNFe.ide.indPag&quot;);
-    var fatnFat = (string)Report.GetColumnValue(&quot;NFe.NFe.infNFe.cobr.fat.nFat&quot;);
-    var fatvOrig = ((Nullable&lt;decimal&gt;)Report.GetColumnValue(&quot;NFe.NFe.infNFe.cobr.fat.vOrig&quot;)) ?? 0M;
-    var fatvDesc = ((Nullable&lt;decimal&gt;)Report.GetColumnValue(&quot;NFe.NFe.infNFe.cobr.fat.vDesc&quot;)) ?? 0M;
-    var fatvLiq = ((Nullable&lt;decimal&gt;)Report.GetColumnValue(&quot;NFe.NFe.infNFe.cobr.fat.vLiq&quot;)) ?? 0M;
-
-    Fatura.Visible = (bool)Report.GetParameterValue(&quot;ExibeCampoFatura&quot;);
-    MemoFatura.Visible  = !string.IsNullOrEmpty(fatnFat);
-    if(MemoFatura.Visible) MemoFatura.Text = string.Format(&quot;Número: {0} - Valor Original: {1:c} - Valor Desconto: {2:c} - ValorLíquido: {3:c}&quot;,
-    fatnFat, fatvOrig, fatvDesc, fatvLiq);
-
-    switch(indPagto)
-    {
-    case IndicadorPagamento.ipVista:
-    Memo146.Text = &quot;PAGAMENTO À VISTA&quot;;
-    break;
-
-    case IndicadorPagamento.ipPrazo:
-    Memo146.Text = &quot;PAGAMENTO A PRAZO&quot;;
-    break;
-
-    case IndicadorPagamento.ipOutras:
-    Memo146.Text = &quot;OUTROS&quot;;
-    break;
-    }
-    }
-
-    string infAdicionais = (string)Report.GetColumnValue(&quot;NFe.NFe.infNFe.infAdic.infCpl&quot;) + Environment.NewLine + (string)Report.GetColumnValue(&quot;NFe.NFe.infNFe.infAdic.infAdFisco&quot;);
-
-    if((bool)Report.GetParameterValue(&quot;QuebrarLinhasObservacao&quot;))
-    {
-    infAdicionais = infAdicionais.Replace(&quot;;&quot;, Environment.NewLine);
-    }
-
-    TextInfAdicionais.Text = infAdicionais;
-    //memContInfAdicionais.Text = string.Empty;
-
-    //string[] lines = infAdicionais.Split(new string[]{ Environment.NewLine, &quot;\n&quot; }, StringSplitOptions.None);
-    //pgContDadosAdicionais.Visible = lines.Length &gt; LINHAS_DADOS_ADICIONAIS;
-
-    //if(pgContDadosAdicionais.Visible)
-    //{
-    //  TextInfAdicionais.Text = string.Join(Environment.NewLine, lines.Take(LINHAS_DADOS_ADICIONAIS-1).ToArray());
-    //  memContInfAdicionais.Text = string.Join(Environment.NewLine, lines.Skip(LINHAS_DADOS_ADICIONAIS-1).ToArray());
-    //}
-    }
-
-    private void DadosProdutos_BeforePrint(object sender, EventArgs e)
-    {
-    var icmsBasico = (ICMSBasico)Report.GetColumnValue(&quot;NFe.NFe.infNFe.det.imposto.ICMS.TipoICMS&quot;);
-    var ipiBasico = (IPIBasico)Report.GetColumnValue(&quot;NFe.NFe.infNFe.det.imposto.IPI.TipoIPI&quot;);
-    var orig = icmsBasico.GetIcmsOrig();
-
-    if ((CRT)(Report.GetColumnValue(&quot;NFe.NFe.infNFe.emit.CRT&quot;)) == CRT.SimplesNacional)
-    {
-    prodOriginCell.Text = orig.OrigemMercadoriaParaString()+icmsBasico.GetIcmsCsosn().CsosnicmsParaString();
-    }
-    else
-    {
-    prodOriginCell.Text = orig.OrigemMercadoriaParaString() + icmsBasico.GetIcmsCst().CsticmsParaString();
-    }
-
-    prodBcCell.Text = FormatNumber(icmsBasico.GetIcmsBcValue(), 2);
-    prodICMSCell.Text = FormatNumber(icmsBasico.GetIcmsValue(), 2);
-    prodAlqICMSCell.Text = FormatNumber(icmsBasico.GetIcmsPercent(),2);
-
-
-    if(ipiBasico != null)
-    {
-    prodIPICell.Text = FormatNumber(ipiBasico.GetIpiValue(),2);
-    prodAlqIPICell.Text = FormatNumber(ipiBasico.GetIpiPercent(),2);
-    }
-    else
-    {
-    prodIPICell.Text = &quot;0,00&quot;;
-    prodAlqIPICell.Text = &quot;0,00&quot;;
-    }
-
-    var imprimirUnidQtdeValor = (ImprimirUnidQtdeValor)Report.GetParameterValue(&quot;ImprimirUnidQtdeValor&quot;);
-    var imprimirDescPorc = (bool)Report.GetParameterValue(&quot;ImprimirDescPorc&quot;);
-    var imprimirTotalLiquido = (bool)Report.GetParameterValue(&quot;ImprimirTotalLiquido&quot;);
-
-    var uCom = ((String)Report.GetColumnValue(&quot;NFe.NFe.infNFe.det.prod.uCom&quot;));
-    var uTrib = ((String)Report.GetColumnValue(&quot;NFe.NFe.infNFe.det.prod.uTrib&quot;));
-
-    var qCom = ((Decimal)Report.GetColumnValue(&quot;NFe.NFe.infNFe.det.prod.qCom&quot;));
-    var qTrib = ((Decimal)Report.GetColumnValue(&quot;NFe.NFe.infNFe.det.prod.qTrib&quot;));
-
-    var vUnCom = ((Decimal)Report.GetColumnValue(&quot;NFe.NFe.infNFe.det.prod.vUnCom&quot;));
-    var vUnTrib = ((Decimal)Report.GetColumnValue(&quot;NFe.NFe.infNFe.det.prod.vUnTrib&quot;));
-
-    var vProd = ((Decimal)Report.GetColumnValue(&quot;NFe.NFe.infNFe.det.prod.vProd&quot;));
-    var vDesc = (((Nullable&lt;Decimal&gt;)Report.GetColumnValue(&quot;NFe.NFe.infNFe.det.prod.vDesc&quot;)) ?? 0);
-
-    if(imprimirTotalLiquido) vProd = vProd - vDesc;
-    if(vDesc &gt; 0 &amp;&amp; imprimirDescPorc)
-    {
-    vDesc = ((vDesc*100)/(vUnCom*qCom));
-    }
-
-    prodValorCell.Text = FormatNumber(vProd,2);
-    prodDescontoCell.Text = FormatNumber(vDesc, 2);
-
-    var decimaisQuantidadeItem = (int)Report.GetParameterValue(&quot;DecimaisQuantidadeItem&quot;);
-    var decimaisValorUnitario = (int)Report.GetParameterValue(&quot;DecimaisValorUnitario&quot;);
-
-    switch(imprimirUnidQtdeValor)
-    {
-    case ImprimirUnidQtdeValor.Comercial:
-    prodUnidadeCell.Text = uCom;
-    prodQtdCell.Text = FormatNumber(qCom, decimaisQuantidadeItem);
-    prodValorUnitarioCell.Text = FormatNumber(vUnCom, decimaisValorUnitario);
-    break;
-
-    case ImprimirUnidQtdeValor.Tributavel:
-    prodUnidadeCell.Text = uTrib;
-    prodQtdCell.Text = FormatNumber(qTrib, decimaisQuantidadeItem);
-    prodValorUnitarioCell.Text = FormatNumber(vUnTrib, decimaisValorUnitario);
-    break;
-
-    case ImprimirUnidQtdeValor.Ambos:
-
-    var qTribFormatado = FormatNumber(qTrib, decimaisQuantidadeItem);
-    var qComFormatado = FormatNumber(qCom, decimaisQuantidadeItem);
-    var vUnComFormatado = FormatNumber(vUnCom, decimaisValorUnitario);
-    var vUnTribFormatado = FormatNumber(vUnTrib, decimaisValorUnitario);
-
-    prodUnidadeCell.Text = string.Format(&quot;{0}{2}{1}&quot;, uCom, uTrib, Environment.NewLine);
-    prodQtdCell.Text = string.Format(&quot;{0}{2}{1}&quot;, qComFormatado, qTribFormatado, Environment.NewLine);
-    prodValorUnitarioCell.Text = string.Format(&quot;{0}{2}{1}&quot;, vUnComFormatado, vUnTribFormatado, Environment.NewLine);
-    break;
-    }
-    }
-
-    private void DadosProdutosFooter_BeforePrint(object sender, EventArgs e)
-    {
-    //var FatorEspaco = DadosAdicionais.Height + PageFooter.Height;
-    //
-    //if(DadosISSQN.Visible) FatorEspaco += subISSQN.Height;
-    //
-    //if(Engine.FinalPass)
-    //{
-    //  while(Engine.FreeSpace &gt; FatorEspaco &amp;&amp; Engine.FreeSpace - ItemEspace.Height &gt; FatorEspaco)
-    //    Engine.ShowBand(ItemEspace);
-    //}
-    }
-
+        
     private string FormatarCampo(string valor, char format)
     {
-    switch (format)
-    {
-    case 'c':  //CEP
-    if (valor.Length == 8)
-    valor = valor.Substring(0,2) + &quot;.&quot; + valor.Substring(2,3) + &quot;-&quot; + valor.Substring(5,3);
-    break;
-
-    case 'f':  //Telefone /celular
-    if (valor.Length == 10)
-    valor = &quot;(&quot; +valor.Substring(0,2) + &quot;)&quot; + valor.Substring(2,4) + &quot;-&quot; + valor.Substring(6,4);
-    else if (valor.Length == 11)
-    valor = &quot;(&quot; +valor.Substring(0,2) + &quot;)&quot; + valor.Substring(2,5) + &quot;-&quot; + valor.Substring(7,4);
-    break;
-
-    case 'd': //cpf / cnpj
-    if (valor.Length == 11)
-    valor = valor.Substring(0,3)+&quot;.&quot;+valor.Substring(3,3)+&quot;.&quot;+valor.Substring(6,3)+&quot;-&quot;+valor.Substring(9,2);
-    else if (valor.Length == 14)
-    valor = valor.Substring(0,2)+&quot;.&quot;+valor.Substring(2,3)+&quot;.&quot;+valor.Substring(5,3)+&quot;/&quot;+valor.Substring(8,4)+&quot;-&quot;+valor.Substring(12,2);
-    break;
-
-    case 'p':
-    if (valor.Length == 7)
-    valor = valor.Substring(0,3)+&quot;-&quot;+valor.Substring(3,4);
-    break;
+      switch (format)
+      {
+        case 'c':  //CEP
+          if (valor.Length == 8)
+            valor = valor.Substring(0,2) + &quot;.&quot; + valor.Substring(2,3) + &quot;-&quot; + valor.Substring(5,3);          
+          break;
+        
+        case 'f':  //Telefone /celular         
+          if (valor.Length == 10)
+            valor = &quot;(&quot; +valor.Substring(0,2) + &quot;)&quot; + valor.Substring(2,4) + &quot;-&quot; + valor.Substring(6,4);
+          else if (valor.Length == 11)
+            valor = &quot;(&quot; +valor.Substring(0,2) + &quot;)&quot; + valor.Substring(2,5) + &quot;-&quot; + valor.Substring(7,4);          
+          break;
+        
+        case 'd': //cpf / cnpj
+          if (valor.Length == 11)
+            valor = valor.Substring(0,3)+&quot;.&quot;+valor.Substring(3,3)+&quot;.&quot;+valor.Substring(6,3)+&quot;-&quot;+valor.Substring(9,2);
+          else if (valor.Length == 14)
+            valor = valor.Substring(0,2)+&quot;.&quot;+valor.Substring(2,3)+&quot;.&quot;+valor.Substring(5,3)+&quot;/&quot;+valor.Substring(8,4)+&quot;-&quot;+valor.Substring(12,2);
+          break;  
+        
+        case 'p':
+          if (valor.Length == 7)
+            valor = valor.Substring(0,3)+&quot;-&quot;+valor.Substring(3,4);
+          break;
+      }                               
+      return valor;
     }
-    return valor;
-    }
-
+    
     public Image ObterLogo()
     {
-    byte[] logomarca = Report.GetParameterValue(&quot;Logo&quot;) as byte[];
-
-    if (logomarca == null) return null;
-
-    using(var ms = new MemoryStream(logomarca))
-    {
-    var image = Image.FromStream(ms);
-    return image;
-    }
-    }
+      byte[] logomarca = Report.GetParameterValue(&quot;Logo&quot;) as byte[];
+      
+      if (logomarca == null) return null;
+      
+      using(var ms = new MemoryStream(logomarca))
+      {
+        var image = Image.FromStream(ms);
+        return image;
+      }
+    }       
 
     private void Imposto_BeforePrint(object sender, EventArgs e)
     {
-    bool exibirIbpt = ((Boolean?)Report.GetParameterValue(&quot;ExibirTotalTributos&quot;)) ?? false;
+      bool exibirIbpt = ((Boolean?)Report.GetParameterValue(&quot;ExibirTotalTributos&quot;)) ?? false;
+      
+      QuadroVTOTTRIB.Visible = exibirIbpt;
+      txtIbptValor.Visible = exibirIbpt;
+      
+      if (exibirIbpt)
+      { 
+        //Base ICMS
+        QuadroVBC.Width = 100f;
+        Text170.Width = QuadroVBC.Width;
+        
+        //Valor ICMS
+        QuadroVICMS.Width = 100f;
+        QuadroVICMS.Left = 100f;
+        Text169.Width = QuadroVICMS.Width;
+        Text169.Left = QuadroVICMS.Left;
+        
+        //Base Calc ICMS ST
+        QuadroVBCST.Text = &quot;BASE CÁLC. ICMS SUBST.&quot;;
+        QuadroVBCST.Width = 100f;
+        QuadroVBCST.Left = 200f;
+        Text168.Width = QuadroVBCST.Width;
+        Text168.Left = QuadroVBCST.Left;                   
+        
+        //ICMS ST
+        QuadrovST.Width = 100f;
+        QuadrovST.Left = 300f;
+        Text162.Width = QuadrovST.Width;
+        Text162.Left = QuadrovST.Left;
+                
+        //PIS
+        QuadroPIS.Width = 100f;
+        QuadroPIS.Left = 400f;
+        Text160.Width = QuadroPIS.Width;
+        Text160.Left = QuadroPIS.Left;
+ 
+        //TOTAL TRIBUTOS
+        QuadroVTOTTRIB.Width = 100f;
+        QuadroVTOTTRIB.Left = 500f;
+        txtIbptValor.Width = QuadroVTOTTRIB.Width;
+        txtIbptValor.Left = QuadroVTOTTRIB.Left;
+        
+        //Total produtos
+        Memo67.Left = 600f;
+        Memo67.Width = 144.5f;
+        Text159.Width = Memo67.Width;
+        Text159.Left = Memo67.Left;              
+        
+        //Frete
+        Memo77.Left = 0f;
+        Memo77.Width = 100f;
+        Text167.Width = Memo77.Width;
+        Text167.Left = Memo77.Left;  
+        
+        //Seguro
+        Memo75.Left = 100f;
+        Memo75.Width = 100f;
+        Text166.Width = Memo75.Width;
+        Text166.Left = Memo75.Left; 
+        
+        //Desconto
+        Memo73.Left = 200f;
+        Memo73.Width = 100f;
+        Text165.Width = Memo73.Width;
+        Text165.Left = Memo73.Left; 
+        
+        //Despesas
+        Memo71.Left = 300f;
+        Memo71.Width = 100f;
+        Text164.Width = Memo71.Width;
+        Text164.Left = Memo71.Left; 
+        
+        //IPI
+        Memo69.Left = 400f;
+        Memo69.Width = 100f;
+        Text163.Width = Memo69.Width;
+        Text163.Left = Memo69.Left; 
+        
+        //Valor Cofins
+        Text158.Left = 500f;
+        Text158.Width = 100f;
+        Text161.Width = Text158.Width;
+        Text161.Left = Text158.Left; 
+        
+        //Total Contábil
+        Memo79.Left = 600f;
+        Memo79.Width = 144.5f;
+        Memo80.Width = Memo79.Width;
+        Memo80.Left = Memo79.Left;
+      }     
+    }
+            
+    private int contadorDuplicatas =0;    
+    private float _TamanhoDuplicatas = 0;
 
-    QuadroVTOTTRIB.Visible = exibirIbpt;
-    txtIbptValor.Visible = exibirIbpt;
-
-    if (exibirIbpt)
+    private void DuplicatasHeader_BeforePrint(object sender, EventArgs e)
     {
-    //Base ICMS
-    QuadroVBC.Width = 100f;
-    Text170.Width = QuadroVBC.Width;
-
-    //Valor ICMS
-    QuadroVICMS.Width = 100f;
-    QuadroVICMS.Left = 100f;
-    Text169.Width = QuadroVICMS.Width;
-    Text169.Left = QuadroVICMS.Left;
-
-    //Base Calc ICMS ST
-    QuadroVBCST.Text = &quot;BASE CÁLC. ICMS SUBST.&quot;;
-    QuadroVBCST.Width = 100f;
-    QuadroVBCST.Left = 200f;
-    Text168.Width = QuadroVBCST.Width;
-    Text168.Left = QuadroVBCST.Left;
-
-    //ICMS ST
-    QuadrovST.Width = 100f;
-    QuadrovST.Left = 300f;
-    Text162.Width = QuadrovST.Width;
-    Text162.Left = QuadrovST.Left;
-
-    //PIS
-    QuadroPIS.Width = 100f;
-    QuadroPIS.Left = 400f;
-    Text160.Width = QuadroPIS.Width;
-    Text160.Left = QuadroPIS.Left;
-
-    //TOTAL TRIBUTOS
-    QuadroVTOTTRIB.Width = 100f;
-    QuadroVTOTTRIB.Left = 500f;
-    txtIbptValor.Width = QuadroVTOTTRIB.Width;
-    txtIbptValor.Left = QuadroVTOTTRIB.Left;
-
-    //Total produtos
-    Memo67.Left = 600f;
-    Memo67.Width = 144.5f;
-    Text159.Width = Memo67.Width;
-    Text159.Left = Memo67.Left;
-
-    //Frete
-    Memo77.Left = 0f;
-    Memo77.Width = 100f;
-    Text167.Width = Memo77.Width;
-    Text167.Left = Memo77.Left;
-
-    //Seguro
-    Memo75.Left = 100f;
-    Memo75.Width = 100f;
-    Text166.Width = Memo75.Width;
-    Text166.Left = Memo75.Left;
-
-    //Desconto
-    Memo73.Left = 200f;
-    Memo73.Width = 100f;
-    Text165.Width = Memo73.Width;
-    Text165.Left = Memo73.Left;
-
-    //Despesas
-    Memo71.Left = 300f;
-    Memo71.Width = 100f;
-    Text164.Width = Memo71.Width;
-    Text164.Left = Memo71.Left;
-
-    //IPI
-    Memo69.Left = 400f;
-    Memo69.Width = 100f;
-    Text163.Width = Memo69.Width;
-    Text163.Left = Memo69.Left;
-
-    //Valor Cofins
-    Text158.Left = 500f;
-    Text158.Width = 100f;
-    Text161.Width = Text158.Width;
-    Text161.Left = Text158.Left;
-
-    //Total Contábil
-    Memo79.Left = 600f;
-    Memo79.Width = 144.5f;
-    Memo80.Width = Memo79.Width;
-    Memo80.Left = Memo79.Left;
+      contadorDuplicatas = 0;
+      _TamanhoDuplicatas = 0;
+    }   
+    
+    private void Duplicatas_BeforePrint(object sender, EventArgs e)
+    {
+      contadorDuplicatas++;
+      if (contadorDuplicatas == 6)
+      {       
+        _TamanhoDuplicatas += Duplicatas.Height;
+        contadorDuplicatas = 0;
+      }
     }
+  
+    private float _Tamanho = 0;
+    private float _TamanhoItens = 0;
+    
+    private void DadosProdutosHeader_BeforePrint(object sender, EventArgs e)
+    {
+      _Tamanho = 0;
+      _TamanhoItens = 0;  
+      
+      if (Canhoto.Visible)
+        _Tamanho += Canhoto.Height;
+      
+      if (Emitente.Visible)
+        _Tamanho += Emitente.Height;
+      
+      if (Destinatario.Visible)
+        _Tamanho += Destinatario.Height;
+      
+      if (LocalRetirada.Visible)
+        _Tamanho += LocalRetirada.Height;
+      
+      if (LocalEntrega.Visible)
+        _Tamanho += LocalEntrega.Height;
+      
+      if (Fatura.Visible)
+        _Tamanho += Fatura.Height;
+      
+      if (DuplicatasHeader.Visible)
+        _Tamanho += DuplicatasHeader.Height;
+      
+      _Tamanho += _TamanhoDuplicatas;
+      
+      if (Imposto.Visible)
+        _Tamanho += Imposto.Height;
+      
+      if (TransportadorVolumes.Visible)
+        _Tamanho += TransportadorVolumes.Height;
+      
+      if (DadosProdutosHeader.Visible)
+        _Tamanho += DadosProdutosHeader.Height;
+      
+      //_Tamanho += _TamanhoItens;
+      
+      if (DadosProdutosFooter.Visible)
+        _Tamanho += DadosProdutosFooter.Height;
+      
+      if (DadosISSQN.Visible)
+        _Tamanho += DadosISSQN.Height;
+      
+      DadosAdicionais.CalcHeight();
+      
+      if (DadosAdicionais.Visible)
+        _Tamanho += DadosAdicionais.Height;
+      
+      if (Rodape.Visible)
+        _Tamanho += Rodape.Height;     
+          
     }
+    
+    private void DadosProdutos_AfterPrint(object sender, EventArgs e)
+    {           
+      DadosProdutos.StartNewPage = false;
+      
+      if (Engine.PageNo == 1)
+      {
+        _TamanhoItens += DadosProdutos.Height;
+        
+        if (_Tamanho + _TamanhoItens &gt;= Engine.PageHeight)
+        {
+          DadosProdutos.StartNewPage = true;
+          _TamanhoItens = 0;
+        }
+      }
+    }
+    
 
-    }
-    }
-  </ScriptText>
+    
+  }
+}     </ScriptText>
   <Dictionary>
-    <BusinessObjectDataSource Name="NFe" ReferenceName="NFe" DataType="NFe.Classes.nfeProc[], NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null" Enabled="true">
+    <BusinessObjectDataSource Name="NFe" ReferenceName="NFe" DataType="NFe.Classes.nfeProc[], NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null" Enabled="true">
       <Column Name="versao" DataType="System.String"/>
-      <Column Name="NFe" DataType="NFe.Classes.NFe, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
-        <Column Name="infNFe" DataType="NFe.Classes.Informacoes.infNFe, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
+      <Column Name="NFe" DataType="NFe.Classes.NFe, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
+        <Column Name="infNFe" DataType="NFe.Classes.Informacoes.infNFe, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
           <Column Name="versao" DataType="System.String"/>
           <Column Name="Id" DataType="System.String"/>
-          <Column Name="ide" DataType="NFe.Classes.Informacoes.Identificacao.ide, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
-            <Column Name="cUF" DataType="DFe.Classes.Entidades.Estado, DFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null"/>
+          <Column Name="ide" DataType="NFe.Classes.Informacoes.Identificacao.ide, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
+            <Column Name="cUF" DataType="DFe.Classes.Entidades.Estado, DFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null"/>
             <Column Name="cNF" DataType="System.String"/>
             <Column Name="natOp" DataType="System.String"/>
-            <Column Name="indPag" DataType="System.Nullable`1[[NFe.Classes.Informacoes.Identificacao.Tipos.IndicadorPagamento, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null]]"/>
-            <Column Name="mod" DataType="DFe.Classes.Flags.ModeloDocumento, DFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null"/>
+            <Column Name="indPag" DataType="System.Nullable`1[[NFe.Classes.Informacoes.Identificacao.Tipos.IndicadorPagamento, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null]]"/>
+            <Column Name="mod" DataType="DFe.Classes.Flags.ModeloDocumento, DFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null"/>
             <Column Name="serie" DataType="System.Int32"/>
             <Column Name="nNF" DataType="System.Int64"/>
             <Column Name="dEmi" DataType="System.DateTime"/>
             <Column Name="dSaiEnt" DataType="System.DateTime"/>
             <Column Name="dhEmi" DataType="System.DateTimeOffset"/>
             <Column Name="dhSaiEnt" DataType="System.Nullable`1[[System.DateTimeOffset, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
-            <Column Name="tpNF" DataType="NFe.Classes.Informacoes.Identificacao.Tipos.TipoNFe, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null"/>
-            <Column Name="idDest" DataType="System.Nullable`1[[NFe.Classes.Informacoes.Identificacao.Tipos.DestinoOperacao, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null]]"/>
+            <Column Name="tpNF" DataType="NFe.Classes.Informacoes.Identificacao.Tipos.TipoNFe, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null"/>
+            <Column Name="idDest" DataType="System.Nullable`1[[NFe.Classes.Informacoes.Identificacao.Tipos.DestinoOperacao, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null]]"/>
             <Column Name="cMunFG" DataType="System.Int64"/>
-            <Column Name="tpImp" DataType="NFe.Classes.Informacoes.Identificacao.Tipos.TipoImpressao, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null"/>
-            <Column Name="tpEmis" DataType="NFe.Classes.Informacoes.Identificacao.Tipos.TipoEmissao, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null"/>
+            <Column Name="tpImp" DataType="NFe.Classes.Informacoes.Identificacao.Tipos.TipoImpressao, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null"/>
+            <Column Name="tpEmis" DataType="NFe.Classes.Informacoes.Identificacao.Tipos.TipoEmissao, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null"/>
             <Column Name="cDV" DataType="System.Int32"/>
-            <Column Name="tpAmb" DataType="DFe.Classes.Flags.TipoAmbiente, DFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null"/>
-            <Column Name="finNFe" DataType="NFe.Classes.Informacoes.Identificacao.Tipos.FinalidadeNFe, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null"/>
-            <Column Name="indFinal" DataType="System.Nullable`1[[NFe.Classes.Informacoes.Identificacao.Tipos.ConsumidorFinal, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null]]"/>
-            <Column Name="indPres" DataType="System.Nullable`1[[NFe.Classes.Informacoes.Identificacao.Tipos.PresencaComprador, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null]]"/>
-            <Column Name="procEmi" DataType="NFe.Classes.Informacoes.Identificacao.Tipos.ProcessoEmissao, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null"/>
+            <Column Name="tpAmb" DataType="DFe.Classes.Flags.TipoAmbiente, DFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null"/>
+            <Column Name="finNFe" DataType="NFe.Classes.Informacoes.Identificacao.Tipos.FinalidadeNFe, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null"/>
+            <Column Name="indFinal" DataType="System.Nullable`1[[NFe.Classes.Informacoes.Identificacao.Tipos.ConsumidorFinal, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null]]"/>
+            <Column Name="indPres" DataType="System.Nullable`1[[NFe.Classes.Informacoes.Identificacao.Tipos.PresencaComprador, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null]]"/>
+            <Column Name="procEmi" DataType="NFe.Classes.Informacoes.Identificacao.Tipos.ProcessoEmissao, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null"/>
             <Column Name="verProc" DataType="System.String"/>
             <Column Name="dhCont" DataType="System.DateTimeOffset"/>
             <Column Name="xJust" DataType="System.String"/>
-            <BusinessObjectDataSource Name="NFref" DataType="System.Collections.Generic.List`1[[NFe.Classes.Informacoes.Identificacao.NFref, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
+            <BusinessObjectDataSource Name="NFref" DataType="System.Collections.Generic.List`1[[NFe.Classes.Informacoes.Identificacao.NFref, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
               <Column Name="refNFe" DataType="System.String"/>
-              <Column Name="refNF" DataType="NFe.Classes.Informacoes.Identificacao.refNF, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
-                <Column Name="cUF" DataType="DFe.Classes.Entidades.Estado, DFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null"/>
+              <Column Name="refNF" DataType="NFe.Classes.Informacoes.Identificacao.refNF, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
+                <Column Name="cUF" DataType="DFe.Classes.Entidades.Estado, DFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null"/>
                 <Column Name="AAMM" DataType="System.String"/>
                 <Column Name="CNPJ" DataType="System.String"/>
-                <Column Name="mod" DataType="NFe.Classes.Informacoes.Identificacao.Tipos.refMod, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null"/>
+                <Column Name="mod" DataType="NFe.Classes.Informacoes.Identificacao.Tipos.refMod, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null"/>
                 <Column Name="serie" DataType="System.Int32"/>
                 <Column Name="nNF" DataType="System.Int32"/>
               </Column>
-              <Column Name="refNFP" DataType="NFe.Classes.Informacoes.Identificacao.refNFP, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
-                <Column Name="cUF" DataType="DFe.Classes.Entidades.Estado, DFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null"/>
+              <Column Name="refNFP" DataType="NFe.Classes.Informacoes.Identificacao.refNFP, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
+                <Column Name="cUF" DataType="DFe.Classes.Entidades.Estado, DFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null"/>
                 <Column Name="AAMM" DataType="System.String"/>
                 <Column Name="CNPJ" DataType="System.String"/>
                 <Column Name="CPF" DataType="System.String"/>
@@ -469,7 +552,7 @@
                 <Column Name="serie" DataType="System.Int32"/>
                 <Column Name="nNF" DataType="System.Int32"/>
               </Column>
-              <Column Name="refECF" DataType="NFe.Classes.Informacoes.Identificacao.refECF, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
+              <Column Name="refECF" DataType="NFe.Classes.Informacoes.Identificacao.refECF, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
                 <Column Name="mod" DataType="System.String"/>
                 <Column Name="nECF" DataType="System.Int32"/>
                 <Column Name="nCOO" DataType="System.Int32"/>
@@ -483,19 +566,19 @@
             <Column Name="ProxydhCont" DataType="System.String"/>
             <Column Name="indPagSpecified" DataType="System.Boolean" BindableControl="CheckBox"/>
           </Column>
-          <Column Name="emit" DataType="NFe.Classes.Informacoes.Emitente.emit, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
+          <Column Name="emit" DataType="NFe.Classes.Informacoes.Emitente.emit, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
             <Column Name="CNPJ" DataType="System.String"/>
             <Column Name="CPF" DataType="System.String"/>
             <Column Name="xNome" DataType="System.String"/>
             <Column Name="xFant" DataType="System.String"/>
-            <Column Name="enderEmit" DataType="NFe.Classes.Informacoes.Emitente.enderEmit, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
+            <Column Name="enderEmit" DataType="NFe.Classes.Informacoes.Emitente.enderEmit, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
               <Column Name="xLgr" DataType="System.String"/>
               <Column Name="nro" DataType="System.String"/>
               <Column Name="xCpl" DataType="System.String"/>
               <Column Name="xBairro" DataType="System.String"/>
               <Column Name="cMun" DataType="System.Int64"/>
               <Column Name="xMun" DataType="System.String"/>
-              <Column Name="UF" DataType="DFe.Classes.Entidades.Estado, DFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null"/>
+              <Column Name="UF" DataType="DFe.Classes.Entidades.Estado, DFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null"/>
               <Column Name="CEP" DataType="System.String"/>
               <Column Name="cPais" DataType="System.Nullable`1[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
               <Column Name="xPais" DataType="System.String"/>
@@ -506,9 +589,9 @@
             <Column Name="IEST" DataType="System.String"/>
             <Column Name="IM" DataType="System.String"/>
             <Column Name="CNAE" DataType="System.String"/>
-            <Column Name="CRT" DataType="NFe.Classes.Informacoes.Emitente.CRT, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null"/>
+            <Column Name="CRT" DataType="NFe.Classes.Informacoes.Emitente.CRT, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null"/>
           </Column>
-          <Column Name="avulsa" DataType="NFe.Classes.Informacoes.avulsa, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
+          <Column Name="avulsa" DataType="NFe.Classes.Informacoes.avulsa, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
             <Column Name="CNPJ" DataType="System.String"/>
             <Column Name="xOrgao" DataType="System.String"/>
             <Column Name="matr" DataType="System.String"/>
@@ -521,12 +604,12 @@
             <Column Name="repEmi" DataType="System.String"/>
             <Column Name="dPag" DataType="System.String"/>
           </Column>
-          <Column Name="dest" DataType="NFe.Classes.Informacoes.Destinatario.dest, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
+          <Column Name="dest" DataType="NFe.Classes.Informacoes.Destinatario.dest, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
             <Column Name="CNPJ" DataType="System.String"/>
             <Column Name="CPF" DataType="System.String"/>
             <Column Name="idEstrangeiro" DataType="System.String"/>
             <Column Name="xNome" DataType="System.String"/>
-            <Column Name="enderDest" DataType="NFe.Classes.Informacoes.Destinatario.enderDest, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
+            <Column Name="enderDest" DataType="NFe.Classes.Informacoes.Destinatario.enderDest, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
               <Column Name="xLgr" DataType="System.String"/>
               <Column Name="nro" DataType="System.String"/>
               <Column Name="xCpl" DataType="System.String"/>
@@ -539,13 +622,13 @@
               <Column Name="xPais" DataType="System.String"/>
               <Column Name="fone" DataType="System.Nullable`1[[System.Int64, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
             </Column>
-            <Column Name="indIEDest" DataType="System.Nullable`1[[NFe.Classes.Informacoes.Destinatario.indIEDest, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null]]"/>
+            <Column Name="indIEDest" DataType="System.Nullable`1[[NFe.Classes.Informacoes.Destinatario.indIEDest, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null]]"/>
             <Column Name="IE" DataType="System.String"/>
             <Column Name="ISUF" DataType="System.String"/>
             <Column Name="IM" DataType="System.String"/>
             <Column Name="email" DataType="System.String"/>
           </Column>
-          <Column Name="retirada" DataType="NFe.Classes.Informacoes.retirada, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
+          <Column Name="retirada" DataType="NFe.Classes.Informacoes.retirada, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
             <Column Name="CNPJ" DataType="System.String"/>
             <Column Name="CPF" DataType="System.String"/>
             <Column Name="xLgr" DataType="System.String"/>
@@ -565,7 +648,7 @@
             <Column Name="email" DataType="System.String"/>
             <Column Name="IE" DataType="System.String"/>
           </Column>
-          <Column Name="entrega" DataType="NFe.Classes.Informacoes.entrega, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
+          <Column Name="entrega" DataType="NFe.Classes.Informacoes.entrega, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
             <Column Name="CNPJ" DataType="System.String"/>
             <Column Name="CPF" DataType="System.String"/>
             <Column Name="xLgr" DataType="System.String"/>
@@ -585,13 +668,13 @@
             <Column Name="email" DataType="System.String"/>
             <Column Name="IE" DataType="System.String"/>
           </Column>
-          <BusinessObjectDataSource Name="autXML" DataType="System.Collections.Generic.List`1[[NFe.Classes.Informacoes.autXML, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
+          <BusinessObjectDataSource Name="autXML" DataType="System.Collections.Generic.List`1[[NFe.Classes.Informacoes.autXML, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
             <Column Name="CNPJ" DataType="System.String"/>
             <Column Name="CPF" DataType="System.String"/>
           </BusinessObjectDataSource>
-          <BusinessObjectDataSource Name="det" DataType="System.Collections.Generic.List`1[[NFe.Classes.Informacoes.Detalhe.det, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
+          <BusinessObjectDataSource Name="det" DataType="System.Collections.Generic.List`1[[NFe.Classes.Informacoes.Detalhe.det, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
             <Column Name="nItem" DataType="System.Int32"/>
-            <Column Name="prod" DataType="NFe.Classes.Informacoes.Detalhe.prod, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
+            <Column Name="prod" DataType="NFe.Classes.Informacoes.Detalhe.prod, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
               <Column Name="cProd" DataType="System.String"/>
               <Column Name="cEAN" DataType="System.String"/>
               <Column Name="xProd" DataType="System.String"/>
@@ -613,20 +696,20 @@
               <Column Name="vSeg" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
               <Column Name="vDesc" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
               <Column Name="vOutro" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
-              <Column Name="indTot" DataType="NFe.Classes.Informacoes.Detalhe.IndicadorTotal, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null"/>
-              <BusinessObjectDataSource Name="DI" DataType="System.Collections.Generic.List`1[[NFe.Classes.Informacoes.Detalhe.DeclaracaoImportacao.DI, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
+              <Column Name="indTot" DataType="NFe.Classes.Informacoes.Detalhe.IndicadorTotal, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null"/>
+              <BusinessObjectDataSource Name="DI" DataType="System.Collections.Generic.List`1[[NFe.Classes.Informacoes.Detalhe.DeclaracaoImportacao.DI, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
                 <Column Name="nDI" DataType="System.String"/>
                 <Column Name="dDI" DataType="System.DateTime"/>
                 <Column Name="xLocDesemb" DataType="System.String"/>
                 <Column Name="UFDesemb" DataType="System.String"/>
                 <Column Name="dDesemb" DataType="System.DateTime"/>
-                <Column Name="tpViaTransp" DataType="NFe.Classes.Informacoes.Detalhe.TipoTransporteInternacional, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null"/>
+                <Column Name="tpViaTransp" DataType="NFe.Classes.Informacoes.Detalhe.TipoTransporteInternacional, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null"/>
                 <Column Name="vAFRMM" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
-                <Column Name="tpIntermedio" DataType="NFe.Classes.Informacoes.Detalhe.TipoIntermediacao, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null"/>
+                <Column Name="tpIntermedio" DataType="NFe.Classes.Informacoes.Detalhe.TipoIntermediacao, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null"/>
                 <Column Name="CNPJ" DataType="System.String"/>
                 <Column Name="UFTerceiro" DataType="System.String"/>
                 <Column Name="cExportador" DataType="System.String"/>
-                <BusinessObjectDataSource Name="adi" DataType="System.Collections.Generic.List`1[[NFe.Classes.Informacoes.Detalhe.DeclaracaoImportacao.adi, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
+                <BusinessObjectDataSource Name="adi" DataType="System.Collections.Generic.List`1[[NFe.Classes.Informacoes.Detalhe.DeclaracaoImportacao.adi, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
                   <Column Name="nAdicao" DataType="System.Int32"/>
                   <Column Name="nSeqAdic" DataType="System.Int32"/>
                   <Column Name="cFabricante" DataType="System.String"/>
@@ -636,9 +719,9 @@
                 <Column Name="ProxydDI" DataType="System.String"/>
                 <Column Name="ProxydDesemb" DataType="System.String"/>
               </BusinessObjectDataSource>
-              <BusinessObjectDataSource Name="detExport" DataType="System.Collections.Generic.List`1[[NFe.Classes.Informacoes.Detalhe.Exportacao.detExport, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
+              <BusinessObjectDataSource Name="detExport" DataType="System.Collections.Generic.List`1[[NFe.Classes.Informacoes.Detalhe.Exportacao.detExport, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
                 <Column Name="nDraw" DataType="System.String"/>
-                <Column Name="exportInd" DataType="NFe.Classes.Informacoes.Detalhe.Exportacao.exportInd, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
+                <Column Name="exportInd" DataType="NFe.Classes.Informacoes.Detalhe.Exportacao.exportInd, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
                   <Column Name="nRE" DataType="System.String"/>
                   <Column Name="chNFe" DataType="System.String"/>
                   <Column Name="qExport" DataType="System.Decimal"/>
@@ -647,14 +730,14 @@
               <Column Name="xPed" DataType="System.String"/>
               <Column Name="nItemPed" DataType="System.Nullable`1[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
               <Column Name="nFCI" DataType="System.String"/>
-              <Column Name="ProdutoEspecifico" DataType="NFe.Classes.Informacoes.Detalhe.ProdEspecifico.ProdutoEspecifico, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
+              <Column Name="ProdutoEspecifico" DataType="NFe.Classes.Informacoes.Detalhe.ProdEspecifico.ProdutoEspecifico, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
                 <Column Name="cProdANP" DataType="System.String"/>
                 <Column Name="pMixGN" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
                 <Column Name="CODIF" DataType="System.String"/>
                 <Column Name="qTemp" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
                 <Column Name="UFCons" DataType="System.String"/>
-                <Column Name="CIDE" Enabled="false" DataType="NFe.Classes.Informacoes.Detalhe.ProdEspecifico.CIDE, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null"/>
-                <Column Name="encerrante" Enabled="false" DataType="NFe.Classes.Informacoes.Detalhe.ProdEspecifico.encerrante, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null"/>
+                <Column Name="CIDE" Enabled="false" DataType="NFe.Classes.Informacoes.Detalhe.ProdEspecifico.CIDE, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null"/>
+                <Column Name="encerrante" Enabled="false" DataType="NFe.Classes.Informacoes.Detalhe.ProdEspecifico.encerrante, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null"/>
                 <Column Name="pMixGNSpecified" DataType="System.Boolean" BindableControl="CheckBox"/>
                 <Column Name="descANP" DataType="System.String"/>
                 <Column Name="pGLP" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
@@ -669,30 +752,47 @@
               </Column>
               <Column Name="nRECOPI" DataType="System.String"/>
               <Column Name="CEST" DataType="System.String"/>
-              <Column Name="indEscala" DataType="System.Nullable`1[[NFe.Classes.Informacoes.Detalhe.indEscala, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null]]"/>
+              <Column Name="indEscala" DataType="System.Nullable`1[[NFe.Classes.Informacoes.Detalhe.indEscala, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null]]"/>
               <Column Name="indEscalaSpecified" DataType="System.Boolean" BindableControl="CheckBox"/>
               <Column Name="CNPJFab" DataType="System.String"/>
               <Column Name="cBenef" DataType="System.String"/>
-              <BusinessObjectDataSource Name="BusinessObjectDataSource1" Alias="rastro" Enabled="false" DataType="System.Collections.Generic.List`1[[NFe.Classes.Informacoes.Detalhe.rastro, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null]]" PropName="rastro"/>
+              <BusinessObjectDataSource Name="BusinessObjectDataSource1" Alias="rastro" Enabled="false" DataType="System.Collections.Generic.List`1[[NFe.Classes.Informacoes.Detalhe.rastro, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null]]" PropName="rastro"/>
             </Column>
-            <Column Name="imposto" DataType="NFe.Classes.Informacoes.Detalhe.Tributacao.imposto, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
+            <Column Name="imposto" DataType="NFe.Classes.Informacoes.Detalhe.Tributacao.imposto, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
               <Column Name="vTotTrib" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
-              <Column Name="ICMS" DataType="NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual.ICMS, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
-                <Column Name="TipoICMS" DataType="NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual.Tipos.ICMSBasico, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
-                  <Column Name="orig" DataType="NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual.Tipos.OrigemMercadoria, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null"/>
-                  <Column Name="CST" DataType="NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual.Tipos.Csticms, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null"/>
-                  <Column Name="vICMSDeson" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
-                  <Column Name="motDesICMS" DataType="System.Nullable`1[[NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual.Tipos.MotivoDesoneracaoIcms, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null]]"/>
+              <Column Name="ICMS" DataType="NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual.ICMS, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
+                <Column Name="TipoICMS" DataType="NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual.Tipos.ICMSBasico, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
+                  <Column Name="orig" DataType="NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual.Tipos.OrigemMercadoria, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null"/>
+                  <Column Name="CSOSN" DataType="NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual.Tipos.Csosnicms, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null"/>
+                  <Column Name="modBC" DataType="System.Nullable`1[[NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual.Tipos.DeterminacaoBaseIcms, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null]]"/>
+                  <Column Name="vBC" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
+                  <Column Name="pRedBC" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
+                  <Column Name="pICMS" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
+                  <Column Name="vICMS" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
+                  <Column Name="modBCST" DataType="System.Nullable`1[[NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual.Tipos.DeterminacaoBaseIcmsSt, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null]]"/>
+                  <Column Name="pMVAST" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
+                  <Column Name="pRedBCST" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
+                  <Column Name="vBCST" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
+                  <Column Name="pICMSST" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
+                  <Column Name="vICMSST" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
+                  <Column Name="vBCFCPST" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
+                  <Column Name="vBCFCPSTSpecified" DataType="System.Boolean" BindableControl="CheckBox"/>
+                  <Column Name="pFCPST" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
+                  <Column Name="pFCPSTSpecified" DataType="System.Boolean" BindableControl="CheckBox"/>
+                  <Column Name="vFCPST" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
+                  <Column Name="vFCPSTSpecified" DataType="System.Boolean" BindableControl="CheckBox"/>
+                  <Column Name="pCredSN" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
+                  <Column Name="vCredICMSSN" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
                 </Column>
               </Column>
-              <Column Name="IPI" DataType="NFe.Classes.Informacoes.Detalhe.Tributacao.Federal.IPI, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
+              <Column Name="IPI" DataType="NFe.Classes.Informacoes.Detalhe.Tributacao.Federal.IPI, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
                 <Column Name="clEnq" DataType="System.String"/>
                 <Column Name="CNPJProd" DataType="System.String"/>
                 <Column Name="cSelo" DataType="System.String"/>
                 <Column Name="qSelo" DataType="System.Nullable`1[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
                 <Column Name="cEnq" DataType="System.Int32"/>
-                <Column Name="TipoIPI" DataType="NFe.Classes.Informacoes.Detalhe.Tributacao.Federal.Tipos.IPIBasico, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
-                  <Column Name="CST" DataType="NFe.Classes.Informacoes.Detalhe.Tributacao.Federal.Tipos.CSTIPI, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null"/>
+                <Column Name="TipoIPI" DataType="NFe.Classes.Informacoes.Detalhe.Tributacao.Federal.Tipos.IPIBasico, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
+                  <Column Name="CST" DataType="NFe.Classes.Informacoes.Detalhe.Tributacao.Federal.Tipos.CSTIPI, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null"/>
                   <Column Name="vBC" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
                   <Column Name="pIPI" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
                   <Column Name="qUnid" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
@@ -701,47 +801,47 @@
                 </Column>
                 <Column Name="ProxycEnq" DataType="System.String"/>
               </Column>
-              <Column Name="II" DataType="NFe.Classes.Informacoes.Detalhe.Tributacao.Federal.II, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
+              <Column Name="II" DataType="NFe.Classes.Informacoes.Detalhe.Tributacao.Federal.II, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
                 <Column Name="vBC" DataType="System.Decimal"/>
                 <Column Name="vDespAdu" DataType="System.Decimal"/>
                 <Column Name="vII" DataType="System.Decimal"/>
                 <Column Name="vIOF" DataType="System.Decimal"/>
               </Column>
-              <Column Name="PIS" DataType="NFe.Classes.Informacoes.Detalhe.Tributacao.Federal.PIS, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
-                <Column Name="TipoPIS" DataType="NFe.Classes.Informacoes.Detalhe.Tributacao.Federal.Tipos.PISBasico, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
-                  <Column Name="CST" DataType="NFe.Classes.Informacoes.Detalhe.Tributacao.Federal.Tipos.CSTPIS, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null"/>
+              <Column Name="PIS" DataType="NFe.Classes.Informacoes.Detalhe.Tributacao.Federal.PIS, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
+                <Column Name="TipoPIS" DataType="NFe.Classes.Informacoes.Detalhe.Tributacao.Federal.Tipos.PISBasico, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
+                  <Column Name="CST" DataType="NFe.Classes.Informacoes.Detalhe.Tributacao.Federal.Tipos.CSTPIS, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null"/>
                   <Column Name="vBC" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
                   <Column Name="pPIS" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
+                  <Column Name="vPIS" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
                   <Column Name="qBCProd" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
                   <Column Name="vAliqProd" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
-                  <Column Name="vPIS" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
                 </Column>
               </Column>
-              <Column Name="PISST" DataType="NFe.Classes.Informacoes.Detalhe.Tributacao.Federal.PISST, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
+              <Column Name="PISST" DataType="NFe.Classes.Informacoes.Detalhe.Tributacao.Federal.PISST, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
                 <Column Name="vBC" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
                 <Column Name="pPIS" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
                 <Column Name="qBCProd" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
                 <Column Name="vAliqProd" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
                 <Column Name="vPIS" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
               </Column>
-              <Column Name="COFINS" DataType="NFe.Classes.Informacoes.Detalhe.Tributacao.Federal.COFINS, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
-                <Column Name="TipoCOFINS" DataType="NFe.Classes.Informacoes.Detalhe.Tributacao.Federal.Tipos.COFINSBasico, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
-                  <Column Name="CST" DataType="NFe.Classes.Informacoes.Detalhe.Tributacao.Federal.Tipos.CSTCOFINS, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null"/>
+              <Column Name="COFINS" DataType="NFe.Classes.Informacoes.Detalhe.Tributacao.Federal.COFINS, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
+                <Column Name="TipoCOFINS" DataType="NFe.Classes.Informacoes.Detalhe.Tributacao.Federal.Tipos.COFINSBasico, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
+                  <Column Name="CST" DataType="NFe.Classes.Informacoes.Detalhe.Tributacao.Federal.Tipos.CSTCOFINS, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null"/>
                   <Column Name="vBC" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
                   <Column Name="pCOFINS" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
+                  <Column Name="vCOFINS" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
                   <Column Name="qBCProd" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
                   <Column Name="vAliqProd" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
-                  <Column Name="vCOFINS" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
                 </Column>
               </Column>
-              <Column Name="COFINSST" DataType="NFe.Classes.Informacoes.Detalhe.Tributacao.Federal.COFINSST, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
+              <Column Name="COFINSST" DataType="NFe.Classes.Informacoes.Detalhe.Tributacao.Federal.COFINSST, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
                 <Column Name="vBC" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
                 <Column Name="pCOFINS" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
                 <Column Name="qBCProd" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
                 <Column Name="vAliqProd" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
                 <Column Name="vCOFINS" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
               </Column>
-              <Column Name="ISSQN" DataType="NFe.Classes.Informacoes.Detalhe.Tributacao.Municipal.ISSQN, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
+              <Column Name="ISSQN" DataType="NFe.Classes.Informacoes.Detalhe.Tributacao.Municipal.ISSQN, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
                 <Column Name="vBC" DataType="System.Decimal"/>
                 <Column Name="vAliq" DataType="System.Decimal"/>
                 <Column Name="vISSQN" DataType="System.Decimal"/>
@@ -756,21 +856,21 @@
                 <Column Name="cMun" DataType="System.Nullable`1[[System.Int64, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
                 <Column Name="cPais" DataType="System.Nullable`1[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
                 <Column Name="nProcesso" DataType="System.String"/>
-                <Column Name="indIncentivo" DataType="NFe.Classes.Informacoes.Detalhe.Tributacao.Municipal.indIncentivo, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null"/>
-                <Column Name="indISS" DataType="NFe.Classes.Informacoes.Detalhe.Tributacao.Municipal.IndicadorISS, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null"/>
+                <Column Name="indIncentivo" DataType="NFe.Classes.Informacoes.Detalhe.Tributacao.Municipal.indIncentivo, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null"/>
+                <Column Name="indISS" DataType="NFe.Classes.Informacoes.Detalhe.Tributacao.Municipal.IndicadorISS, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null"/>
               </Column>
-              <Column Name="ICMSUFDest" Enabled="false" DataType="NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual.ICMSUFDest, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null"/>
+              <Column Name="ICMSUFDest" Enabled="false" DataType="NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual.ICMSUFDest, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null"/>
             </Column>
-            <Column Name="impostoDevol" DataType="NFe.Classes.Informacoes.Detalhe.impostoDevol, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
+            <Column Name="impostoDevol" DataType="NFe.Classes.Informacoes.Detalhe.impostoDevol, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
               <Column Name="pDevol" DataType="System.Decimal"/>
-              <Column Name="IPI" DataType="NFe.Classes.Informacoes.Detalhe.IPIDevolvido, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
+              <Column Name="IPI" DataType="NFe.Classes.Informacoes.Detalhe.IPIDevolvido, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
                 <Column Name="vIPIDevol" DataType="System.Decimal"/>
               </Column>
             </Column>
             <Column Name="infAdProd" DataType="System.String"/>
           </BusinessObjectDataSource>
-          <Column Name="total" DataType="NFe.Classes.Informacoes.Total.total, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
-            <Column Name="ICMSTot" DataType="NFe.Classes.Informacoes.Total.ICMSTot, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
+          <Column Name="total" DataType="NFe.Classes.Informacoes.Total.total, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
+            <Column Name="ICMSTot" DataType="NFe.Classes.Informacoes.Total.ICMSTot, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
               <Column Name="vBC" DataType="System.Decimal"/>
               <Column Name="vICMS" DataType="System.Decimal"/>
               <Column Name="vICMSDeson" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
@@ -799,7 +899,7 @@
               <Column Name="vIPIDevol" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
               <Column Name="vIPIDevolSpecified" DataType="System.Boolean" BindableControl="CheckBox"/>
             </Column>
-            <Column Name="ISSQNtot" DataType="NFe.Classes.Informacoes.Total.ISSQNtot, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
+            <Column Name="ISSQNtot" DataType="NFe.Classes.Informacoes.Total.ISSQNtot, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
               <Column Name="vServ" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
               <Column Name="vBC" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
               <Column Name="vISS" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
@@ -811,9 +911,9 @@
               <Column Name="vDescIncond" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
               <Column Name="vDescCond" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
               <Column Name="vISSRet" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
-              <Column Name="cRegTrib" DataType="System.Nullable`1[[NFe.Classes.Informacoes.Total.RegTribISSQN, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null]]"/>
+              <Column Name="cRegTrib" DataType="System.Nullable`1[[NFe.Classes.Informacoes.Total.RegTribISSQN, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null]]"/>
             </Column>
-            <Column Name="retTrib" DataType="NFe.Classes.Informacoes.Total.retTrib, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
+            <Column Name="retTrib" DataType="NFe.Classes.Informacoes.Total.retTrib, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
               <Column Name="vRetPIS" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
               <Column Name="vRetCOFINS" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
               <Column Name="vRetCSLL" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
@@ -823,9 +923,9 @@
               <Column Name="vRetPrev" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
             </Column>
           </Column>
-          <Column Name="transp" DataType="NFe.Classes.Informacoes.Transporte.transp, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
-            <Column Name="modFrete" DataType="System.Nullable`1[[NFe.Classes.Informacoes.Transporte.ModalidadeFrete, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null]]"/>
-            <Column Name="transporta" DataType="NFe.Classes.Informacoes.Transporte.transporta, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
+          <Column Name="transp" DataType="NFe.Classes.Informacoes.Transporte.transp, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
+            <Column Name="modFrete" DataType="System.Nullable`1[[NFe.Classes.Informacoes.Transporte.ModalidadeFrete, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null]]"/>
+            <Column Name="transporta" DataType="NFe.Classes.Informacoes.Transporte.transporta, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
               <Column Name="CNPJ" DataType="System.String"/>
               <Column Name="CPF" DataType="System.String"/>
               <Column Name="xNome" DataType="System.String"/>
@@ -834,7 +934,7 @@
               <Column Name="xMun" DataType="System.String"/>
               <Column Name="UF" DataType="System.String"/>
             </Column>
-            <Column Name="retTransp" DataType="NFe.Classes.Informacoes.Transporte.retTransp, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
+            <Column Name="retTransp" DataType="NFe.Classes.Informacoes.Transporte.retTransp, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
               <Column Name="vServ" DataType="System.Decimal"/>
               <Column Name="vBCRet" DataType="System.Decimal"/>
               <Column Name="pICMSRet" DataType="System.Decimal"/>
@@ -842,24 +942,24 @@
               <Column Name="CFOP" DataType="System.Int32"/>
               <Column Name="cMunFG" DataType="System.Int64"/>
             </Column>
-            <Column Name="veicTransp" DataType="NFe.Classes.Informacoes.Transporte.veicTransp, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
+            <Column Name="veicTransp" DataType="NFe.Classes.Informacoes.Transporte.veicTransp, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
               <Column Name="placa" DataType="System.String"/>
               <Column Name="UF" DataType="System.String"/>
               <Column Name="RNTC" DataType="System.String"/>
             </Column>
-            <BusinessObjectDataSource Name="reboque" DataType="System.Collections.Generic.List`1[[NFe.Classes.Informacoes.Transporte.reboque, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
+            <BusinessObjectDataSource Name="reboque" DataType="System.Collections.Generic.List`1[[NFe.Classes.Informacoes.Transporte.reboque, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
               <Column Name="placa" DataType="System.String"/>
               <Column Name="UF" DataType="System.String"/>
               <Column Name="RNTC" DataType="System.String"/>
             </BusinessObjectDataSource>
-            <BusinessObjectDataSource Name="vol" DataType="System.Collections.Generic.List`1[[NFe.Classes.Informacoes.Transporte.vol, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
+            <BusinessObjectDataSource Name="vol" DataType="System.Collections.Generic.List`1[[NFe.Classes.Informacoes.Transporte.vol, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
               <Column Name="qVol" DataType="System.Nullable`1[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
               <Column Name="esp" DataType="System.String"/>
               <Column Name="marca" DataType="System.String"/>
               <Column Name="nVol" DataType="System.String"/>
               <Column Name="pesoL" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
               <Column Name="pesoB" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
-              <BusinessObjectDataSource Name="lacres" DataType="System.Collections.Generic.List`1[[NFe.Classes.Informacoes.Transporte.lacres, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
+              <BusinessObjectDataSource Name="lacres" DataType="System.Collections.Generic.List`1[[NFe.Classes.Informacoes.Transporte.lacres, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
                 <Column Name="nLacre" DataType="System.String"/>
               </BusinessObjectDataSource>
             </BusinessObjectDataSource>
@@ -867,72 +967,72 @@
             <Column Name="balsa" DataType="System.String"/>
             <Column Name="modFreteSpecified" DataType="System.Boolean" BindableControl="CheckBox"/>
           </Column>
-          <Column Name="cobr" DataType="NFe.Classes.Informacoes.Cobranca.cobr, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
-            <Column Name="fat" DataType="NFe.Classes.Informacoes.Cobranca.fat, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
+          <Column Name="cobr" DataType="NFe.Classes.Informacoes.Cobranca.cobr, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
+            <Column Name="fat" DataType="NFe.Classes.Informacoes.Cobranca.fat, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
               <Column Name="nFat" DataType="System.String"/>
               <Column Name="vOrig" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
               <Column Name="vDesc" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
               <Column Name="vLiq" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
             </Column>
-            <BusinessObjectDataSource Name="dup" DataType="System.Collections.Generic.List`1[[NFe.Classes.Informacoes.Cobranca.dup, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
+            <BusinessObjectDataSource Name="dup" DataType="System.Collections.Generic.List`1[[NFe.Classes.Informacoes.Cobranca.dup, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
               <Column Name="nDup" DataType="System.String"/>
               <Column Name="dVenc" DataType="System.Nullable`1[[System.DateTime, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
               <Column Name="vDup" DataType="System.Decimal"/>
               <Column Name="ProxydVenc" DataType="System.String"/>
             </BusinessObjectDataSource>
           </Column>
-          <BusinessObjectDataSource Name="pag" DataType="System.Collections.Generic.List`1[[NFe.Classes.Informacoes.Pagamento.pag, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
-            <Column Name="tPag" DataType="System.Nullable`1[[NFe.Classes.Informacoes.Pagamento.FormaPagamento, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null]]"/>
+          <BusinessObjectDataSource Name="pag" DataType="System.Collections.Generic.List`1[[NFe.Classes.Informacoes.Pagamento.pag, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
+            <Column Name="tPag" DataType="System.Nullable`1[[NFe.Classes.Informacoes.Pagamento.FormaPagamento, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null]]"/>
             <Column Name="vPag" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
-            <Column Name="card" DataType="NFe.Classes.Informacoes.Pagamento.card, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
-              <Column Name="tpIntegra" DataType="System.Nullable`1[[NFe.Classes.Informacoes.Pagamento.TipoIntegracaoPagamento, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null]]"/>
+            <Column Name="card" DataType="NFe.Classes.Informacoes.Pagamento.card, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
+              <Column Name="tpIntegra" DataType="System.Nullable`1[[NFe.Classes.Informacoes.Pagamento.TipoIntegracaoPagamento, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null]]"/>
               <Column Name="CNPJ" DataType="System.String"/>
-              <Column Name="tBand" DataType="System.Nullable`1[[NFe.Classes.Informacoes.Pagamento.BandeiraCartao, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null]]"/>
+              <Column Name="tBand" DataType="System.Nullable`1[[NFe.Classes.Informacoes.Pagamento.BandeiraCartao, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null]]"/>
               <Column Name="cAut" DataType="System.String"/>
             </Column>
-            <BusinessObjectDataSource Name="BusinessObjectDataSource2" Alias="detPag" Enabled="false" DataType="System.Collections.Generic.List`1[[NFe.Classes.Informacoes.Pagamento.detPag, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null]]" PropName="detPag"/>
+            <BusinessObjectDataSource Name="BusinessObjectDataSource2" Alias="detPag" Enabled="false" DataType="System.Collections.Generic.List`1[[NFe.Classes.Informacoes.Pagamento.detPag, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null]]" PropName="detPag"/>
             <Column Name="vTroco" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
             <Column Name="vTrocoSpecified" DataType="System.Boolean" BindableControl="CheckBox"/>
             <Column Name="tPagSpecified" DataType="System.Boolean" BindableControl="CheckBox"/>
             <Column Name="vPagSpecified" DataType="System.Boolean" BindableControl="CheckBox"/>
           </BusinessObjectDataSource>
-          <Column Name="infAdic" DataType="NFe.Classes.Informacoes.Observacoes.infAdic, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
+          <Column Name="infAdic" DataType="NFe.Classes.Informacoes.Observacoes.infAdic, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
             <Column Name="infAdFisco" DataType="System.String"/>
             <Column Name="infCpl" DataType="System.String"/>
-            <BusinessObjectDataSource Name="obsCont" DataType="System.Collections.Generic.List`1[[NFe.Classes.Informacoes.Observacoes.obsCont, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
+            <BusinessObjectDataSource Name="obsCont" DataType="System.Collections.Generic.List`1[[NFe.Classes.Informacoes.Observacoes.obsCont, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
               <Column Name="xCampo" DataType="System.String"/>
               <Column Name="xTexto" DataType="System.String"/>
             </BusinessObjectDataSource>
-            <BusinessObjectDataSource Name="obsFisco" DataType="System.Collections.Generic.List`1[[NFe.Classes.Informacoes.Observacoes.obsFisco, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
+            <BusinessObjectDataSource Name="obsFisco" DataType="System.Collections.Generic.List`1[[NFe.Classes.Informacoes.Observacoes.obsFisco, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
               <Column Name="xCampo" DataType="System.String"/>
               <Column Name="xTexto" DataType="System.String"/>
             </BusinessObjectDataSource>
-            <BusinessObjectDataSource Name="procRef" DataType="System.Collections.Generic.List`1[[NFe.Classes.Informacoes.Observacoes.procRef, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
+            <BusinessObjectDataSource Name="procRef" DataType="System.Collections.Generic.List`1[[NFe.Classes.Informacoes.Observacoes.procRef, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
               <Column Name="nProc" DataType="System.String"/>
-              <Column Name="indProc" DataType="NFe.Classes.Informacoes.Observacoes.IndicadorProcesso, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null"/>
+              <Column Name="indProc" DataType="NFe.Classes.Informacoes.Observacoes.IndicadorProcesso, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null"/>
             </BusinessObjectDataSource>
           </Column>
-          <Column Name="exporta" DataType="NFe.Classes.Informacoes.exporta, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
+          <Column Name="exporta" DataType="NFe.Classes.Informacoes.exporta, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
             <Column Name="UFSaidaPais" DataType="System.String"/>
             <Column Name="xLocExporta" DataType="System.String"/>
             <Column Name="xLocDespacho" DataType="System.String"/>
           </Column>
-          <Column Name="compra" DataType="NFe.Classes.Informacoes.compra, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
+          <Column Name="compra" DataType="NFe.Classes.Informacoes.compra, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
             <Column Name="xNEmp" DataType="System.String"/>
             <Column Name="xPed" DataType="System.String"/>
             <Column Name="xCont" DataType="System.String"/>
           </Column>
-          <Column Name="cana" DataType="NFe.Classes.Informacoes.Cana.cana, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
+          <Column Name="cana" DataType="NFe.Classes.Informacoes.Cana.cana, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
             <Column Name="safra" DataType="System.String"/>
             <Column Name="ref" DataType="System.String"/>
-            <BusinessObjectDataSource Name="forDia" DataType="System.Collections.Generic.List`1[[NFe.Classes.Informacoes.Cana.forDia, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
+            <BusinessObjectDataSource Name="forDia" DataType="System.Collections.Generic.List`1[[NFe.Classes.Informacoes.Cana.forDia, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
               <Column Name="dia" DataType="System.Int32"/>
               <Column Name="qtde" DataType="System.Decimal"/>
               <Column Name="qTotMes" DataType="System.Decimal"/>
               <Column Name="qTotAnt" DataType="System.Decimal"/>
               <Column Name="qTotGer" DataType="System.Decimal"/>
             </BusinessObjectDataSource>
-            <BusinessObjectDataSource Name="deduc" DataType="System.Collections.Generic.List`1[[NFe.Classes.Informacoes.Cana.deduc, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
+            <BusinessObjectDataSource Name="deduc" DataType="System.Collections.Generic.List`1[[NFe.Classes.Informacoes.Cana.deduc, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
               <Column Name="xDed" DataType="System.String"/>
               <Column Name="vDed" DataType="System.Decimal"/>
               <Column Name="vFor" DataType="System.Decimal"/>
@@ -940,44 +1040,44 @@
               <Column Name="vLiqFor" DataType="System.Decimal"/>
             </BusinessObjectDataSource>
           </Column>
-          <Column Name="infRespTec" Enabled="false" DataType="Shared.NFe.Classes.Informacoes.InfRespTec.infRespTec, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null"/>
+          <Column Name="infRespTec" Enabled="false" DataType="Shared.NFe.Classes.Informacoes.InfRespTec.infRespTec, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null"/>
         </Column>
-        <Column Name="infNFeSupl" DataType="NFe.Classes.infNFeSupl, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
+        <Column Name="infNFeSupl" DataType="NFe.Classes.infNFeSupl, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
           <Column Name="qrCode" DataType="System.String"/>
           <Column Name="urlChave" DataType="System.String"/>
         </Column>
-        <Column Name="Signature" DataType="DFe.Classes.Assinatura.Signature, DFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
-          <Column Name="SignedInfo" DataType="DFe.Classes.Assinatura.SignedInfo, DFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
-            <Column Name="CanonicalizationMethod" DataType="DFe.Classes.Assinatura.CanonicalizationMethod, DFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
+        <Column Name="Signature" DataType="DFe.Classes.Assinatura.Signature, DFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
+          <Column Name="SignedInfo" DataType="DFe.Classes.Assinatura.SignedInfo, DFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
+            <Column Name="CanonicalizationMethod" DataType="DFe.Classes.Assinatura.CanonicalizationMethod, DFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
               <Column Name="Algorithm" DataType="System.String"/>
             </Column>
-            <Column Name="SignatureMethod" DataType="DFe.Classes.Assinatura.SignatureMethod, DFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
+            <Column Name="SignatureMethod" DataType="DFe.Classes.Assinatura.SignatureMethod, DFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
               <Column Name="Algorithm" DataType="System.String"/>
             </Column>
-            <Column Name="Reference" DataType="DFe.Classes.Assinatura.Reference, DFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
+            <Column Name="Reference" DataType="DFe.Classes.Assinatura.Reference, DFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
               <Column Name="URI" DataType="System.String"/>
-              <BusinessObjectDataSource Name="Transforms" DataType="System.Collections.Generic.List`1[[DFe.Classes.Assinatura.Transform, DFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
+              <BusinessObjectDataSource Name="Transforms" DataType="System.Collections.Generic.List`1[[DFe.Classes.Assinatura.Transform, DFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
                 <Column Name="Algorithm" DataType="System.String"/>
               </BusinessObjectDataSource>
-              <Column Name="DigestMethod" DataType="DFe.Classes.Assinatura.DigestMethod, DFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
+              <Column Name="DigestMethod" DataType="DFe.Classes.Assinatura.DigestMethod, DFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
                 <Column Name="Algorithm" DataType="System.String"/>
               </Column>
               <Column Name="DigestValue" DataType="System.String"/>
             </Column>
           </Column>
           <Column Name="SignatureValue" DataType="System.String"/>
-          <Column Name="KeyInfo" DataType="DFe.Classes.Assinatura.KeyInfo, DFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
-            <Column Name="X509Data" DataType="DFe.Classes.Assinatura.X509Data, DFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
+          <Column Name="KeyInfo" DataType="DFe.Classes.Assinatura.KeyInfo, DFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
+            <Column Name="X509Data" DataType="DFe.Classes.Assinatura.X509Data, DFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
               <Column Name="X509Certificate" DataType="System.String"/>
             </Column>
           </Column>
         </Column>
       </Column>
-      <Column Name="protNFe" DataType="NFe.Classes.Protocolo.protNFe, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
+      <Column Name="protNFe" DataType="NFe.Classes.Protocolo.protNFe, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
         <Column Name="versao" DataType="System.String"/>
-        <Column Name="infProt" DataType="NFe.Classes.Protocolo.infProt, NFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
+        <Column Name="infProt" DataType="NFe.Classes.Protocolo.infProt, NFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
           <Column Name="Id" DataType="System.String"/>
-          <Column Name="tpAmb" DataType="DFe.Classes.Flags.TipoAmbiente, DFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null"/>
+          <Column Name="tpAmb" DataType="DFe.Classes.Flags.TipoAmbiente, DFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null"/>
           <Column Name="verAplic" DataType="System.String"/>
           <Column Name="chNFe" DataType="System.String"/>
           <Column Name="dhRecbto" DataType="System.DateTime"/>
@@ -985,28 +1085,28 @@
           <Column Name="digVal" DataType="System.String"/>
           <Column Name="cStat" DataType="System.Int32"/>
           <Column Name="xMotivo" DataType="System.String"/>
-          <Column Name="Signature" DataType="DFe.Classes.Assinatura.Signature, DFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
-            <Column Name="SignedInfo" DataType="DFe.Classes.Assinatura.SignedInfo, DFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
-              <Column Name="CanonicalizationMethod" DataType="DFe.Classes.Assinatura.CanonicalizationMethod, DFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
+          <Column Name="Signature" DataType="DFe.Classes.Assinatura.Signature, DFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
+            <Column Name="SignedInfo" DataType="DFe.Classes.Assinatura.SignedInfo, DFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
+              <Column Name="CanonicalizationMethod" DataType="DFe.Classes.Assinatura.CanonicalizationMethod, DFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
                 <Column Name="Algorithm" DataType="System.String"/>
               </Column>
-              <Column Name="SignatureMethod" DataType="DFe.Classes.Assinatura.SignatureMethod, DFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
+              <Column Name="SignatureMethod" DataType="DFe.Classes.Assinatura.SignatureMethod, DFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
                 <Column Name="Algorithm" DataType="System.String"/>
               </Column>
-              <Column Name="Reference" DataType="DFe.Classes.Assinatura.Reference, DFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
+              <Column Name="Reference" DataType="DFe.Classes.Assinatura.Reference, DFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
                 <Column Name="URI" DataType="System.String"/>
-                <BusinessObjectDataSource Name="Transforms1" Alias="Transforms" DataType="System.Collections.Generic.List`1[[DFe.Classes.Assinatura.Transform, DFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null]]" PropName="Transforms" Enabled="true">
+                <BusinessObjectDataSource Name="Transforms1" Alias="Transforms" DataType="System.Collections.Generic.List`1[[DFe.Classes.Assinatura.Transform, DFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null]]" PropName="Transforms" Enabled="true">
                   <Column Name="Algorithm" DataType="System.String"/>
                 </BusinessObjectDataSource>
-                <Column Name="DigestMethod" DataType="DFe.Classes.Assinatura.DigestMethod, DFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
+                <Column Name="DigestMethod" DataType="DFe.Classes.Assinatura.DigestMethod, DFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
                   <Column Name="Algorithm" DataType="System.String"/>
                 </Column>
                 <Column Name="DigestValue" DataType="System.String"/>
               </Column>
             </Column>
             <Column Name="SignatureValue" DataType="System.String"/>
-            <Column Name="KeyInfo" DataType="DFe.Classes.Assinatura.KeyInfo, DFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
-              <Column Name="X509Data" DataType="DFe.Classes.Assinatura.X509Data, DFe.Classes, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null">
+            <Column Name="KeyInfo" DataType="DFe.Classes.Assinatura.KeyInfo, DFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
+              <Column Name="X509Data" DataType="DFe.Classes.Assinatura.X509Data, DFe.Classes, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null">
                 <Column Name="X509Certificate" DataType="System.String"/>
               </Column>
             </Column>
@@ -1031,12 +1131,12 @@
     <Parameter Name="ContingenciaID" DataType="System.String"/>
     <Parameter Name="ImprimirISSQN" DataType="System.Boolean"/>
     <Parameter Name="Logo" DataType="System.Byte[]"/>
-    <Parameter Name="ImprimirUnidQtdeValor" DataType="NFe.Danfe.Base.NFe.ImprimirUnidQtdeValor, NFe.Danfe.Base, Version=1.0.0.763, Culture=neutral, PublicKeyToken=null"/>
+    <Parameter Name="ImprimirUnidQtdeValor" DataType="NFe.Danfe.Base.NFe.ImprimirUnidQtdeValor, NFe.Danfe.Base, Version=1.0.0.768, Culture=neutral, PublicKeyToken=null"/>
     <Parameter Name="ExibeCampoFatura" DataType="System.Boolean"/>
     <Parameter Name="ExibirTotalTributos" DataType="System.Boolean"/>
     <Parameter Name="DecimaisValorUnitario" DataType="System.Int32"/>
     <Parameter Name="DecimaisQuantidadeItem" DataType="System.Int32"/>
-    <Parameter Name="DataHoraImpressao" DateType="System.DateTime"/>
+    <Parameter Name="DataHoraImpressao" DataType="System.DateTime"/>
   </Dictionary>
   <ReportPage Name="Page1" LeftMargin="6" TopMargin="7" RightMargin="7" BottomMargin="7">
     <ReportTitleBand Name="Canhoto" Width="744.66" Height="79.37">
@@ -1046,7 +1146,7 @@
       <LineObject Name="Line1" Top="73.81" Width="744.57" Border.Style="Dot" Border.Width="0.5"/>
       <TextObject Name="Memo17" Left="642.52" Width="102.05" Height="68.03" Border.Lines="All" Border.Width="0.5" Text="NF-e&#13;&#10;Nº [Format(&quot;{0:000,000,000}&quot;,[NFe.NFe.infNFe.ide.nNF])]&#13;&#10;Série [Format(&quot;{0:000}&quot;, [NFe.NFe.infNFe.ide.serie])]" Padding="2, 2, 2, 2" HorzAlign="Center" VertAlign="Center" Font="Times New Roman, 10pt, style=Bold"/>
     </ReportTitleBand>
-    <PageHeaderBand Name="Emitente" Top="82.04" Width="744.66" Height="173.86" BeforePrintEvent="Emitente_BeforePrint">
+    <PageHeaderBand Name="Emitente" Top="82.57" Width="744.66" Height="173.86" BeforePrintEvent="Emitente_BeforePrint">
       <TextObject Name="Memo12" Left="310.34" Top="16.9" Width="113.4" Height="26.46" CanShrink="true" Text="Documento Auxiliar da &#13;&#10;Nota Fiscal Eletrônica" Padding="2, 1, 2, 1" HorzAlign="Center" VertAlign="Center" Font="Times New Roman, 8pt"/>
       <TextObject Name="Memo9" Left="309.92" Width="113.39" Height="120.94" Border.Lines="All" Border.Width="0.5" Text="DANFE" Padding="2, 2, 2, 2" HorzAlign="Center" Font="Times New Roman, 12pt, style=Bold"/>
       <TextObject Name="Memo15" Left="313.72" Top="41.9" Width="75.59" Height="32.13" Text="0 - ENTRADA&#13;&#10;1 - SAÍDA" Padding="2, 1, 2, 1" VertAlign="Center" Font="Times New Roman, 8pt"/>
@@ -1072,7 +1172,7 @@
       <BarcodeObject Name="BarcodeChave" Left="445.66" Top="5.67" Width="277.07" Height="37.8" AutoSize="false" Text="123456789012345678946546546579878454676546546546546556465" ShowText="false" AllowExpressions="true" Barcode="Code128" Barcode.CalcCheckSum="false" Barcode.AutoEncode="true"/>
       <BarcodeObject Name="BarCodeContigencia" Left="445.66" Top="83.16" Width="277.07" Height="34.02" ShiftMode="WhenOverlapped" AutoSize="false" Text="123456789012345678946546546579878454676546546546546556465" ShowText="false" AllowExpressions="true" Barcode="Code128" Barcode.CalcCheckSum="false" Barcode.AutoEncode="true"/>
     </PageHeaderBand>
-    <DataBand Name="Destinatario" Top="258.56" Width="744.66" Height="96.27">
+    <DataBand Name="Destinatario" Top="259.63" Width="744.66" Height="96.27">
       <TextObject Name="Memo29" Top="16.9" Width="468.66" Height="26.46" Border.Lines="All" Border.Width="0.5" Text="NOME / RAZÃO SOCIAL" Padding="2, 2, 2, 2" Font="Times New Roman, 5pt"/>
       <TextObject Name="Memo30" Top="26.35" Width="464.88" Height="17.01" Text="[NFe.NFe.infNFe.dest.xNome]" Padding="5, 1, 5, 1" WordWrap="false" Font="Times New Roman, 8pt"/>
       <TextObject Name="Memo31" Left="631.18" Top="16.9" Width="113.39" Height="26.46" Border.Lines="All" Border.Width="0.5" Text="DATA DA EMISSÃO" Padding="2, 2, 2, 2" Font="Times New Roman, 5pt"/>
@@ -1099,7 +1199,7 @@
       <TextObject Name="Memo52" Left="498.9" Top="79.26" Width="132.28" Height="17.01" Text="[NFe.NFe.infNFe.dest.IE]" Padding="5, 1, 5, 1" VertAlign="Bottom" Font="Times New Roman, 8pt"/>
       <TextObject Name="Memo53" Top="3.78" Width="430.87" Height="13.23" Text="DESTINATÁRIO / REMETENTE" Padding="0, 1, 0, 1" VertAlign="Bottom" Font="Times New Roman, 7pt, style=Bold"/>
     </DataBand>
-    <DataBand Name="LocalRetirada" Top="357.5" Width="744.66" Height="100.06">
+    <DataBand Name="LocalRetirada" Top="359.1" Width="744.66" Height="100.06">
       <TextObject Name="Memo11" Left="633.15" Top="28.35" Width="103.94" Height="17.01" Text="[FormatarCampo(ToString(IIf([NFe.NFe.infNFe.retirada.IE] == &quot;&quot; || [NFe.NFe.infNFe.retirada.IE] == null, [NFe.NFe.infNFe.retirada.IE], [NFe.NFe.infNFe.retirada.IE])), 'd')]&#13;&#10;" Padding="2, 2, 2, 2" VertAlign="Bottom" WordWrap="false" Font="Times New Roman, 8pt"/>
       <TextObject Name="Memo18" Left="-0.01" Top="54.7" Width="376.03" Height="17.01" Text="[NFe.NFe.infNFe.retirada.xLgr], [NFe.NFe.infNFe.retirada.nro] [NFe.NFe.infNFe.retirada.xCpl]" Padding="2, 2, 2, 2" VertAlign="Bottom" WordWrap="false" Font="Times New Roman, 8pt"/>
       <TextObject Name="Memo185" Top="3.78" Width="430.87" Height="13.23" Text="LOCAL RETIRADA" Padding="0, 1, 0, 1" VertAlign="Bottom" Font="Times New Roman, 7pt, style=Bold"/>
@@ -1120,7 +1220,7 @@
       <TextObject Name="Text188" Left="604.65" Top="81.27" Width="20.79" Height="17.01" Text="[NFe.NFe.infNFe.retirada.UF]" Padding="2, 2, 2, 2" VertAlign="Bottom" WordWrap="false" Font="Times New Roman, 8pt"/>
       <TextObject Name="Text189" Left="631.26" Top="81.27" Width="115.29" Height="17.01" Text="[FormatarCampo(ToString(IIf([NFe.NFe.infNFe.retirada.Fone] == &quot;&quot; || [NFe.NFe.infNFe.retirada.Fone] == null, [NFe.NFe.infNFe.retirada.Fone], [NFe.NFe.infNFe.retirada.Fone])), 'f')]&#13;&#10;" Padding="5, 1, 5, 1" VertAlign="Bottom" WordWrap="false" Font="Times New Roman, 8pt"/>
     </DataBand>
-    <DataBand Name="LocalEntrega" Top="460.23" Width="744.66" Height="100.06">
+    <DataBand Name="LocalEntrega" Top="462.36" Width="744.66" Height="100.06">
       <TextObject Name="Text190" Left="633.15" Top="28.35" Width="103.94" Height="17.01" Text="[FormatarCampo(ToString(IIf([NFe.NFe.infNFe.entrega.IE] == &quot;&quot; || [NFe.NFe.infNFe.entrega.IE] == null, [NFe.NFe.infNFe.entrega.IE], [NFe.NFe.infNFe.entrega.IE])), 'd')]&#13;&#10;" Padding="2, 2, 2, 2" VertAlign="Bottom" WordWrap="false" Font="Times New Roman, 8pt"/>
       <TextObject Name="Text191" Left="-0.01" Top="54.7" Width="376.03" Height="17.01" Text="[NFe.NFe.infNFe.entrega.xLgr], [NFe.NFe.infNFe.entrega.nro] [NFe.NFe.infNFe.entrega.xCpl]" Padding="2, 2, 2, 2" VertAlign="Bottom" WordWrap="false" Font="Times New Roman, 8pt"/>
       <TextObject Name="Text192" Top="3.78" Width="430.87" Height="13.23" Text="LOCAL ENTREGA" Padding="0, 1, 0, 1" VertAlign="Bottom" Font="Times New Roman, 7pt, style=Bold"/>
@@ -1141,25 +1241,25 @@
       <TextObject Name="Text207" Left="604.8" Top="81.27" Width="20.79" Height="17.01" Text="[NFe.NFe.infNFe.entrega.UF]" Padding="2, 2, 2, 2" VertAlign="Bottom" WordWrap="false" Font="Times New Roman, 8pt"/>
       <TextObject Name="Text208" Left="631.26" Top="81.27" Width="115.29" Height="17.01" Text="[FormatarCampo(ToString(IIf([NFe.NFe.infNFe.entrega.Fone] == &quot;&quot; || [NFe.NFe.infNFe.entrega.Fone] == null, [NFe.NFe.infNFe.entrega.Fone], [NFe.NFe.infNFe.entrega.Fone])), 'f')]&#13;&#10;" Padding="5, 1, 5, 1" VertAlign="Bottom" WordWrap="false" Font="Times New Roman, 8pt"/>
     </DataBand>
-    <DataBand Name="Fatura" Top="562.95" Width="744.66" Height="43.46">
+    <DataBand Name="Fatura" Top="565.62" Width="744.66" Height="43.46">
       <TextObject Name="Memo146" Top="17.01" Width="744.57" Height="20.79" Border.Lines="All" Border.Width="0.5" Text="DADOS DA FATURA" Padding="3, 0, 3, 0" VertAlign="Center" WordWrap="false" Font="Times New Roman, 8pt"/>
       <TextObject Name="Memo190" Top="3.78" Width="430.87" Height="13.23" Text="FATURA" Padding="0, 1, 0, 1" VertAlign="Bottom" Font="Times New Roman, 7pt, style=Bold"/>
       <TextObject Name="MemoFatura" Left="128.5" Top="17.01" Width="616.06" Height="20.79" Border.Lines="All" Border.Width="0.5" Text="  Número:   [NFe.NFe.infNFe.cobr.fat.nFat]    -   Valor Original: [FormatCurrency([NFe.NFe.infNFe.cobr.fat.vOrig])]    -   Valor Desconto:  [FormatCurrency([NFe.NFe.infNFe.cobr.fat.vDesc])]    -   ValorLíquido: [FormatCurrency([NFe.NFe.infNFe.cobr.fat.vLiq])]" Padding="3, 0, 3, 0" VertAlign="Center" WordWrap="false" Font="Times New Roman, 8pt"/>
     </DataBand>
-    <GroupHeaderBand Name="DuplicatasHeader" Top="609.08" Width="744.66" Height="17.01" RepeatOnEveryPage="true" Condition="[NFe.NFe.infNFe.cobr.fat.nFat]">
-      <TextObject Name="Memo205" Top="3.78" Width="430.87" Height="13.23" Text="DUPLICATAS" Padding="0, 1, 0, 1" VertAlign="Bottom" Font="Times New Roman, 7pt, style=Bold"/>
-      <DataBand Name="Duplicatas" Top="628.76" Width="148.91" Height="38.55" DataSource="dup" Columns.Count="5" Columns.Width="148.91">
-        <TextObject Name="Memo66" Top="1.13" Width="148.91" Height="36.67" Border.Lines="All" Border.Width="0.5" Text="Número&#13;&#10;Vencimento&#13;&#10;Valor" Padding="3, 1, 3, 1" VertAlign="Center" WordWrap="false" Font="Times New Roman, 8pt"/>
-        <TextObject Name="Memo138" Left="56.69" Width="3.78" Height="37.8" Text=":&#13;&#10;:&#13;&#10;:" Padding="2, 1, 2, 1" VertAlign="Center" WordWrap="false" Font="Times New Roman, 6pt"/>
-        <TextObject Name="Memo147" Left="60.47" Width="86.93" Height="12.47" Text="[NFe.NFe.infNFe.cobr.dup.nDup]" Padding="3, 1, 3, 1" VertAlign="Center" WordWrap="false" Font="Times New Roman, 8pt"/>
-        <TextObject Name="Memo148" Left="60.47" Top="12.47" Width="86.93" Height="12.47" Text="[FormatDateTime(ToDateTime([NFe.NFe.infNFe.cobr.dup.dVenc]), &quot;dd/MM/yyyy&quot;)]" Padding="3, 1, 3, 1" Format="Date" Format.Format="dd/MM/yyyy" VertAlign="Center" WordWrap="false" Font="Times New Roman, 8pt"/>
-        <TextObject Name="Memo156" Left="60.47" Top="24.94" Width="86.93" Height="12.47" Text="[FormatCurrency([NFe.NFe.infNFe.cobr.dup.vDup])]" Padding="3, 1, 3, 1" Format="Currency" Format.UseLocale="true" VertAlign="Center" WordWrap="false" Font="Times New Roman, 8pt"/>
-        <Sort>
-          <Sort Expression="[NFe.NFe.infNFe.cobr.dup.dVenc]"/>
-        </Sort>
-      </DataBand>
-    </GroupHeaderBand>
-    <DataBand Name="Imposto" Top="669.97" Width="744.66" Height="70.03" BeforePrintEvent="Imposto_BeforePrint">
+    <DataBand Name="Duplicatas" Top="634.38" Width="744.66" Height="38.55" BeforePrintEvent="Duplicatas_BeforePrint" DataSource="dup" Columns.Count="5" Columns.Width="148.91">
+      <TextObject Name="Memo66" Top="1.13" Width="148.91" Height="36.67" Border.Lines="All" Border.Width="0.5" Text="Número&#13;&#10;Vencimento&#13;&#10;Valor" Padding="3, 1, 3, 1" VertAlign="Center" WordWrap="false" Font="Times New Roman, 8pt"/>
+      <TextObject Name="Memo138" Left="56.69" Width="3.78" Height="37.8" Text=":&#13;&#10;:&#13;&#10;:" Padding="2, 1, 2, 1" VertAlign="Center" WordWrap="false" Font="Times New Roman, 6pt"/>
+      <TextObject Name="Memo147" Left="60.47" Width="86.93" Height="12.47" Text="[NFe.NFe.infNFe.cobr.dup.nDup]" Padding="3, 1, 3, 1" VertAlign="Center" WordWrap="false" Font="Times New Roman, 8pt"/>
+      <TextObject Name="Memo148" Left="60.47" Top="12.47" Width="86.93" Height="12.47" Text="[FormatDateTime(ToDateTime([NFe.NFe.infNFe.cobr.dup.dVenc]), &quot;dd/MM/yyyy&quot;)]" Padding="3, 1, 3, 1" Format="Date" Format.Format="dd/MM/yyyy" VertAlign="Center" WordWrap="false" Font="Times New Roman, 8pt"/>
+      <TextObject Name="Memo156" Left="60.47" Top="24.94" Width="86.93" Height="12.47" Text="[FormatCurrency([NFe.NFe.infNFe.cobr.dup.vDup])]" Padding="3, 1, 3, 1" Format="Currency" Format.UseLocale="true" VertAlign="Center" WordWrap="false" Font="Times New Roman, 8pt"/>
+      <DataHeaderBand Name="DuplicatasHeader" Top="612.28" Width="744.66" Height="18.9" BeforePrintEvent="DuplicatasHeader_BeforePrint">
+        <TextObject Name="Memo205" Top="3.78" Width="430.87" Height="13.23" Text="DUPLICATAS" Padding="0, 1, 0, 1" VertAlign="Bottom" Font="Times New Roman, 7pt, style=Bold"/>
+      </DataHeaderBand>
+      <Sort>
+        <Sort Expression="[NFe.NFe.infNFe.cobr.dup.nDup]"/>
+      </Sort>
+    </DataBand>
+    <DataBand Name="Imposto" Top="676.13" Width="744.66" Height="70.03" BeforePrintEvent="Imposto_BeforePrint">
       <TextObject Name="QuadroPIS" Left="490.27" Top="17.01" Width="106.97" Height="26.46" Border.Lines="All" Border.Width="0.5" Text="VALOR DO PIS" Padding="2, 2, 2, 2" Font="Times New Roman, 5pt"/>
       <TextObject Name="QuadroVTOTTRIB" Left="497.85" Top="16.9" Width="99.52" Height="26.46" Visible="false" Border.Lines="All" Border.Width="0.5" Text="Total dos Tributos (Fonte: IBPT)" Padding="2, 2, 2, 2" Font="Times New Roman, 5pt"/>
       <TextObject Name="Memo58" Top="3.78" Width="430.87" Height="13.23" Text="CÁLCULO DO IMPOSTO" Padding="0, 1, 0, 1" VertAlign="Bottom" Font="Times New Roman, 7pt, style=Bold"/>
@@ -1190,7 +1290,7 @@
       <TextObject Name="Text170" Left="0.38" Top="25.33" Width="114.53" Height="17.01" Text="[NFe.NFe.infNFe.total.ICMSTot.vBC]" Padding="5, 1, 5, 1" Format="Number" Format.UseLocale="false" Format.DecimalDigits="2" Format.DecimalSeparator="," Format.GroupSeparator="." Format.NegativePattern="1" HorzAlign="Right" VertAlign="Bottom" WordWrap="false" Font="Times New Roman, 8pt"/>
       <TextObject Name="txtIbptValor" Left="499.85" Top="25.35" Width="96.22" Height="17.01" Visible="false" Text="[NFe.NFe.infNFe.total.ICMSTot.vTotTrib]" Padding="5, 1, 5, 1" Format="Number" Format.UseLocale="false" Format.DecimalDigits="2" Format.DecimalSeparator="," Format.GroupSeparator="." Format.NegativePattern="1" HorzAlign="Right" VertAlign="Bottom" WordWrap="false" Font="Times New Roman, 8pt"/>
     </DataBand>
-    <DataBand Name="TransportadorVolumes" Top="742.67" Width="744.66" Height="96.38">
+    <DataBand Name="TransportadorVolumes" Top="749.36" Width="744.66" Height="96.38">
       <TextObject Name="Memo82" Top="3.78" Width="430.87" Height="13.23" Text="TRANSPORTADOR / VOLUMES TRANSPORTADOS" Padding="0, 1, 0, 1" Font="Times New Roman, 7pt, style=Bold"/>
       <TextObject Name="Memo83" Left="636.09" Top="17.01" Width="108.47" Height="26.46" Border.Lines="All" Border.Width="0.5" Text="CNPJ / CPF" Padding="2, 2, 2, 2" Font="Times New Roman, 5pt"/>
       <TextObject Name="Memo84" Left="636.09" Top="26.46" Width="108.47" Height="17.01" Text="[FormatarCampo(ToString(IIf([NFe.NFe.infNFe.transp.transporta.CPF] == &quot;&quot; || [NFe.NFe.infNFe.transp.transporta.CPF] == null, [NFe.NFe.infNFe.transp.transporta.CNPJ], [NFe.NFe.infNFe.transp.transporta.CPF])), 'd')]" Padding="5, 1, 5, 1" VertAlign="Bottom" WordWrap="false" Font="Times New Roman, 8pt"/>
@@ -1225,92 +1325,89 @@
       <TextObject Name="Memo113" Left="636.22" Top="69.92" Width="108.35" Height="26.46" Border.Lines="All" Border.Width="0.5" Text="PESO LÍQUIDO" Padding="2, 2, 2, 2" Font="Times New Roman, 5pt"/>
       <TextObject Name="Memo114" Left="636.22" Top="79.37" Width="108.35" Height="17.01" Text="[NFe.NFe.infNFe.transp.vol.pesoL]" Padding="5, 1, 5, 1" HideValue="0" Format="Number" Format.UseLocale="true" HorzAlign="Right" VertAlign="Bottom" WordWrap="false" Font="Times New Roman, 8pt"/>
     </DataBand>
-    <GroupHeaderBand Name="DadosProdutosHeader" Top="841.72" Width="744.66" Height="41.2" RepeatOnEveryPage="true" Condition="[NFe.NFe.infNFe.Id]" SortOrder="None">
-      <TextObject Name="Memo115" Top="3.78" Width="430.87" Height="13.23" Text="DADOS DOS PRODUTOS / SERVIÇOS" Padding="0, 1, 0, 1" VertAlign="Bottom" Font="Times New Roman, 7pt, style=Bold"/>
-      <TextObject Name="Memo116" Top="18.34" Width="60.47" Height="22.68" Border.Lines="All" Border.Width="0.5" Fill.Color="Gainsboro" Text="CÓDIGO&#13;&#10;PRODUTO" Padding="2, 2, 2, 2" HorzAlign="Center" VertAlign="Center" WordWrap="false" Font="Times New Roman, 5pt"/>
-      <TextObject Name="Memo117" Left="60.47" Top="18.34" Width="222.99" Height="22.68" Border.Lines="All" Border.Width="0.5" Fill.Color="Gainsboro" Text="DESCRIÇÃO DO PRODUTO / SERVIÇO" Padding="2, 2, 2, 2" HorzAlign="Center" VertAlign="Center" WordWrap="false" Font="Times New Roman, 5pt"/>
-      <TextObject Name="Memo118" Left="283.46" Top="18.34" Width="37.8" Height="22.68" Border.Lines="All" Border.Width="0.5" Fill.Color="Gainsboro" Text="NCM/SH" Padding="2, 2, 2, 2" HorzAlign="Center" VertAlign="Center" WordWrap="false" Font="Times New Roman, 5pt"/>
-      <TextObject Name="Memo119" Left="321.26" Top="18.34" Width="26.46" Height="22.68" Border.Lines="All" Border.Width="0.5" Fill.Color="Gainsboro" Text="O/CST" Padding="2, 2, 2, 2" HorzAlign="Right" VertAlign="Center" WordWrap="false" Font="Times New Roman, 5pt"/>
-      <TextObject Name="Memo120" Left="347.72" Top="18.34" Width="24.95" Height="22.68" Border.Lines="All" Border.Width="0.5" Fill.Color="Gainsboro" Text="CFOP" Padding="2, 2, 2, 2" HorzAlign="Center" VertAlign="Center" WordWrap="false" Font="Times New Roman, 5pt"/>
-      <TextObject Name="Memo121" Left="372.71" Top="18.34" Width="22.3" Height="22.68" Border.Lines="All" Border.Width="0.5" Fill.Color="Gainsboro" Text="UNID." Padding="2, 2, 2, 2" HorzAlign="Center" VertAlign="Center" WordWrap="false" Font="Times New Roman, 5pt"/>
-      <TextObject Name="Memo122" Left="394.96" Top="18.34" Width="43.46" Height="22.68" Border.Lines="All" Border.Width="0.5" Fill.Color="Gainsboro" Text="QTDE." Padding="2, 2, 2, 2" HorzAlign="Center" VertAlign="Center" WordWrap="false" Font="Times New Roman, 5pt"/>
-      <TextObject Name="Memo123" Left="438.43" Top="18.34" Width="52.91" Height="22.68" Border.Lines="All" Border.Width="0.5" Fill.Color="Gainsboro" Text="VALOR&#13;&#10;UNITÁRIO" Padding="2, 2, 2, 2" HorzAlign="Center" VertAlign="Center" WordWrap="false" Font="Times New Roman, 5pt"/>
-      <TextObject Name="Memo124" Left="491.34" Top="18.34" Width="45.35" Height="22.68" Border.Lines="All" Border.Width="0.5" Fill.Color="Gainsboro" Text="[IIf([ImprimirDescPorc],&quot;%&quot;, &quot;VALOR&quot;)]&#13;&#10;DESCONTO" Padding="2, 2, 2, 2" HorzAlign="Center" VertAlign="Center" WordWrap="false" Font="Times New Roman, 5pt"/>
-      <TextObject Name="Memo125" Left="536.69" Top="18.34" Width="41.57" Height="22.68" Border.Lines="All" Border.Width="0.5" Fill.Color="Gainsboro" Text="VALOR&#13;&#10;[IIf([ImprimirTotalLiquido], &quot;LÍQUIDO&quot;, &quot;TOTAL&quot;)]" Padding="2, 2, 2, 2" HorzAlign="Center" VertAlign="Center" WordWrap="false" Font="Times New Roman, 5pt"/>
-      <TextObject Name="Memo126" Left="578.27" Top="18.34" Width="41.57" Height="22.68" Border.Lines="All" Border.Width="0.5" Fill.Color="Gainsboro" Text="BASE DE &#13;&#10;CÁLC. ICMS" Padding="2, 2, 2, 2" HorzAlign="Center" VertAlign="Center" WordWrap="false" Font="Times New Roman, 5pt"/>
-      <TextObject Name="Memo127" Left="619.84" Top="18.34" Width="41.57" Height="22.68" Border.Lines="All" Border.Width="0.5" Fill.Color="Gainsboro" Text="VALOR&#13;&#10;ICMS" Padding="2, 2, 2, 2" HorzAlign="Center" VertAlign="Center" WordWrap="false" Font="Times New Roman, 5pt"/>
-      <TextObject Name="Memo128" Left="661.42" Top="18.34" Width="41.57" Height="22.68" Border.Lines="All" Border.Width="0.5" Fill.Color="Gainsboro" Text="VALOR&#13;&#10;IPI" Padding="2, 2, 2, 2" HorzAlign="Center" VertAlign="Center" WordWrap="false" Font="Times New Roman, 5pt"/>
-      <TextObject Name="Memo129" Left="702.99" Top="29.68" Width="20.79" Height="11.34" Border.Lines="All" Border.Width="0.5" Fill.Color="Gainsboro" Text="ICMS" Padding="2, 2, 2, 2" HorzAlign="Center" VertAlign="Center" WordWrap="false" Font="Times New Roman, 5pt"/>
-      <TextObject Name="Memo130" Left="723.78" Top="29.68" Width="20.79" Height="11.34" Border.Lines="All" Border.Width="0.5" Fill.Color="Gainsboro" Text="IPI" Padding="2, 2, 2, 2" HorzAlign="Center" VertAlign="Center" WordWrap="false" Font="Times New Roman, 5pt"/>
-      <TextObject Name="Memo189" Left="702.99" Top="18.34" Width="41.57" Height="11.34" Border.Lines="All" Border.Width="0.5" Fill.Color="Gainsboro" Text="ALÍQ. %" Padding="2, 2, 2, 2" HorzAlign="Center" VertAlign="Center" WordWrap="false" Font="Times New Roman, 5pt"/>
-      <DataBand Name="DadosProdutos" Top="885.58" Width="744.66" Height="11.34" CanGrow="true" CanShrink="true" BeforePrintEvent="DadosProdutos_BeforePrint" Guides="0" DataSource="det">
-        <TableObject Name="prodTable" Width="744.66" Height="11.34">
-          <TableColumn Name="prodCodigo" Width="60.48"/>
-          <TableColumn Name="prodNome" Width="223.02"/>
-          <TableColumn Name="prodNCM" Width="37.8"/>
-          <TableColumn Name="prodOrigin" Width="26.46"/>
-          <TableColumn Name="prodCFOP" Width="24.95"/>
-          <TableColumn Name="prodUnidade" Width="22.3"/>
-          <TableColumn Name="prodQtd" Width="43.47"/>
-          <TableColumn Name="prodValorUnitario" Width="52.92"/>
-          <TableColumn Name="prodDesconto" Width="45.36"/>
-          <TableColumn Name="prodValor" Width="41.58"/>
-          <TableColumn Name="prodBc" Width="41.58"/>
-          <TableColumn Name="prodICMS" Width="41.58"/>
-          <TableColumn Name="prodIPI" Width="41.58"/>
-          <TableColumn Name="prodAlqICMS" Width="20.79"/>
-          <TableColumn Name="prodAlqIPI" Width="20.79"/>
-          <TableRow Name="prodRow" Height="11.34" AutoSize="true">
-            <TableCell Name="prodCodigoCell" Border.Lines="Left, Right, Bottom" Border.LeftLine.Width="0.5" Border.RightLine.Width="0.5" Border.BottomLine.Style="Dot" Border.BottomLine.Width="0.5" Text="[NFe.NFe.infNFe.det.prod.cProd]" HorzAlign="Center" VertAlign="Center" Font="Times New Roman, 6pt"/>
-            <TableCell Name="prodNomeCell" Border.Lines="Right, Bottom" Border.LeftLine.Width="0.5" Border.TopLine.Width="0.5" Border.RightLine.Width="0.5" Border.BottomLine.Style="Dot" Border.BottomLine.Width="0.5" Text="[NFe.NFe.infNFe.det.prod.xProd][IIf([NFe.NFe.infNFe.det.infAdProd] == null || [NFe.NFe.infNFe.det.infAdProd] == &quot;&quot;, &quot;&quot;, &quot; &quot; + [NFe.NFe.infNFe.det.infAdProd])]" HorzAlign="Justify" Font="Times New Roman, 6pt"/>
-            <TableCell Name="prodNCMCell" Border.Lines="Right, Bottom" Border.LeftLine.Width="0.5" Border.TopLine.Width="0.5" Border.RightLine.Width="0.5" Border.BottomLine.Style="Dot" Border.BottomLine.Width="0.5" Text="[NFe.NFe.infNFe.det.prod.NCM]" Padding="1, 1, 1, 1" HorzAlign="Center" VertAlign="Center" Font="Times New Roman, 6pt"/>
-            <TableCell Name="prodOriginCell" Border.Lines="Right, Bottom" Border.LeftLine.Width="0.5" Border.TopLine.Width="0.5" Border.RightLine.Width="0.5" Border.BottomLine.Style="Dot" Border.BottomLine.Width="0.5" HorzAlign="Center" VertAlign="Center" Font="Times New Roman, 6pt"/>
-            <TableCell Name="prodCFOPCell" Border.Lines="Right, Bottom" Border.LeftLine.Width="0.5" Border.TopLine.Width="0.5" Border.RightLine.Width="0.5" Border.BottomLine.Style="Dot" Border.BottomLine.Width="0.5" Text="[NFe.NFe.infNFe.det.prod.CFOP]" HorzAlign="Center" VertAlign="Center" Font="Times New Roman, 6pt"/>
-            <TableCell Name="prodUnidadeCell" Border.Lines="Right, Bottom" Border.LeftLine.Width="0.5" Border.TopLine.Width="0.5" Border.RightLine.Width="0.5" Border.BottomLine.Style="Dot" Border.BottomLine.Width="0.5" HorzAlign="Center" VertAlign="Center" Font="Times New Roman, 6pt"/>
-            <TableCell Name="prodQtdCell" Border.Lines="Right, Bottom" Border.LeftLine.Width="0.5" Border.TopLine.Width="0.5" Border.RightLine.Width="0.5" Border.BottomLine.Style="Dot" Border.BottomLine.Width="0.5" HorzAlign="Right" VertAlign="Center" Font="Times New Roman, 6pt"/>
-            <TableCell Name="prodValorUnitarioCell" Border.Lines="Right, Bottom" Border.LeftLine.Width="0.5" Border.TopLine.Width="0.5" Border.RightLine.Width="0.5" Border.BottomLine.Style="Dot" Border.BottomLine.Width="0.5" HorzAlign="Right" VertAlign="Center" Font="Times New Roman, 6pt"/>
-            <TableCell Name="prodDescontoCell" Border.Lines="Right, Bottom" Border.LeftLine.Width="0.5" Border.TopLine.Width="0.5" Border.RightLine.Width="0.5" Border.BottomLine.Style="Dot" Border.BottomLine.Width="0.5" HorzAlign="Right" VertAlign="Center" Font="Times New Roman, 6pt"/>
-            <TableCell Name="prodValorCell" Border.Lines="Right, Bottom" Border.LeftLine.Width="0.5" Border.TopLine.Width="0.5" Border.RightLine.Width="0.5" Border.BottomLine.Style="Dot" Border.BottomLine.Width="0.5" HorzAlign="Right" VertAlign="Center" Font="Times New Roman, 6pt"/>
-            <TableCell Name="prodBcCell" Border.Lines="Right, Bottom" Border.LeftLine.Width="0.5" Border.TopLine.Width="0.5" Border.RightLine.Width="0.5" Border.BottomLine.Style="Dot" Border.BottomLine.Width="0.5" HorzAlign="Right" VertAlign="Center" Font="Times New Roman, 6pt"/>
-            <TableCell Name="prodICMSCell" Border.Lines="Right, Bottom" Border.LeftLine.Width="0.5" Border.TopLine.Width="0.5" Border.RightLine.Width="0.5" Border.BottomLine.Style="Dot" Border.BottomLine.Width="0.5" HorzAlign="Right" VertAlign="Center" Font="Times New Roman, 6pt"/>
-            <TableCell Name="prodIPICell" Border.Lines="Right, Bottom" Border.LeftLine.Width="0.5" Border.TopLine.Width="0.5" Border.RightLine.Width="0.5" Border.BottomLine.Style="Dot" Border.BottomLine.Width="0.5" HorzAlign="Right" VertAlign="Center" Font="Times New Roman, 6pt"/>
-            <TableCell Name="prodAlqICMSCell" Border.Lines="Right, Bottom" Border.LeftLine.Width="0.5" Border.TopLine.Width="0.5" Border.RightLine.Width="0.5" Border.BottomLine.Style="Dot" Border.BottomLine.Width="0.5" Padding="1, 1, 1, 1" Format="Percent" Format.UseLocale="true" HorzAlign="Center" VertAlign="Center" Font="Times New Roman, 5pt"/>
-            <TableCell Name="prodAlqIPICell" Border.Lines="Right, Bottom" Border.LeftLine.Width="0.5" Border.TopLine.Width="0.5" Border.RightLine.Width="0.5" Border.BottomLine.Style="Dot" Border.BottomLine.Width="0.5" Padding="1, 1, 1, 1" Format="Percent" Format.UseLocale="true" HorzAlign="Center" VertAlign="Center" Font="Times New Roman, 5pt"/>
-          </TableRow>
-        </TableObject>
-      </DataBand>
-      <GroupFooterBand Name="DadosProdutosFooter" Top="899.59" Width="744.66" BeforePrintEvent="DadosProdutosFooter_BeforePrint"/>
-    </GroupHeaderBand>
-    <DataBand Name="ItemEspace" Top="902.26" Width="744.66" Height="11.34"/>
-    <DataBand Name="DadosISSQN" Top="916.26" Width="744.66" Height="9.45" CanGrow="true" CanShrink="true">
-      <SubreportObject Name="Subreport1" Width="746.55" Height="9.45" ReportPage="PageISSQN"/>
+    <DataBand Name="DadosProdutos" Top="893.39" Width="744.66" Height="11.34" CanGrow="true" CanShrink="true" BeforePrintEvent="DadosProdutos_BeforePrint" AfterPrintEvent="DadosProdutos_AfterPrint" Guides="0" DataSource="det">
+      <TableObject Name="prodTable" Width="744.66" Height="11.34">
+        <TableColumn Name="prodCodigo" Width="60.48"/>
+        <TableColumn Name="prodNome" Width="223.02"/>
+        <TableColumn Name="prodNCM" Width="37.8"/>
+        <TableColumn Name="prodOrigin" Width="26.46"/>
+        <TableColumn Name="prodCFOP" Width="24.95"/>
+        <TableColumn Name="prodUnidade" Width="22.3"/>
+        <TableColumn Name="prodQtd" Width="43.47"/>
+        <TableColumn Name="prodValorUnitario" Width="52.92"/>
+        <TableColumn Name="prodDesconto" Width="45.36"/>
+        <TableColumn Name="prodValor" Width="41.58"/>
+        <TableColumn Name="prodBc" Width="41.58"/>
+        <TableColumn Name="prodICMS" Width="41.58"/>
+        <TableColumn Name="prodIPI" Width="41.58"/>
+        <TableColumn Name="prodAlqICMS" Width="20.79"/>
+        <TableColumn Name="prodAlqIPI" Width="20.79"/>
+        <TableRow Name="prodRow" Height="11.34" AutoSize="true">
+          <TableCell Name="prodCodigoCell" Border.Lines="Left, Right, Bottom" Border.LeftLine.Width="0.5" Border.RightLine.Width="0.5" Border.BottomLine.Style="Dot" Border.BottomLine.Width="0.5" Text="[NFe.NFe.infNFe.det.prod.cProd]" HorzAlign="Center" VertAlign="Center" Font="Times New Roman, 6pt"/>
+          <TableCell Name="prodNomeCell" Border.Lines="Right, Bottom" Border.LeftLine.Width="0.5" Border.TopLine.Width="0.5" Border.RightLine.Width="0.5" Border.BottomLine.Style="Dot" Border.BottomLine.Width="0.5" Text="[NFe.NFe.infNFe.det.prod.xProd][IIf([NFe.NFe.infNFe.det.infAdProd] == null || [NFe.NFe.infNFe.det.infAdProd] == &quot;&quot;, &quot;&quot;, &quot; &quot; + [NFe.NFe.infNFe.det.infAdProd])]" HorzAlign="Justify" Font="Times New Roman, 6pt"/>
+          <TableCell Name="prodNCMCell" Border.Lines="Right, Bottom" Border.LeftLine.Width="0.5" Border.TopLine.Width="0.5" Border.RightLine.Width="0.5" Border.BottomLine.Style="Dot" Border.BottomLine.Width="0.5" Text="[NFe.NFe.infNFe.det.prod.NCM]" Padding="1, 1, 1, 1" HorzAlign="Center" VertAlign="Center" Font="Times New Roman, 6pt"/>
+          <TableCell Name="prodOriginCell" Border.Lines="Right, Bottom" Border.LeftLine.Width="0.5" Border.TopLine.Width="0.5" Border.RightLine.Width="0.5" Border.BottomLine.Style="Dot" Border.BottomLine.Width="0.5" HorzAlign="Center" VertAlign="Center" Font="Times New Roman, 6pt"/>
+          <TableCell Name="prodCFOPCell" Border.Lines="Right, Bottom" Border.LeftLine.Width="0.5" Border.TopLine.Width="0.5" Border.RightLine.Width="0.5" Border.BottomLine.Style="Dot" Border.BottomLine.Width="0.5" Text="[NFe.NFe.infNFe.det.prod.CFOP]" HorzAlign="Center" VertAlign="Center" Font="Times New Roman, 6pt"/>
+          <TableCell Name="prodUnidadeCell" Border.Lines="Right, Bottom" Border.LeftLine.Width="0.5" Border.TopLine.Width="0.5" Border.RightLine.Width="0.5" Border.BottomLine.Style="Dot" Border.BottomLine.Width="0.5" HorzAlign="Center" VertAlign="Center" Font="Times New Roman, 6pt"/>
+          <TableCell Name="prodQtdCell" Border.Lines="Right, Bottom" Border.LeftLine.Width="0.5" Border.TopLine.Width="0.5" Border.RightLine.Width="0.5" Border.BottomLine.Style="Dot" Border.BottomLine.Width="0.5" HorzAlign="Right" VertAlign="Center" Font="Times New Roman, 6pt"/>
+          <TableCell Name="prodValorUnitarioCell" Border.Lines="Right, Bottom" Border.LeftLine.Width="0.5" Border.TopLine.Width="0.5" Border.RightLine.Width="0.5" Border.BottomLine.Style="Dot" Border.BottomLine.Width="0.5" HorzAlign="Right" VertAlign="Center" Font="Times New Roman, 6pt"/>
+          <TableCell Name="prodDescontoCell" Border.Lines="Right, Bottom" Border.LeftLine.Width="0.5" Border.TopLine.Width="0.5" Border.RightLine.Width="0.5" Border.BottomLine.Style="Dot" Border.BottomLine.Width="0.5" HorzAlign="Right" VertAlign="Center" Font="Times New Roman, 6pt"/>
+          <TableCell Name="prodValorCell" Border.Lines="Right, Bottom" Border.LeftLine.Width="0.5" Border.TopLine.Width="0.5" Border.RightLine.Width="0.5" Border.BottomLine.Style="Dot" Border.BottomLine.Width="0.5" HorzAlign="Right" VertAlign="Center" Font="Times New Roman, 6pt"/>
+          <TableCell Name="prodBcCell" Border.Lines="Right, Bottom" Border.LeftLine.Width="0.5" Border.TopLine.Width="0.5" Border.RightLine.Width="0.5" Border.BottomLine.Style="Dot" Border.BottomLine.Width="0.5" HorzAlign="Right" VertAlign="Center" Font="Times New Roman, 6pt"/>
+          <TableCell Name="prodICMSCell" Border.Lines="Right, Bottom" Border.LeftLine.Width="0.5" Border.TopLine.Width="0.5" Border.RightLine.Width="0.5" Border.BottomLine.Style="Dot" Border.BottomLine.Width="0.5" HorzAlign="Right" VertAlign="Center" Font="Times New Roman, 6pt"/>
+          <TableCell Name="prodIPICell" Border.Lines="Right, Bottom" Border.LeftLine.Width="0.5" Border.TopLine.Width="0.5" Border.RightLine.Width="0.5" Border.BottomLine.Style="Dot" Border.BottomLine.Width="0.5" HorzAlign="Right" VertAlign="Center" Font="Times New Roman, 6pt"/>
+          <TableCell Name="prodAlqICMSCell" Border.Lines="Right, Bottom" Border.LeftLine.Width="0.5" Border.TopLine.Width="0.5" Border.RightLine.Width="0.5" Border.BottomLine.Style="Dot" Border.BottomLine.Width="0.5" Padding="1, 1, 1, 1" Format="Percent" Format.UseLocale="true" HorzAlign="Center" VertAlign="Center" Font="Times New Roman, 5pt"/>
+          <TableCell Name="prodAlqIPICell" Border.Lines="Right, Bottom" Border.LeftLine.Width="0.5" Border.TopLine.Width="0.5" Border.RightLine.Width="0.5" Border.BottomLine.Style="Dot" Border.BottomLine.Width="0.5" Padding="1, 1, 1, 1" Format="Percent" Format.UseLocale="true" HorzAlign="Center" VertAlign="Center" Font="Times New Roman, 5pt"/>
+        </TableRow>
+      </TableObject>
+      <DataHeaderBand Name="DadosProdutosHeader" Top="848.94" Width="744.66" Height="41.25" BeforePrintEvent="DadosProdutosHeader_BeforePrint">
+        <TextObject Name="Memo129" Left="702.99" Top="29.68" Width="20.79" Height="11.34" Border.Lines="All" Border.Width="0.5" Fill.Color="Gainsboro" Text="ICMS" Padding="2, 2, 2, 2" HorzAlign="Center" VertAlign="Center" WordWrap="false" Font="Times New Roman, 5pt"/>
+        <TextObject Name="Memo130" Left="723.78" Top="29.68" Width="20.79" Height="11.34" Border.Lines="All" Border.Width="0.5" Fill.Color="Gainsboro" Text="IPI" Padding="2, 2, 2, 2" HorzAlign="Center" VertAlign="Center" WordWrap="false" Font="Times New Roman, 5pt"/>
+        <TextObject Name="Memo116" Top="18.34" Width="60.47" Height="22.68" Border.Lines="All" Border.Width="0.5" Fill.Color="Gainsboro" Text="CÓDIGO&#13;&#10;PRODUTO" Padding="2, 2, 2, 2" HorzAlign="Center" VertAlign="Center" WordWrap="false" Font="Times New Roman, 5pt"/>
+        <TextObject Name="Memo117" Left="60.47" Top="18.34" Width="222.99" Height="22.68" Border.Lines="All" Border.Width="0.5" Fill.Color="Gainsboro" Text="DESCRIÇÃO DO PRODUTO / SERVIÇO" Padding="2, 2, 2, 2" HorzAlign="Center" VertAlign="Center" WordWrap="false" Font="Times New Roman, 5pt"/>
+        <TextObject Name="Memo118" Left="283.46" Top="18.34" Width="37.8" Height="22.68" Border.Lines="All" Border.Width="0.5" Fill.Color="Gainsboro" Text="NCM/SH" Padding="2, 2, 2, 2" HorzAlign="Center" VertAlign="Center" WordWrap="false" Font="Times New Roman, 5pt"/>
+        <TextObject Name="Memo119" Left="321.26" Top="18.34" Width="26.46" Height="22.68" Border.Lines="All" Border.Width="0.5" Fill.Color="Gainsboro" Text="O/CST" Padding="2, 2, 2, 2" HorzAlign="Right" VertAlign="Center" WordWrap="false" Font="Times New Roman, 5pt"/>
+        <TextObject Name="Memo120" Left="347.72" Top="18.34" Width="24.95" Height="22.68" Border.Lines="All" Border.Width="0.5" Fill.Color="Gainsboro" Text="CFOP" Padding="2, 2, 2, 2" HorzAlign="Center" VertAlign="Center" WordWrap="false" Font="Times New Roman, 5pt"/>
+        <TextObject Name="Memo121" Left="372.71" Top="18.34" Width="22.3" Height="22.68" Border.Lines="All" Border.Width="0.5" Fill.Color="Gainsboro" Text="UNID." Padding="2, 2, 2, 2" HorzAlign="Center" VertAlign="Center" WordWrap="false" Font="Times New Roman, 5pt"/>
+        <TextObject Name="Memo122" Left="394.96" Top="18.34" Width="43.46" Height="22.68" Border.Lines="All" Border.Width="0.5" Fill.Color="Gainsboro" Text="QTDE." Padding="2, 2, 2, 2" HorzAlign="Center" VertAlign="Center" WordWrap="false" Font="Times New Roman, 5pt"/>
+        <TextObject Name="Memo123" Left="438.43" Top="18.34" Width="52.91" Height="22.68" Border.Lines="All" Border.Width="0.5" Fill.Color="Gainsboro" Text="VALOR&#13;&#10;UNITÁRIO" Padding="2, 2, 2, 2" HorzAlign="Center" VertAlign="Center" WordWrap="false" Font="Times New Roman, 5pt"/>
+        <TextObject Name="Memo124" Left="491.34" Top="18.34" Width="45.35" Height="22.68" Border.Lines="All" Border.Width="0.5" Fill.Color="Gainsboro" Text="[IIf([ImprimirDescPorc],&quot;%&quot;, &quot;VALOR&quot;)]&#13;&#10;DESCONTO" Padding="2, 2, 2, 2" HorzAlign="Center" VertAlign="Center" WordWrap="false" Font="Times New Roman, 5pt"/>
+        <TextObject Name="Memo125" Left="536.69" Top="18.34" Width="41.57" Height="22.68" Border.Lines="All" Border.Width="0.5" Fill.Color="Gainsboro" Text="VALOR&#13;&#10;[IIf([ImprimirTotalLiquido], &quot;LÍQUIDO&quot;, &quot;TOTAL&quot;)]" Padding="2, 2, 2, 2" HorzAlign="Center" VertAlign="Center" WordWrap="false" Font="Times New Roman, 5pt"/>
+        <TextObject Name="Memo126" Left="578.27" Top="18.34" Width="41.57" Height="22.68" Border.Lines="All" Border.Width="0.5" Fill.Color="Gainsboro" Text="BASE DE &#13;&#10;CÁLC. ICMS" Padding="2, 2, 2, 2" HorzAlign="Center" VertAlign="Center" WordWrap="false" Font="Times New Roman, 5pt"/>
+        <TextObject Name="Memo127" Left="619.84" Top="18.34" Width="41.57" Height="22.68" Border.Lines="All" Border.Width="0.5" Fill.Color="Gainsboro" Text="VALOR&#13;&#10;ICMS" Padding="2, 2, 2, 2" HorzAlign="Center" VertAlign="Center" WordWrap="false" Font="Times New Roman, 5pt"/>
+        <TextObject Name="Memo128" Left="661.42" Top="18.34" Width="41.57" Height="22.68" Border.Lines="All" Border.Width="0.5" Fill.Color="Gainsboro" Text="VALOR&#13;&#10;IPI" Padding="2, 2, 2, 2" HorzAlign="Center" VertAlign="Center" WordWrap="false" Font="Times New Roman, 5pt"/>
+        <TextObject Name="Memo189" Left="702.99" Top="18.34" Width="41.57" Height="11.34" Border.Lines="All" Border.Width="0.5" Fill.Color="Gainsboro" Text="ALÍQ. %" Padding="2, 2, 2, 2" HorzAlign="Center" VertAlign="Center" WordWrap="false" Font="Times New Roman, 5pt"/>
+        <TextObject Name="Memo115" Top="3.78" Width="430.87" Height="13.23" Text="DADOS DOS PRODUTOS / SERVIÇOS" Padding="0, 1, 0, 1" VertAlign="Bottom" Font="Times New Roman, 7pt, style=Bold"/>
+      </DataHeaderBand>
+      <DataFooterBand Name="DadosProdutosFooter" Top="907.93" Width="744.66" Height="9.45"/>
+      <Sort>
+        <Sort Expression="[NFe.NFe.infNFe.det.nItem]"/>
+      </Sort>
     </DataBand>
-    <PageFooterBand Name="PageFooter1" Top="928.38" Width="744.66" Height="60.15" CanGrow="true" PrintOn="FirstPage">
+    <DataBand Name="DadosISSQN" Top="920.58" Width="744.66" Height="40.25" CanGrow="true" CanShrink="true">
+      <TextObject Name="Memo5" Width="430.87" Height="13.23" Text="CÁLCULO DO ISSQN" Padding="0, 1, 0, 1" VertAlign="Bottom" Font="Times New Roman, 7pt, style=Bold"/>
+      <TextObject Name="Memo7" Top="13.12" Width="217.32" Height="26.46" Border.Lines="All" Border.Width="0.5" Text="INSCRIÇÃO MUNICIPAL" Padding="2, 2, 2, 2" Font="Times New Roman, 5pt"/>
+      <TextObject Name="Memo59" Top="22.57" Width="217.32" Height="17.01" Text="[NFe.NFe.infNFe.emit.IM]" Padding="5, 1, 5, 1" VertAlign="Bottom" Font="Times New Roman, 8pt"/>
+      <TextObject Name="Memo60" Left="217.32" Top="13.12" Width="179.53" Height="26.46" Border.Lines="All" Border.Width="0.5" Text="VALOR TOTAL DOS SERVIÇOS" Padding="2, 2, 2, 2" Font="Times New Roman, 5pt"/>
+      <TextObject Name="Memo61" Left="217.32" Top="22.57" Width="179.53" Height="17.01" Text="[NFe.NFe.infNFe.total.ISSQNtot.vServ]" Padding="5, 1, 5, 1" Format="Number" Format.UseLocale="true" HorzAlign="Right" VertAlign="Bottom" Font="Times New Roman, 8pt"/>
+      <TextObject Name="Memo62" Left="396.85" Top="13.12" Width="179.53" Height="26.46" Border.Lines="All" Border.Width="0.5" Text="BASE DE CÁLCULO DO ISSQN" Padding="2, 2, 2, 2" Font="Times New Roman, 5pt"/>
+      <TextObject Name="Memo63" Left="396.85" Top="22.57" Width="179.53" Height="17.01" Text="[NFe.NFe.infNFe.total.ISSQNtot.vBC]" Padding="5, 1, 5, 1" Format="Number" Format.UseLocale="true" HorzAlign="Right" VertAlign="Bottom" Font="Times New Roman, 8pt"/>
+      <TextObject Name="Memo64" Left="576.38" Top="13.12" Width="168.21" Height="26.46" Border.Lines="All" Border.Width="0.5" Text="VALOR TOTAL DO ISSQN" Padding="2, 2, 2, 2" Font="Times New Roman, 5pt"/>
+      <TextObject Name="Memo65" Left="576.38" Top="22.57" Width="167.08" Height="17.01" Text="[NFe.NFe.infNFe.total.ISSQNtot.vISS]" Padding="5, 1, 5, 1" Format="Number" Format.UseLocale="true" HorzAlign="Right" VertAlign="Bottom" Font="Times New Roman, 8pt"/>
+    </DataBand>
+    <PageFooterBand Name="DadosAdicionais" Top="964.03" Width="744.66" Height="60.15" CanGrow="true" PrintOn="FirstPage">
       <TextObject Name="Text155" Top="13.46" Width="470.06" Height="45.36" Border.Lines="All" Border.Width="0.5" CanGrow="true" GrowToBottom="true" CanBreak="false" Text="INFORMAÇÕES COMPLEMENTARES" Padding="2, 2, 2, 0" Font="Times New Roman, 5pt, style=Bold"/>
       <TextObject Name="TextInfAdicionais" Left="1.45" Top="26.91" Width="468.5" Height="29.8" CanGrow="true" GrowToBottom="true" CanBreak="false" Font="Times New Roman, 8pt"/>
       <TextObject Name="Text156" Left="470.5" Top="13.46" Width="274.06" Height="45.36" Border.Lines="All" Border.Width="0.5" CanGrow="true" GrowToBottom="true" CanBreak="false" Text="RESERVADO AO FISCO" Padding="2, 2, 2, 0" Font="Times New Roman, 5pt, style=Bold"/>
       <TextObject Name="Text37" Left="472.5" Top="26.91" Width="270.05" Height="29.8" CanGrow="true" GrowToBottom="true" CanBreak="false" Text="[NFe.protNFe.infProt.cMsg] [NFe.protNFe.infProt.xMsg]" Font="Times New Roman, 8pt"/>
       <TextObject Name="Text157" Left="1.89" Top="1.89" Width="124.65" Height="9.35" Text="DADOS ADICIONAIS" Padding="0, 0, 0, 0" VertAlign="Center" Font="Times New Roman, 8pt, style=Bold"/>
-      <ChildBand Name="Child1" Top="991.2" Width="744.66" Height="16.9" PrintOn="FirstPage">
+      <ChildBand Name="Rodape" Top="1027.38" Width="744.66" Height="16.9" PrintOn="FirstPage" BeforePrintEvent="Rodape_BeforePrint">
         <TextObject Name="memDataHora" Top="2" Width="445.98" Height="13.23" Text="DATA E HORA DA IMPRESSÃO: [FormatDateTime([DataHoraImpressao], &quot;dd/MM/yyyy HH:mm:ss&quot;)]" Padding="2, 1, 2, 1" Font="Times New Roman, 6pt"/>
         <TextObject Name="memSistema" Left="453.54" Top="2" Width="291.02" Height="13.23" Text="[Desenvolvedor]" Padding="2, 1, 2, 1" HorzAlign="Right" Font="Times New Roman, 6pt"/>
       </ChildBand>
     </PageFooterBand>
-    <OverlayBand Name="MarcaDagua" Top="1010.76" Width="744.66" Height="1122.52">
+    <OverlayBand Name="MarcaDagua" Top="1047.48" Width="744.66" Height="1122.52">
       <TextObject Name="memWatermark" Width="744.57" Height="1122.52" Text="[Mensagem]" Padding="0, 0, 0, 0" HorzAlign="Center" VertAlign="Center" Font="Times New Roman, 50pt, style=Bold" TextFill.Color="216, 216, 216"/>
     </OverlayBand>
-  </ReportPage>
-  <ReportPage Name="PageISSQN" LeftMargin="6" TopMargin="7" RightMargin="7" BottomMargin="7">
-    <DataBand Name="subISSQN" Width="744.66" Height="43.36">
-      <TextObject Name="Memo5" Top="3.78" Width="430.87" Height="13.23" Text="CÁLCULO DO ISSQN" Padding="0, 1, 0, 1" VertAlign="Bottom" Font="Times New Roman, 7pt, style=Bold"/>
-      <TextObject Name="Memo7" Top="16.9" Width="217.32" Height="26.46" Border.Lines="All" Border.Width="0.5" Text="INSCRIÇÃO MUNICIPAL" Padding="2, 2, 2, 2" Font="Times New Roman, 5pt"/>
-      <TextObject Name="Memo59" Top="26.35" Width="217.32" Height="17.01" Text="[NFe.NFe.infNFe.emit.IM]" Padding="5, 1, 5, 1" VertAlign="Bottom" Font="Times New Roman, 8pt"/>
-      <TextObject Name="Memo60" Left="217.32" Top="16.9" Width="179.53" Height="26.46" Border.Lines="All" Border.Width="0.5" Text="VALOR TOTAL DOS SERVIÇOS" Padding="2, 2, 2, 2" Font="Times New Roman, 5pt"/>
-      <TextObject Name="Memo61" Left="217.32" Top="26.35" Width="179.53" Height="17.01" Text="[NFe.NFe.infNFe.total.ISSQNtot.vServ]" Padding="5, 1, 5, 1" Format="Number" Format.UseLocale="true" HorzAlign="Right" VertAlign="Bottom" Font="Times New Roman, 8pt"/>
-      <TextObject Name="Memo62" Left="396.85" Top="16.9" Width="179.53" Height="26.46" Border.Lines="All" Border.Width="0.5" Text="BASE DE CÁLCULO DO ISSQN" Padding="2, 2, 2, 2" Font="Times New Roman, 5pt"/>
-      <TextObject Name="Memo63" Left="396.85" Top="26.35" Width="179.53" Height="17.01" Text="[NFe.NFe.infNFe.total.ISSQNtot.vBC]" Padding="5, 1, 5, 1" Format="Number" Format.UseLocale="true" HorzAlign="Right" VertAlign="Bottom" Font="Times New Roman, 8pt"/>
-      <TextObject Name="Memo64" Left="576.38" Top="16.9" Width="168.21" Height="26.46" Border.Lines="All" Border.Width="0.5" Text="VALOR TOTAL DO ISSQN" Padding="2, 2, 2, 2" Font="Times New Roman, 5pt"/>
-      <TextObject Name="Memo65" Left="576.38" Top="26.35" Width="167.08" Height="17.01" Text="[NFe.NFe.infNFe.total.ISSQNtot.vISS]" Padding="5, 1, 5, 1" Format="Number" Format.UseLocale="true" HorzAlign="Right" VertAlign="Bottom" Font="Times New Roman, 8pt"/>
-    </DataBand>
   </ReportPage>
 </Report>

--- a/NFe.Danfe.Fast.Standard/NFe/NFeRetrato.frx
+++ b/NFe.Danfe.Fast.Standard/NFe/NFeRetrato.frx
@@ -30,7 +30,8 @@ using NFe.Danfe.Base.NFe;
 namespace FastReport
 {        
   public class ReportScript
-  {    
+  {
+  
     private void Emitente_BeforePrint(object sender, EventArgs e)
     {
       var chave = Substring(((String)Report.GetColumnValue(&quot;NFe.NFe.infNFe.Id&quot;)), 3);
@@ -298,19 +299,16 @@ namespace FastReport
     public Image ObterLogo()
     {
       byte[] logomarca = Report.GetParameterValue(&quot;Logo&quot;) as byte[];
-      
-      if (logomarca == null) return null;
-      
-      using(var ms = new MemoryStream(logomarca))
-      {
-        var image = Image.FromStream(ms);
-        return image;
-      }
-    }       
+      if(logomarca == null)
+        return null;
+      Stream imageStream = new MemoryStream(logomarca); //precisa ficar aberto senao causa erro gdi+ #Zeus Issue 1119, acesse a issue para mais detalhes.
+      var image = Image.FromStream(imageStream);
+      return image;
+    }
 
     private void Imposto_BeforePrint(object sender, EventArgs e)
     {
-      bool exibirIbpt = ((Boolean?)Report.GetParameterValue(&quot;ExibirTotalTributos&quot;)) ?? false;
+    bool exibirIbpt = ((Boolean?)Report.GetParameterValue(&quot;ExibirTotalTributos&quot;)) ?? false;
       
       QuadroVTOTTRIB.Visible = exibirIbpt;
       txtIbptValor.Visible = exibirIbpt;


### PR DESCRIPTION
Os frx do projeto .netStandard (NFeRetrato e NFeEvento) foram atualizados para a versão mais nova das versões do projeto do .netFramework.

Foi modificado a função ObterLogo() do relatório do .net Standard NFeRetrato. O mesmo causava um erro de GDI+. Foi verificado que o erro acontece pois em alguns tipos de extensão (.png por exemplo) a stream que criou o é acessada mesmo após o fechamento da stream, causando o erro.
Foi retirado o "using" da Stream o mesmo foi solucionado. Criei alguns testes de performance no projeto do DEMO do .net core Fast Report, alem de melhoria de código nesse projeto demo. 

Não verifiquei nenhum problema de performance com a modificação.
Foi verificado que o GarbageCollection cuida tranquilamente da questão de memória da logo. E ao final do uso do report todo os objetos são disposed (primeiro link abaixo).

Referencias:
https://supportcenter.devexpress.com/ticket/details/t302264/how-to-dispose-of-resources-created-in-a-report-script
https://stackoverflow.com/questions/9508879/cannot-access-a-closed-stream-of-a-memorystream-how-to-reopen
https://github.com/FastReports/FastReport/blob/master/Demos/Reports/Image.frx
https://fastreports.github.io/FastReport.Documentation/ClassReference/api/FastReport.PictureObject.html#FastReport_PictureObject_Image

Resolve #1119  e #1173 