### PR TITLE
Ajustes NT_2021_001 - Vale Pedágio

### DIFF
--- a/MDFe.Classes/Informacoes/MDFeDisp.cs
+++ b/MDFe.Classes/Informacoes/MDFeDisp.cs
@@ -66,5 +66,11 @@ namespace MDFe.Classes.Informacoes
             get { return _vValePed.Arredondar(2); }
             set { _vValePed = value.Arredondar(2); }
         }
+        
+        /// <summary>
+        /// Tipo do Vale Pedágio
+        /// </summary>
+        [XmlElement(ElementName = "tpValePed")]
+        public string TpValePed { get; set; }
     }
 }

--- a/MDFe.Classes/Informacoes/MDFeValePed.cs
+++ b/MDFe.Classes/Informacoes/MDFeValePed.cs
@@ -44,5 +44,11 @@ namespace MDFe.Classes.Informacoes
         /// </summary>
         [XmlElement(ElementName = "disp")]
         public List<MDFeDisp> Disp { get; set; }
+        
+        /// <summary>
+        /// Categoria de Combinação Veicular
+        /// </summary>
+        [XmlElement(ElementName = "categCombVeic")]
+        public string CategCombVeic { get; set; }
     }
 }


### PR DESCRIPTION
Adição das TAGs **tpValePed** e **categCombVeic** do grupo de Informações de Vale Pedágio.

Foram inclusas outras tags na NT, porém só homologuei essas duas.