### PR TITLE
Removendo a TAG TCOrgaoIBGE que estava em duplicidade

### DIFF
--- a/NFe.AppTeste/Schemas/leiauteConfRecebto_v1.00.xsd
+++ b/NFe.AppTeste/Schemas/leiauteConfRecebto_v1.00.xsd
@@ -366,41 +366,4 @@
 			<xs:pattern value="1\.00"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="TCOrgaoIBGE">
-		<xs:annotation>
-			<xs:documentation>Tipo Código de orgão (UF da tabela do IBGE + 90 SUFRAMA + 91 - RFB)</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:string">
-			<xs:whiteSpace value="preserve"/>
-			<xs:enumeration value="11"/>
-			<xs:enumeration value="12"/>
-			<xs:enumeration value="13"/>
-			<xs:enumeration value="14"/>
-			<xs:enumeration value="15"/>
-			<xs:enumeration value="16"/>
-			<xs:enumeration value="17"/>
-			<xs:enumeration value="21"/>
-			<xs:enumeration value="22"/>
-			<xs:enumeration value="23"/>
-			<xs:enumeration value="24"/>
-			<xs:enumeration value="25"/>
-			<xs:enumeration value="26"/>
-			<xs:enumeration value="27"/>
-			<xs:enumeration value="28"/>
-			<xs:enumeration value="29"/>
-			<xs:enumeration value="31"/>
-			<xs:enumeration value="32"/>
-			<xs:enumeration value="33"/>
-			<xs:enumeration value="35"/>
-			<xs:enumeration value="41"/>
-			<xs:enumeration value="42"/>
-			<xs:enumeration value="43"/>
-			<xs:enumeration value="50"/>
-			<xs:enumeration value="51"/>
-			<xs:enumeration value="52"/>
-			<xs:enumeration value="53"/>
-			<xs:enumeration value="90"/>
-			<xs:enumeration value="91"/>
-		</xs:restriction>
-	</xs:simpleType>
 </xs:schema>


### PR DESCRIPTION
Como havia comentado no commit (https://github.com/ZeusAutomacao/DFe.NET/commit/94638387f9fa54d2b69691749e75ab32bc5d1f41) do @robertorp a TAG "<xs:simpleType name="TCOrgaoIBGE">" ficou em duplicidade no arquivo "leiauteConfRecebto_v1.00.xsd", assim não sendo possível manifestar uma NF-e resumida.
![TCOrgaoIBGE_REPETIDO](https://user-images.githubusercontent.com/50238521/146258431-95dbc7a1-66df-43b0-b492-0be972dd1a91.png)
