### PR TITLE
Inclui BL (Bill of Landing) no tipo tpDocAnterior

### DIFF
--- a/Shared.CTe.Classes/Informacoes/Tipos/tpDocAnterior.cs
+++ b/Shared.CTe.Classes/Informacoes/Tipos/tpDocAnterior.cs
@@ -62,6 +62,8 @@ namespace CTe.Classes.Informacoes.Tipos
         ConhecimentoAvulso = 11,
         [XmlEnum("12")]
         TIF = 12,
+        [XmlEnum("13")]
+        BL = 13,
         [XmlEnum("99")]
         Outros = 99
     }


### PR DESCRIPTION
Somente um acréscimo ao Enum tpDocAnterior. Estava faltando o tipo BL (Bill of Landing).
Segue um print da documentação de Leiaute de CTe segundo a SEFAZ que inclui esse tipo:

![image](https://user-images.githubusercontent.com/42043408/126685708-61d10f5e-9f17-48b4-97f6-ea31d26b2352.png)
