### PR TITLE
Alterado novamente a URL agora de homologação para consulta a NFCe via QRCode para Minas Gerais. 

### DIFF
--- a/Shared.NFe.Utils/InformacoesSuplementares/ExtinfNFeSupl.cs
+++ b/Shared.NFe.Utils/InformacoesSuplementares/ExtinfNFeSupl.cs
@@ -179,7 +179,7 @@ namespace NFe.Utils.InformacoesSuplementares
                 {Estado.RO, versao3E4, "http://www.nfce.sefin.ro.gov.br/consultanfce/consulta.jsp"},
                 {Estado.RR, versao3E4, "http://200.174.88.103:8080/nfce/servlet/qrcode"},
                 {Estado.TO, versao3E4, "http://apps.sefaz.to.gov.br/portal-nfce-homologacao/qrcodeNFCe"},
-                {Estado.MG, versao3E4, "https://portalsped.fazenda.mg.gov.br/portalnfce/sistema/qrcode.xhtml"}
+                {Estado.MG, versao3E4, "https://hnfce.fazenda.mg.gov.br/portalnfce/sistema/qrcode.xhtml"}
             };
             adicionarUrls(TipoAmbiente.Homologacao, TipoUrlConsultaPublica.UrlQrCode, new[] { VersaoQrCode.QrCodeVersao1, VersaoQrCode.QrCodeVersao2 }, urlsQrCodeHomologacaoQrCode1E2);
 


### PR DESCRIPTION
Alterado URL de homologação para consulta a NFCe via QRCode para Minas Gerais, conforme relatado na issue #1330 .
- WebServices: 
http://www.sped.fazenda.mg.gov.br/spedmg/nfce/web-services/

Pessoal conforme comentei na issue https://github.com/ZeusAutomacao/DFe.NET/issues/1330#issuecomment-1086353991.
A Sefaz fez uma alteração nos planos e decidiu não alterar a URL de Homologação, portanto quando criei o outro Pull Rest #1331 estava de acordo com a informação presente no site. 
Agora fiz novamente a alteração conforme está no site, como a URL antiga sai do ar na segunda dia 04/03 acredito não ter mais modificações.

Então @robertorp e @douglashferreira como vocês comentaram no outro Pull request, fica o aviso sobre essa alteração, agora só liberar novamente e gerar o nuget.
Obrigado e perdão pela questão gerada mais como foi decisão da sefaz a gente só concorda ne.