### PR TITLE
Correção: arredondamento de campos _vFcpst conforme regras do xsd tipos

### DIFF
--- a/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS30.cs
+++ b/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS30.cs
@@ -154,8 +154,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         [XmlElement(Order = 11)]
         public decimal? vFCPST
         {
-            get { return _vFcpst; }
-            set { _vFcpst = value; }
+            get { return _vFcpst.Arredondar(2); }
+            set { _vFcpst = value.Arredondar(2); }
         }
 
         public bool vFCPSTSpecified

--- a/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS70.cs
+++ b/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS70.cs
@@ -255,8 +255,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         [XmlElement(Order = 19)]
         public decimal? vFCPST
         {
-            get { return _vFcpst; }
-            set { _vFcpst = value; }
+            get { return _vFcpst.Arredondar(2); }
+            set { _vFcpst = value.Arredondar(2); }
         }
 
         public bool vFCPSTSpecified


### PR DESCRIPTION
A correção visa resolver a validação do XSD de tipos que pode ser encontrada no link https://www.nfe.fazenda.gov.br/portal/exibirArquivo.aspx?conteudo=lhqXSmnywl4=

Abaixo fiz um print do trecho do schema

![campo](https://user-images.githubusercontent.com/19821231/134690034-4e93f7c1-63fa-41b0-b25e-ca7317eff589.png)

![restricao-xsd](https://user-images.githubusercontent.com/19821231/134690016-b17d4578-eae4-4856-8236-ef9ddfe3dd8b.png)

Para concluir o erro retornado pela receita é o seguinte:

![image](https://user-images.githubusercontent.com/19821231/134690677-8a434189-1085-48f5-9001-fc6a277f2211.png)

Abaixo o trecho do XML enviado:

![image](https://user-images.githubusercontent.com/19821231/134690826-7eb80a57-0ab3-48db-91bd-825093d1a1b4.png)

A PR adiciona o arredondamento no campo.



