### PR TITLE
ajuste ordem dos impostos [erro ao deserializar enviNFE4]

### DIFF
--- a/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Federal/COFINSAliq.cs
+++ b/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Federal/COFINSAliq.cs
@@ -31,6 +31,7 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 using NFe.Classes.Informacoes.Detalhe.Tributacao.Federal.Tipos;
+using System.Xml.Serialization;
 
 namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
 {
@@ -43,11 +44,15 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// <summary>
         ///     S06 - Código de Situação Tributária da COFINS
         /// </summary>
+        /// 
+        [XmlElement(Order = 1)]
         public CSTCOFINS CST { get; set; }
 
         /// <summary>
         ///     S07 - Valor da Base de Cálculo da COFINS
         /// </summary>
+        /// 
+        [XmlElement(Order = 2)]
         public decimal vBC
         {
             get { return _vBc; }
@@ -57,6 +62,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// <summary>
         ///     S08 - Alíquota da COFINS (em percentual)
         /// </summary>
+        /// 
+        [XmlElement(Order = 3)]
         public decimal pCOFINS
         {
             get { return _pCofins; }
@@ -66,6 +73,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// <summary>
         ///     S09 - Valor da COFINS
         /// </summary>
+        /// 
+        [XmlElement(Order = 4)]
         public decimal vCOFINS
         {
             get { return _vCofins; }

--- a/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Federal/COFINSNT.cs
+++ b/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Federal/COFINSNT.cs
@@ -31,6 +31,7 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 using NFe.Classes.Informacoes.Detalhe.Tributacao.Federal.Tipos;
+using System.Xml.Serialization;
 
 namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
 {
@@ -39,6 +40,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// <summary>
         ///     S06 - Código de Situação Tributária da COFINS
         /// </summary>
+        /// 
+        [XmlElement(Order = 1)]
         public CSTCOFINS CST { get; set; }
     }
 }

--- a/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Federal/COFINSOutr.cs
+++ b/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Federal/COFINSOutr.cs
@@ -31,6 +31,7 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 using NFe.Classes.Informacoes.Detalhe.Tributacao.Federal.Tipos;
+using System.Xml.Serialization;
 
 namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
 {
@@ -45,11 +46,16 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// <summary>
         ///     S06 - Código de Situação Tributária da COFINS
         /// </summary>
+        /// 
+
+        [XmlElement(Order = 1)]
         public CSTCOFINS CST { get; set; }
 
         /// <summary>
         ///     S07 - Valor da Base de Cálculo da COFINS
         /// </summary>
+        /// 
+        [XmlElement(Order = 2)]
         public decimal? vBC
         {
             get { return _vBc.Arredondar(2); }
@@ -59,6 +65,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// <summary>
         ///     S08 - Alíquota da COFINS (em percentual)
         /// </summary>
+        /// 
+        [XmlElement(Order = 3)]
         public decimal? pCOFINS
         {
             get { return _pCofins.Arredondar(4); }
@@ -68,6 +76,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// <summary>
         ///     S09 - Quantidade Vendida
         /// </summary>
+        /// 
+        [XmlElement(Order = 4)]
         public decimal? qBCProd
         {
             get { return _qBcProd.Arredondar(4); }
@@ -77,6 +87,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// <summary>
         ///     S10 - Alíquota da COFINS (em reais)
         /// </summary>
+        /// 
+        [XmlElement(Order = 5)]
         public decimal? vAliqProd
         {
             get { return _vAliqProd.Arredondar(4); }
@@ -86,6 +98,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// <summary>
         ///     S11 - Valor da COFINS
         /// </summary>
+        /// 
+        [XmlElement(Order = 6)]
         public decimal? vCOFINS
         {
             get { return _vCofins.Arredondar(2); }

--- a/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Federal/COFINSQtde.cs
+++ b/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Federal/COFINSQtde.cs
@@ -31,6 +31,7 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 using NFe.Classes.Informacoes.Detalhe.Tributacao.Federal.Tipos;
+using System.Xml.Serialization;
 
 namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
 {
@@ -43,11 +44,15 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// <summary>
         ///     S06 - Código de Situação Tributária da COFINS
         /// </summary>
+        /// 
+        [XmlElement(Order = 1)]
         public CSTCOFINS CST { get; set; }
 
         /// <summary>
         ///     S09 - Quantidade Vendida
         /// </summary>
+        /// 
+        [XmlElement(Order = 2)]
         public decimal qBCProd
         {
             get { return _qBcProd; }
@@ -57,6 +62,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// <summary>
         ///     S10 - Alíquota da COFINS (em reais)
         /// </summary>
+        /// 
+        [XmlElement(Order = 3)]
         public decimal vAliqProd
         {
             get { return _vAliqProd; }
@@ -66,6 +73,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// <summary>
         ///     S11 - Valor da COFINS
         /// </summary>
+        /// 
+        [XmlElement(Order = 4)]
         public decimal vCOFINS
         {
             get { return _vCofins; }

--- a/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Federal/COFINSST.cs
+++ b/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Federal/COFINSST.cs
@@ -31,6 +31,7 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 using NFe.Classes.Informacoes.Detalhe.Tributacao.Federal.Tipos;
+using System.Xml.Serialization;
 
 namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
 {
@@ -45,6 +46,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// <summary>
         ///     T02 - Valor da Base de Cálculo da COFINS
         /// </summary>
+        /// 
+        [XmlElement(Order = 1)]
         public decimal? vBC
         {
             get { return _vBc.Arredondar(2); }
@@ -54,6 +57,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// <summary>
         ///     T03 - Alíquota da COFINS (em percentual)
         /// </summary>
+        /// 
+        [XmlElement(Order = 2)]
         public decimal? pCOFINS
         {
             get { return _pCofins.Arredondar(4); }
@@ -63,6 +68,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// <summary>
         ///     T04 - Quantidade Vendida
         /// </summary>
+        /// 
+        [XmlElement(Order = 3)]
         public decimal? qBCProd
         {
             get { return _qBcProd.Arredondar(4); }
@@ -72,6 +79,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// <summary>
         ///     T05 - Alíquota da COFINS (em reais)
         /// </summary>
+        /// 
+        [XmlElement(Order = 4)]
         public decimal? vAliqProd
         {
             get { return _vAliqProd.Arredondar(4); }
@@ -81,6 +90,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// <summary>
         ///     T06 - Valor da COFINS
         /// </summary>
+        /// 
+        [XmlElement(Order = 5)]
         public decimal? vCOFINS
         {
             get { return _vCofins.Arredondar(2); }

--- a/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Federal/IPINT.cs
+++ b/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Federal/IPINT.cs
@@ -31,6 +31,7 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 using NFe.Classes.Informacoes.Detalhe.Tributacao.Federal.Tipos;
+using System.Xml.Serialization;
 
 namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
 {
@@ -39,6 +40,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// <summary>
         ///     O09 - Código da Situação Tributária do IPI:
         /// </summary>
+        /// 
+        [XmlElement(Order = 1)]
         public CSTIPI CST { get; set; }
     }
 }

--- a/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Federal/IPITrib.cs
+++ b/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Federal/IPITrib.cs
@@ -31,6 +31,7 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 using NFe.Classes.Informacoes.Detalhe.Tributacao.Federal.Tipos;
+using System.Xml.Serialization;
 
 namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
 {
@@ -45,11 +46,15 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// <summary>
         ///     O09 - Código da Situação Tributária do IPI:
         /// </summary>
+        /// 
+        [XmlElement(Order = 1)]
         public CSTIPI CST { get; set; }
 
         /// <summary>
         ///     O10 - Valor da BC do IPI
         /// </summary>
+        /// 
+        [XmlElement(Order = 2)]
         public decimal? vBC
         {
             get { return _vBc.Arredondar(2); }
@@ -59,6 +64,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// <summary>
         ///     O13 - Alíquota do IPI
         /// </summary>
+        /// 
+        [XmlElement(Order = 3)]
         public decimal? pIPI
         {
             get { return _pIpi.Arredondar(4); }
@@ -68,6 +75,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// <summary>
         ///     O11 - Quantidade total na unidade padrão para tributação (somente para os produtos tributados por unidade)
         /// </summary>
+        /// 
+        [XmlElement(Order = 4)]
         public decimal? qUnid
         {
             get { return _qUnid.Arredondar(4); }
@@ -77,6 +86,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// <summary>
         ///     O12 - Valor por Unidade Tributável
         /// </summary>
+        /// 
+        [XmlElement(Order = 5)]
         public decimal? vUnid
         {
             get { return _vUnid.Arredondar(4); }
@@ -86,6 +97,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// <summary>
         ///     O14 - Valor do IPI
         /// </summary>
+        /// 
+        [XmlElement(Order = 6)]
         public decimal? vIPI
         {
             get { return _vIpi.Arredondar(2); }

--- a/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Federal/PISAliq.cs
+++ b/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Federal/PISAliq.cs
@@ -31,6 +31,7 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 using NFe.Classes.Informacoes.Detalhe.Tributacao.Federal.Tipos;
+using System.Xml.Serialization;
 
 namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
 {
@@ -43,11 +44,15 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// <summary>
         ///     Q06 - Código de Situação Tributária do PIS
         /// </summary>
+        /// 
+        [XmlElement(Order = 1)]
         public CSTPIS CST { get; set; }
 
         /// <summary>
         ///     Q07 - Valor da Base de Cálculo do PIS
         /// </summary>
+        /// 
+        [XmlElement(Order = 2)]
         public decimal vBC
         {
             get { return _vBc; }
@@ -57,6 +62,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// <summary>
         ///     Q08 - Alíquota do PIS (em percentual)
         /// </summary>
+        /// 
+        [XmlElement(Order = 3)]
         public decimal pPIS
         {
             get { return _pPis; }
@@ -66,6 +73,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// <summary>
         ///     Q09 - Valor do PIS
         /// </summary>
+        /// 
+        [XmlElement(Order = 4)]
         public decimal vPIS
         {
             get { return _vPis; }

--- a/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Federal/PISNT.cs
+++ b/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Federal/PISNT.cs
@@ -31,6 +31,7 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 using NFe.Classes.Informacoes.Detalhe.Tributacao.Federal.Tipos;
+using System.Xml.Serialization;
 
 namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
 {
@@ -39,6 +40,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// <summary>
         ///     Q06 - Código de Situação Tributária do PIS
         /// </summary>
+        /// 
+        [XmlElement(Order = 1)]
         public CSTPIS CST { get; set; }
     }
 }

--- a/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Federal/PISOutr.cs
+++ b/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Federal/PISOutr.cs
@@ -31,6 +31,7 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 using NFe.Classes.Informacoes.Detalhe.Tributacao.Federal.Tipos;
+using System.Xml.Serialization;
 
 namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
 {
@@ -45,11 +46,17 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// <summary>
         ///     Q06 - Código de Situação Tributária do PIS
         /// </summary>
+        /// 
+
+        [XmlElement(Order = 1)]
         public CSTPIS CST { get; set; }
 
         /// <summary>
         ///     Q07 - Valor da Base de Cálculo do PIS
         /// </summary>
+        /// 
+
+        [XmlElement(Order = 2)]
         public decimal? vBC
         {
             get { return _vBc.Arredondar(2); }
@@ -59,6 +66,9 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// <summary>
         ///     Q08 - Alíquota do PIS (em percentual)
         /// </summary>
+        /// 
+
+        [XmlElement(Order = 3)]
         public decimal? pPIS
         {
             get { return _pPis.Arredondar(4); }
@@ -68,6 +78,9 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// <summary>
         ///     Q10 - Quantidade Vendida
         /// </summary>
+        /// 
+
+        [XmlElement(Order = 4)]
         public decimal? qBCProd
         {
             get { return _qBcProd.Arredondar(4); }
@@ -77,6 +90,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// <summary>
         ///     Q11 - Alíquota do PIS (em reais)
         /// </summary>
+        /// 
+        [XmlElement(Order = 5)]
         public decimal? vAliqProd
         {
             get { return _vAliqProd.Arredondar(4); }
@@ -86,6 +101,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// <summary>
         ///     Q09 - Valor do PIS
         /// </summary>
+        /// 
+        [XmlElement(Order = 6)]
         public decimal? vPIS
         {
             get { return _vPis.Arredondar(2); }

--- a/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Federal/PISQtde.cs
+++ b/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Federal/PISQtde.cs
@@ -31,6 +31,7 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 using NFe.Classes.Informacoes.Detalhe.Tributacao.Federal.Tipos;
+using System.Xml.Serialization;
 
 namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
 {
@@ -43,11 +44,17 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// <summary>
         ///     Q06 - Código de Situação Tributária do PIS
         /// </summary>
+        /// 
+
+        [XmlElement(Order = 1)]
         public CSTPIS CST { get; set; }
 
         /// <summary>
         ///     Q10 - Quantidade Vendida
         /// </summary>
+        /// 
+
+        [XmlElement(Order = 2)]
         public decimal qBCProd
         {
             get { return _qBcProd; }
@@ -57,6 +64,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// <summary>
         ///     Q11 - Alíquota do PIS (em reais)
         /// </summary>
+        /// 
+        [XmlElement(Order = 3)]
         public decimal vAliqProd
         {
             get { return _vAliqProd; }
@@ -66,6 +75,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// <summary>
         ///     Q09 - Valor do PIS
         /// </summary>
+        /// 
+        [XmlElement(Order = 4)]
         public decimal vPIS
         {
             get { return _vPis; }

--- a/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Federal/PISST.cs
+++ b/Shared.NFe.Classes/Informacoes/Detalhe/Tributacao/Federal/PISST.cs
@@ -31,6 +31,7 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 using NFe.Classes.Informacoes.Detalhe.Tributacao.Federal.Tipos;
+using System.Xml.Serialization;
 
 namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
 {
@@ -45,6 +46,9 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// <summary>
         ///     R02 - Valor da Base de Cálculo do PIS
         /// </summary>
+        /// 
+
+        [XmlElement(Order = 1)]
         public decimal? vBC
         {
             get { return _vBc.Arredondar(2); }
@@ -54,6 +58,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// <summary>
         ///     R03 - Alíquota do PIS (em percentual)
         /// </summary>
+        /// 
+        [XmlElement(Order = 2)]
         public decimal? pPIS
         {
             get { return _pPis.Arredondar(4); }
@@ -63,6 +69,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// <summary>
         ///     R04 - Quantidade Vendida
         /// </summary>
+        /// 
+        [XmlElement(Order = 3)]
         public decimal? qBCProd
         {
             get { return _qBcProd.Arredondar(4); }
@@ -72,6 +80,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// <summary>
         ///     R05 - Alíquota do PIS (em reais)
         /// </summary>
+        /// 
+        [XmlElement(Order = 4)]
         public decimal? vAliqProd
         {
             get { return _vAliqProd.Arredondar(4); }
@@ -81,6 +91,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         /// <summary>
         ///     R06 - Valor do PIS
         /// </summary>
+        /// 
+        [XmlElement(Order = 5)]
         public decimal? vPIS
         {
             get { return _vPis.Arredondar(2); }


### PR DESCRIPTION
Ao debugar o código fonte na deserialização do enviNFE4 para xmlstring está invertendo a ordem dos impostos.

deserializando apartir da nfe :

![1](https://user-images.githubusercontent.com/7989768/151447568-d117edfc-22a8-4385-8366-a5446a35a008.PNG)

deserializando apartir da enviNFe4, note que vPis fica acima do CST gerando problema de validação no schema.

![2](https://user-images.githubusercontent.com/7989768/151447722-05416471-d733-4482-854a-92c0b2d10c30.PNG)


onde ocorre o problema:
classe ServicosNFe

![3](https://user-images.githubusercontent.com/7989768/151447753-b29e9088-7f2d-4b3e-833e-62d7bf2e6407.PNG)

