### PR TITLE
Response lento quando a SEFAZ está instável

### DIFF
--- a/Shared.DFe.Wsdl/Common/SoapUtils.cs
+++ b/Shared.DFe.Wsdl/Common/SoapUtils.cs
@@ -93,6 +93,8 @@ namespace CTe.CTeOSDocumento.Soap
             var respStream = webResponse.GetResponseStream();
             StreamReader streamReader = new StreamReader(respStream);
 
+            streamReader.BaseStream.ReadTimeout = httpWr.Timeout;
+
             string xmlRetorno = streamReader.ReadToEnd();
             return await Task.FromResult(xmlRetorno);
         }
@@ -128,6 +130,8 @@ namespace CTe.CTeOSDocumento.Soap
             var webResponse = httpWr.GetResponse();
             var respStream = webResponse.GetResponseStream();
             StreamReader streamReader = new StreamReader(respStream);
+
+            streamReader.BaseStream.ReadTimeout = httpWr.Timeout;
 
             string xmlRetorno = streamReader.ReadToEnd();
             return xmlRetorno;


### PR DESCRIPTION
Foi identificado que quando a SEFAZ está instável, o response fica extremamente lento.
Setando a propriedade "ReadTimeout" do objeto "streamReader", conseguimos resolver o problema.
#1244 