### PR TITLE
Inclui preenchimento icms outra uf

### DIFF
--- a/CTe.Dacte.Fast/Resources/CTeRetrato.frx
+++ b/CTe.Dacte.Fast/Resources/CTeRetrato.frx
@@ -374,6 +374,16 @@ namespace FastReport
           Text196.Text = FormatCurrency(icms90.vICMS ,2);
           Text197.Text = FormatNumber(icms90.pRedBC ,2) + &quot;%&quot;;  
         }
+        else if (icms is ICMSOutraUF)
+        {
+          Text188.Text = &quot;90 - ICMS Outra UF&quot;;
+        
+          ICMSOutraUF icmsOutraUf = icms as ICMSOutraUF;
+          Text194.Text = FormatCurrency(icmsOutraUf.vBCOutraUF ,2);
+          Text195.Text = FormatNumber(icmsOutraUf.pICMSOutraUF ,2) + &quot;%&quot;;
+          Text196.Text = FormatCurrency(icmsOutraUf.vICMSOutraUF ,2);
+          Text197.Text = icmsOutraUf.pRedBCOutraUFSpecified ? FormatNumber(icmsOutraUf.pRedBCOutraUF ,2) + &quot;%&quot; : "";  
+        }
       }
       #endregion
           


### PR DESCRIPTION
Na impressão do cte esse dado não era exibido caso o icms fosse dessa modalidade. Se precisarem do xml para teste só avisar. 
Segue o resultado visual da implementação:
![image](https://user-images.githubusercontent.com/42043408/95855820-62f85d00-0d2f-11eb-9fb7-b52946eb9b56.png)

E o original do cliente ao qual me baseei:
![image](https://user-images.githubusercontent.com/42043408/95855874-7efbfe80-0d2f-11eb-90ad-ab1ec12a96b5.png)
