### PR TITLE
Correção: Arredondando valor de vFCPST para seguir o Schema

### DIFF
--- a/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS90.cs
+++ b/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS90.cs
@@ -255,8 +255,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         [XmlElement(Order = 19)]
         public decimal? vFCPST
         {
-            get { return _vFcpst; }
-            set { _vFcpst = value; }
+            get { return _vFcpst.Arredondar(2); }
+            set { _vFcpst = value.Arredondar(2); }
         }
 
         public bool vFCPSTSpecified


### PR DESCRIPTION
Bom dia.
Hoje eu tive um problema com o campo vFCPST. O schema barrou a nota com esse erro:
![Erro Schema](https://user-images.githubusercontent.com/2027566/111809101-6205c180-88b3-11eb-88d2-2cc944764e0f.png)
Ao olhar o XML, percebi que o vFCPST estava apenas com 1 casa decimal
![xml](https://user-images.githubusercontent.com/2027566/111809173-7b0e7280-88b3-11eb-9820-c876d0ebc427.png)

O PR é somente para arredondar esse valor para 2 casas decimais.