### PR TITLE
Movidas informações de tributos incidentes para o final do DANFE da NFC-e

### DIFF
--- a/NFe.Danfe.Fast/NFCe/NFCe.frx
+++ b/NFe.Danfe.Fast/NFCe/NFCe.frx
@@ -994,10 +994,6 @@ namespace FastReport
         <TextObject Name="Text47" Top="13.23" Width="196.56" Height="13.23" Text="TROCO R$:" VertAlign="Center" Font="Ubuntu Condensed, 8pt, style=Bold"/>
       </DataFooterBand>
     </DataBand>
-    <DataBand Name="dbTributos" Top="512.75" Width="264.6" Height="28.35" Border.Lines="Top" Border.Width="0.5" AfterPrintEvent="dbTributos_AfterPrint">
-      <TextObject Name="Memo23" Left="192.87" Width="71.81" Height="28.35" Text="[NFCe.NFe.infNFe.total.ICMSTot.vTotTrib]" Padding="2, 2, 2, 2" Format="Number" Format.UseLocale="true" HorzAlign="Right" WordWrap="false" Font="Ubuntu Condensed, 8pt"/>
-      <TextObject Name="Memo17" Width="190.87" Height="28.35" Text="Informação dos Tributos Totais Incidentes (Lei Federal 12.741 /2012)" Padding="2, 2, 2, 2" Font="Ubuntu Condensed, 8pt"/>
-    </DataBand>
     <DataBand Name="dbObservacao" Top="543.77" Width="264.6" Height="18.9" Border.Lines="Top" Border.Width="0.5" CanGrow="true" CanShrink="true" AfterPrintEvent="dbObservacao_AfterPrint">
       <TextObject Name="txtObs" Width="264.6" Height="18.9" CanGrow="true" CanShrink="true" BeforePrintEvent="txtObs_BeforePrint" Text="[NFCe.NFe.infNFe.infAdic.infCpl]" Padding="2, 2, 2, 2" VertAlign="Center" Font="Ubuntu Condensed, 8pt"/>
     </DataBand>
@@ -1036,6 +1032,9 @@ namespace FastReport
     </DataBand>
     <DataBand Name="dbProtocolo" Top="1065.2" Width="264.6" Height="28.35" BeforePrintEvent="dbProtocolo_BeforePrint" AfterPrintEvent="dbProtocolo_AfterPrint">
       <TextObject Name="txtProtocoloAutorizacao" Width="264.6" Height="27.14" Text="Protocolo de Autorização&#13;&#10;[NFCe.protNFe.infProt.nProt] [NFCe.protNFe.infProt.dhRecbto]" Padding="2, 1, 2, 1" HorzAlign="Center" VertAlign="Center" Font="Ubuntu Condensed, 8pt"/>
+    </DataBand>
+    <DataBand Name="dbTributos" Top="1066.06" Width="264.6" Height="18.9" Border.Lines="Top" Border.Width="0.5" CanGrow="true" CanShrink="true" AfterPrintEvent="dbTributos_AfterPrint">
+      <TextObject Name="Memo17" Width="264.6" Height="18.9" CanGrow="true" CanShrink="true" Text="Tributos Totais Incidentes (Lei Federal 12.741 /2012): [NFCe.NFe.infNFe.total.ICMSTot.vTotTrib]" Padding="2, 2, 2, 2" HorzAlign="Center" VertAlign="Center" Font="Ubuntu Condensed, 8pt"/>
     </DataBand>
     <DataBand Name="dbTextoRodape" Top="1096.22" Width="264.6" Height="18.9" CanGrow="true" CanShrink="true">
       <TextObject Name="Text19" Width="264.6" Height="18.9" Border.Lines="Top" CanGrow="true" CanShrink="true" Text="[TextoRodape]" Font="Ubuntu Condensed, 8pt"/>


### PR DESCRIPTION
Movidas informações de tributos incidentes para o final do DANFE da NFC-e, conforme sugestão no Manual de especificações técnicas do DANFE_NFC-e e Qr_Code Versão 5.1

**Sugestão do manual:**
(QR Code na lateral)
![image](https://user-images.githubusercontent.com/6733483/150342920-b49779cf-51e6-4a84-82dd-eab0cc234a32.png)

(QR Code centralizado)
![image](https://user-images.githubusercontent.com/6733483/150342989-a211909e-b11c-48e4-9f6a-6cb07d674237.png)


Mudança aplicada no PR:
(QR Code na lateral)
![image](https://user-images.githubusercontent.com/6733483/150343063-62bc6734-30d7-4e59-b9a8-7358b89e6e2e.png)

(QR Code centralizado)
![image](https://user-images.githubusercontent.com/6733483/150343092-e3bc5b75-aec3-4aa5-82fc-777983a1d99b.png)
