### PR TITLE
Ajustes no conteúdo do PR  #1344

### DIFF
--- a/NFe.AppTeste/Schemas/leiauteNFe_v4.00.xsd
+++ b/NFe.AppTeste/Schemas/leiauteNFe_v4.00.xsd
@@ -1698,7 +1698,7 @@ N-NormalVIN</xs:documentation>
 																	</xs:annotation>
 																	<xs:simpleType>
 																		<xs:restriction base="TString">
-																			<xs:pattern value="[0-9]{13}|ISENTO"/>
+																			<xs:pattern value="[0-9]{11}|[0-9]{13}|ISENTO"/>
 																		</xs:restriction>
 																	</xs:simpleType>
 																</xs:element>
@@ -3220,6 +3220,23 @@ Operação interestadual para consumidor final com partilha do ICMS  devido na o
 																						<xs:documentation>Valor do ICMS ST</xs:documentation>
 																					</xs:annotation>
 																				</xs:element>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="vBCFCPST" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor da Base de cálculo do FCP retido por substituicao tributaria.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pFCPST" type="TDec_0302a04Opc">
+																						<xs:annotation>
+																							<xs:documentation>Percentual de FCP retido por substituição tributária.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vFCPST" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do FCP retido por substituição tributária.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																				</xs:sequence>
 																				<xs:element name="pBCOp" type="TDec_0302a04Opc">
 																					<xs:annotation>
 																						<xs:documentation>Percentual para determinação do valor  da Base de Cálculo da operação própria.</xs:documentation>
@@ -4653,6 +4670,65 @@ Substituição Tributaria;</xs:documentation>
 											</xs:restriction>
 										</xs:simpleType>
 									</xs:element>
+									<xs:element name="obsItem" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Grupo de observações de uso livre (para o item da NF-e) </xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="obsCont" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Grupo de observações de uso livre (para o item da NF-e) </xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element name="xTexto">
+																<xs:simpleType>
+																	<xs:restriction base="TString">
+																		<xs:minLength value="1"/>
+																		<xs:maxLength value="60"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+														</xs:sequence>
+														<xs:attribute name="xCampo" use="required">
+															<xs:simpleType>
+																<xs:restriction base="TString">
+																	<xs:minLength value="1"/>
+																	<xs:maxLength value="20"/>
+																</xs:restriction>
+															</xs:simpleType>
+														</xs:attribute>
+													</xs:complexType>
+												</xs:element>
+												<xs:element name="obsFisco" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Grupo de observações de uso livre (para o item da NF-e) </xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element name="xTexto">
+																<xs:simpleType>
+																	<xs:restriction base="TString">
+																		<xs:minLength value="1"/>
+																		<xs:maxLength value="60"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+														</xs:sequence>
+														<xs:attribute name="xCampo" use="required">
+															<xs:simpleType>
+																<xs:restriction base="TString">
+																	<xs:minLength value="1"/>
+																	<xs:maxLength value="20"/>
+																</xs:restriction>
+															</xs:simpleType>
+														</xs:attribute>
+													</xs:complexType>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
 								</xs:sequence>
 								<xs:attribute name="nItem" use="required">
 									<xs:annotation>
@@ -5511,6 +5587,24 @@ concessório</xs:documentation>
 														</xs:restriction>
 													</xs:simpleType>
 												</xs:element>
+												<xs:element name="tpAto" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Tipo do ato concessório
+														Para origem do Processo na SEFAZ (indProc=0), informar o
+tipo de ato concessório:
+08=Termo de Acordo;
+10=Regime Especial;
+12=Autorização específica;</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:whiteSpace value="preserve"/>
+															<xs:enumeration value="08"/>
+															<xs:enumeration value="10"/>
+															<xs:enumeration value="12"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
 											</xs:sequence>
 										</xs:complexType>
 									</xs:element>
@@ -5728,7 +5822,7 @@ concessório</xs:documentation>
 										<xs:simpleType>
 											<xs:restriction base="xs:string">
 												<xs:minLength value="2"/>
-												<xs:maxLength value="2000"/>
+												<xs:maxLength value="5000"/>
 											</xs:restriction>
 										</xs:simpleType>
 									</xs:element>
@@ -5772,7 +5866,7 @@ concessório</xs:documentation>
 									<xs:whiteSpace value="preserve"/>
 									<xs:minLength value="100"/>
 									<xs:maxLength value="600"/>
-									<xs:pattern value="(((HTTPS?|https?)://.*\?chNFe=[0-9]{44}&amp;nVersao=100&amp;tpAmb=[1-2](&amp;cDest=([A-Za-z0-9.:+-/)(]{0}|[A-Za-z0-9.:+-/)(]{5,20})?)?&amp;dhEmi=[A-Fa-f0-9]{50}&amp;vNF=(0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?)&amp;vICMS=(0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?)&amp;digVal=[A-Fa-f0-9]{56}&amp;cIdToken=[0-9]{6}&amp;cHashQRCode=[A-Fa-f0-9]{40})|((HTTPS?|https?)://.*\?p=([0-9]{34}(1|4)[0-9]{9})\|[2]\|[1-2]\|(0|[1-9]{1}([0-9]{1,5})?)\|[A-Fa-f0-9]{40})|((HTTPS?|https?)://.*\?p=([0-9]{34}9[0-9]{9})\|[2]\|[1-2]\|([0]{1}[1-9]{1}|[1-2]{1}[0-9]{1}|[3]{1}[0-1]{1})\|(0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?)\|[A-Fa-f0-9]{56}\|(0|[1-9]{1}([0-9]{1,5})?)\|[A-Fa-f0-9]{40}))"/>
+									<xs:pattern value="(((HTTPS?|https?)://.*\?chNFe=[0-9]{44}&amp;nVersao=100&amp;tpAmb=[1-2](&amp;cDest=([A-Za-z0-9.:+-/)(]{0}|[A-Za-z0-9.:+-/)(]{5,20})?)?&amp;dhEmi=[A-Fa-f0-9]{50}&amp;vNF=(0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?)&amp;vICMS=(0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?)&amp;digVal=[A-Fa-f0-9]{56}&amp;cIdToken=[0-9]{6}&amp;cHashQRCode=[A-Fa-f0-9]{40})|((HTTPS?|https?)://.*\?p=([0-9]{34}(1|3|4)[0-9]{9})\|[2]\|[1-2]\|(0|[1-9]{1}([0-9]{1,5})?)\|[A-Fa-f0-9]{40})|((HTTPS?|https?)://.*\?p=([0-9]{34}9[0-9]{9})\|[2]\|[1-2]\|([0]{1}[1-9]{1}|[1-2]{1}[0-9]{1}|[3]{1}[0-1]{1})\|(0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?)\|[A-Fa-f0-9]{56}\|(0|[1-9]{1}([0-9]{1,5})?)\|[A-Fa-f0-9]{40}))"/>
 								</xs:restriction>
 							</xs:simpleType>
 						</xs:element>
@@ -6609,205 +6703,7 @@ alterado para tamanho variavel 1-4. (NT2011/004)</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:whiteSpace value="preserve"/>
-			<xs:enumeration value="01.01"/>
-			<xs:enumeration value="01.02"/>
-			<xs:enumeration value="01.03"/>
-			<xs:enumeration value="01.04"/>
-			<xs:enumeration value="01.05"/>
-			<xs:enumeration value="01.06"/>
-			<xs:enumeration value="01.07"/>
-			<xs:enumeration value="01.08"/>
-			<xs:enumeration value="01.09"/>
-			<xs:enumeration value="02.01"/>
-			<xs:enumeration value="03.02"/>
-			<xs:enumeration value="03.03"/>
-			<xs:enumeration value="03.04"/>
-			<xs:enumeration value="03.05"/>
-			<xs:enumeration value="04.01"/>
-			<xs:enumeration value="04.02"/>
-			<xs:enumeration value="04.03"/>
-			<xs:enumeration value="04.04"/>
-			<xs:enumeration value="04.05"/>
-			<xs:enumeration value="04.06"/>
-			<xs:enumeration value="04.07"/>
-			<xs:enumeration value="04.08"/>
-			<xs:enumeration value="04.09"/>
-			<xs:enumeration value="04.10"/>
-			<xs:enumeration value="04.11"/>
-			<xs:enumeration value="04.12"/>
-			<xs:enumeration value="04.13"/>
-			<xs:enumeration value="04.14"/>
-			<xs:enumeration value="04.15"/>
-			<xs:enumeration value="04.16"/>
-			<xs:enumeration value="04.17"/>
-			<xs:enumeration value="04.18"/>
-			<xs:enumeration value="04.19"/>
-			<xs:enumeration value="04.20"/>
-			<xs:enumeration value="04.21"/>
-			<xs:enumeration value="04.22"/>
-			<xs:enumeration value="04.23"/>
-			<xs:enumeration value="05.01"/>
-			<xs:enumeration value="05.02"/>
-			<xs:enumeration value="05.03"/>
-			<xs:enumeration value="05.04"/>
-			<xs:enumeration value="05.05"/>
-			<xs:enumeration value="05.06"/>
-			<xs:enumeration value="05.07"/>
-			<xs:enumeration value="05.08"/>
-			<xs:enumeration value="05.09"/>
-			<xs:enumeration value="06.01"/>
-			<xs:enumeration value="06.02"/>
-			<xs:enumeration value="06.03"/>
-			<xs:enumeration value="06.04"/>
-			<xs:enumeration value="06.05"/>
-			<xs:enumeration value="06.06"/>
-			<xs:enumeration value="07.01"/>
-			<xs:enumeration value="07.02"/>
-			<xs:enumeration value="07.03"/>
-			<xs:enumeration value="07.04"/>
-			<xs:enumeration value="07.05"/>
-			<xs:enumeration value="07.06"/>
-			<xs:enumeration value="07.07"/>
-			<xs:enumeration value="07.08"/>
-			<xs:enumeration value="07.09"/>
-			<xs:enumeration value="07.10"/>
-			<xs:enumeration value="07.11"/>
-			<xs:enumeration value="07.12"/>
-			<xs:enumeration value="07.13"/>
-			<xs:enumeration value="07.16"/>
-			<xs:enumeration value="07.17"/>
-			<xs:enumeration value="07.18"/>
-			<xs:enumeration value="07.19"/>
-			<xs:enumeration value="07.20"/>
-			<xs:enumeration value="07.21"/>
-			<xs:enumeration value="07.22"/>
-			<xs:enumeration value="08.01"/>
-			<xs:enumeration value="08.02"/>
-			<xs:enumeration value="09.01"/>
-			<xs:enumeration value="09.02"/>
-			<xs:enumeration value="09.03"/>
-			<xs:enumeration value="10.01"/>
-			<xs:enumeration value="10.02"/>
-			<xs:enumeration value="10.03"/>
-			<xs:enumeration value="10.04"/>
-			<xs:enumeration value="10.05"/>
-			<xs:enumeration value="10.06"/>
-			<xs:enumeration value="10.07"/>
-			<xs:enumeration value="10.08"/>
-			<xs:enumeration value="10.09"/>
-			<xs:enumeration value="10.10"/>
-			<xs:enumeration value="11.01"/>
-			<xs:enumeration value="11.02"/>
-			<xs:enumeration value="11.03"/>
-			<xs:enumeration value="11.04"/>
-			<xs:enumeration value="12.01"/>
-			<xs:enumeration value="12.02"/>
-			<xs:enumeration value="12.03"/>
-			<xs:enumeration value="12.04"/>
-			<xs:enumeration value="12.05"/>
-			<xs:enumeration value="12.06"/>
-			<xs:enumeration value="12.07"/>
-			<xs:enumeration value="12.08"/>
-			<xs:enumeration value="12.09"/>
-			<xs:enumeration value="12.10"/>
-			<xs:enumeration value="12.11"/>
-			<xs:enumeration value="12.12"/>
-			<xs:enumeration value="12.13"/>
-			<xs:enumeration value="12.14"/>
-			<xs:enumeration value="12.15"/>
-			<xs:enumeration value="12.16"/>
-			<xs:enumeration value="12.17"/>
-			<xs:enumeration value="13.02"/>
-			<xs:enumeration value="13.03"/>
-			<xs:enumeration value="13.04"/>
-			<xs:enumeration value="13.05"/>
-			<xs:enumeration value="14.01"/>
-			<xs:enumeration value="14.02"/>
-			<xs:enumeration value="14.03"/>
-			<xs:enumeration value="14.04"/>
-			<xs:enumeration value="14.05"/>
-			<xs:enumeration value="14.06"/>
-			<xs:enumeration value="14.07"/>
-			<xs:enumeration value="14.08"/>
-			<xs:enumeration value="14.09"/>
-			<xs:enumeration value="14.10"/>
-			<xs:enumeration value="14.11"/>
-			<xs:enumeration value="14.12"/>
-			<xs:enumeration value="14.13"/>
-			<xs:enumeration value="14.14"/>
-			<xs:enumeration value="15.01"/>
-			<xs:enumeration value="15.02"/>
-			<xs:enumeration value="15.03"/>
-			<xs:enumeration value="15.04"/>
-			<xs:enumeration value="15.05"/>
-			<xs:enumeration value="15.06"/>
-			<xs:enumeration value="15.07"/>
-			<xs:enumeration value="15.08"/>
-			<xs:enumeration value="15.09"/>
-			<xs:enumeration value="15.10"/>
-			<xs:enumeration value="15.11"/>
-			<xs:enumeration value="15.12"/>
-			<xs:enumeration value="15.13"/>
-			<xs:enumeration value="15.14"/>
-			<xs:enumeration value="15.15"/>
-			<xs:enumeration value="15.16"/>
-			<xs:enumeration value="15.17"/>
-			<xs:enumeration value="15.18"/>
-			<xs:enumeration value="16.01"/>
-			<xs:enumeration value="16.02"/>
-			<xs:enumeration value="17.01"/>
-			<xs:enumeration value="17.02"/>
-			<xs:enumeration value="17.03"/>
-			<xs:enumeration value="17.04"/>
-			<xs:enumeration value="17.05"/>
-			<xs:enumeration value="17.06"/>
-			<xs:enumeration value="17.08"/>
-			<xs:enumeration value="17.09"/>
-			<xs:enumeration value="17.10"/>
-			<xs:enumeration value="17.11"/>
-			<xs:enumeration value="17.12"/>
-			<xs:enumeration value="17.13"/>
-			<xs:enumeration value="17.14"/>
-			<xs:enumeration value="17.15"/>
-			<xs:enumeration value="17.16"/>
-			<xs:enumeration value="17.17"/>
-			<xs:enumeration value="17.18"/>
-			<xs:enumeration value="17.19"/>
-			<xs:enumeration value="17.20"/>
-			<xs:enumeration value="17.21"/>
-			<xs:enumeration value="17.22"/>
-			<xs:enumeration value="17.23"/>
-			<xs:enumeration value="17.24"/>
-			<xs:enumeration value="17.25"/>
-			<xs:enumeration value="18.01"/>
-			<xs:enumeration value="19.01"/>
-			<xs:enumeration value="20.01"/>
-			<xs:enumeration value="20.02"/>
-			<xs:enumeration value="20.03"/>
-			<xs:enumeration value="21.01"/>
-			<xs:enumeration value="22.01"/>
-			<xs:enumeration value="23.01"/>
-			<xs:enumeration value="24.01"/>
-			<xs:enumeration value="25.01"/>
-			<xs:enumeration value="25.02"/>
-			<xs:enumeration value="25.03"/>
-			<xs:enumeration value="25.04"/>
-			<xs:enumeration value="25.05"/>
-			<xs:enumeration value="26.01"/>
-			<xs:enumeration value="27.01"/>
-			<xs:enumeration value="28.01"/>
-			<xs:enumeration value="29.01"/>
-			<xs:enumeration value="30.01"/>
-			<xs:enumeration value="31.01"/>
-			<xs:enumeration value="32.01"/>
-			<xs:enumeration value="33.01"/>
-			<xs:enumeration value="34.01"/>
-			<xs:enumeration value="35.01"/>
-			<xs:enumeration value="36.01"/>
-			<xs:enumeration value="37.01"/>
-			<xs:enumeration value="38.01"/>
-			<xs:enumeration value="39.01"/>
-			<xs:enumeration value="40.01"/>
+			<xs:pattern value="[0-9]{2}.[0-9]{2}"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="TIdLote">

--- a/NFe.AppTeste/Schemas/tiposBasico_v4.00.xsd
+++ b/NFe.AppTeste/Schemas/tiposBasico_v4.00.xsd
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- PL_008  - 30/07/2013- NT 2013/005 -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:nfe="http://www.portalfiscal.inf.br/nfe" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xs:simpleType name="TCodUfIBGE">
@@ -512,7 +512,7 @@
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:whiteSpace value="preserve"/>
-			<xs:pattern value="[!-ÿ]{1}[ -ÿ]*[!-ÿ]{1}|[!-ÿ]{1}"/>
+			<xs:pattern value="[!-ÿ]{1}[ -ÿ]{0,}[!-ÿ]{1}|[!-ÿ]{1}"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="TData">

--- a/NFe.Classes/Informacoes/Detalhe/Observacao/obsItem.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Observacao/obsItem.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Xml.Serialization;
 
 namespace NFe.Classes.Informacoes.Detalhe.Observacao
 {
@@ -12,12 +13,14 @@ namespace NFe.Classes.Informacoes.Detalhe.Observacao
         ///     VA02 - Grupo de observações de uso livre do Contribuinte
         ///     <para>Ocorrência: 0-1</para>
         /// </summary>
+        [XmlElement(Namespace = nameof(Observacao))]
         public obsCont obsCont { get; set; }
 
         /// <summary>
         ///     VA05 - Grupo de observações de uso livre do Fisco
         ///     <para>Ocorrência: 0-1</para>
         /// </summary>
+        [XmlElement(Namespace = nameof(Observacao))]
         public obsFisco obsFisco { get; set; }
     }
 }

--- a/NFe.Classes/Informacoes/Detalhe/det.cs
+++ b/NFe.Classes/Informacoes/Detalhe/det.cs
@@ -60,13 +60,14 @@ namespace NFe.Classes.Informacoes.Detalhe
         public impostoDevol impostoDevol { get; set; }
 
         /// <summary>
-        ///     VA01 - Grupo de observações de uso livre (para o item da NF-e)
-        /// </summary>
-        public obsItem obsItem { get; set; }
-
-        /// <summary>
         ///     V01 - Informações Adicionais do Produto
         /// </summary>
-        public string infAdProd { get; set; }
+        public string infAdProd { get; set; }        
+        
+        /// <summary>
+        ///     VA01 - Grupo de observações de uso livre (para o item da NF-e)
+        /// </summary>
+        [XmlElement(nameof(obsItem))]
+        public obsItem obsItem { get; set; }
     }
 }

--- a/NFe.Classes/Informacoes/Observacoes/infAdic.cs
+++ b/NFe.Classes/Informacoes/Observacoes/infAdic.cs
@@ -56,21 +56,21 @@ namespace NFe.Classes.Informacoes.Observacoes
         ///     Z04 - Grupo Campo de uso livre do contribuinte
         ///     <para>Ocorrência: 0-10</para>
         /// </summary>
-        [XmlElement("obsCont")]
+        [XmlElement(ElementName = nameof(obsCont), Namespace = nameof(Observacoes))]
         public List<obsCont> obsCont { get; set; }
 
         /// <summary>
         ///     Z07 - Grupo Campo de uso livre do Fisco
         ///     <para>Ocorrência: 0-10</para>
         /// </summary>
-        [XmlElement("obsFisco")]
+        [XmlElement(ElementName = nameof(obsFisco), Namespace = nameof(Observacoes))]
         public List<obsFisco> obsFisco { get; set; }
 
         /// <summary>
         ///     Z10 - Grupo Processo referenciado
         ///     <para>Ocorrência: 0-100</para>
         /// </summary>
-        [XmlElement("procRef")]
+        [XmlElement(nameof(procRef))]
         public List<procRef> procRef { get; set; }
     }
 }

--- a/NFe.Classes/Informacoes/Observacoes/obsCont.cs
+++ b/NFe.Classes/Informacoes/Observacoes/obsCont.cs
@@ -30,7 +30,6 @@
 /* http://www.zeusautomacao.com.br/                                             */
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
-using System.Xml.Serialization;
 
 namespace NFe.Classes.Informacoes.Observacoes
 {
@@ -39,7 +38,6 @@ namespace NFe.Classes.Informacoes.Observacoes
         /// <summary>
         ///     Z05 - Identificação do campo
         /// </summary>
-        [XmlAttribute]
         public string xCampo { get; set; }
 
         /// <summary>

--- a/NFe.Danfe.Base/NFCe/NFCe.frx
+++ b/NFe.Danfe.Base/NFCe/NFCe.frx
@@ -161,12 +161,6 @@ namespace FastReport
     }
 
 
-    private void rtbTitulo_BeforePrint(object sender, EventArgs e)
-    {
-      rtbTitulo.Visible = (poEmitLogo.Image != null);
-    }
-
-
     private void memMsgFiscal_BeforePrint(object sender, EventArgs e)
     {
       //Conforme Manual de Padrões Padrões Técnicos do DANFE-NFC-e e QR Code, página 8
@@ -196,7 +190,7 @@ namespace FastReport
         return;        
         
       PgNfce.PaperHeight = 
-        (rtbTituloHeight + 
+        (rtbEmitLogoHeight + 
          phbEmitenteHeight + 
          ((Boolean)Report.GetParameterValue(&quot;NfceCancelado&quot;) ? phbCancelado.Height : 0)+
          ghbProdutosUmaLinhaHeight + 
@@ -250,10 +244,10 @@ namespace FastReport
       dbConsultaHeight = (dbConsulta.Visible ? dbConsulta.Height : 0);
     }
 
-    float rtbTituloHeight;
-    private void rtbTitulo_AfterPrint(object sender, EventArgs e)
+    float rtbEmitLogoHeight;
+    private void rtbEmitLogo_AfterPrint(object sender, EventArgs e)
     {
-      rtbTituloHeight = (rtbTitulo.Visible ? rtbTitulo.Height : 0);
+      rtbEmitLogoHeight = (rtbEmitLogo.Visible ? rtbEmitLogo.Height : 0);
     }
 
     float phbEmitenteHeight;
@@ -881,7 +875,7 @@ namespace FastReport
     <Total Name="TotalDetPagamentos" Expression="[NFCe.NFe.infNFe.pag.detPag.vPag]" Evaluator="dbDetPagamento"/>
   </Dictionary>
   <ReportPage Name="PgNfce" PaperWidth="79" LeftMargin="4.5" TopMargin="0" RightMargin="4.5" BottomMargin="1" FirstPageSource="15" OtherPagesSource="15" StartPageEvent="PgNfce_StartPage">
-    <ReportTitleBand Name="rtbTitulo" Width="264.6" Height="85.8" BeforePrintEvent="rtbTitulo_BeforePrint" AfterPrintEvent="rtbTitulo_AfterPrint">
+    <ReportTitleBand Name="rtbEmitLogo" Width="264.6" Height="85.8" AfterPrintEvent="rtbEmitLogo_AfterPrint">
       <PictureObject Name="poEmitLogo" Top="3.78" Width="264.6" Height="79.38" Image=""/>
     </ReportTitleBand>
     <PageHeaderBand Name="phbEmitente" Top="88.47" Width="264.6" Height="122.83" CanGrow="true" PrintOn="FirstPage, SinglePage" AfterPrintEvent="phbEmitente_AfterPrint">

--- a/NFe.Utils/Assinatura/Assinador.cs
+++ b/NFe.Utils/Assinatura/Assinador.cs
@@ -91,10 +91,11 @@ namespace NFe.Utils.Assinatura
             try
             {
                 var documento = new XmlDocument { PreserveWhitespace = true };
-
-                documento.LoadXml(cfgServicoRemoverAcentos
+                var xml = cfgServicoRemoverAcentos
                     ? FuncoesXml.ClasseParaXmlString(objetoLocal).RemoverAcentos()
-                    : FuncoesXml.ClasseParaXmlString(objetoLocal));
+                    : FuncoesXml.ClasseParaXmlString(objetoLocal);
+
+                documento.LoadXml(xml);
 
                 var docXml = new SignedXml(documento) { SigningKey = certificadoDigital.PrivateKey };
 

--- a/Shared.NFe.Danfe/DanfeSharedHelper.cs
+++ b/Shared.NFe.Danfe/DanfeSharedHelper.cs
@@ -63,21 +63,10 @@ namespace Shared.DFe.Danfe
             ((ReportPage)relatorio.FindObject("PgNfce")).LeftMargin = configuracaoDanfeNfce.MargemEsquerda;
             ((ReportPage)relatorio.FindObject("PgNfce")).RightMargin = configuracaoDanfeNfce.MargemDireita;
 
-            //alteracao necessaria para .netstandard, o código abaixo utiliza um método onde não é compativel para .netstandard:
-            //de : //((PictureObject)relatorio.FindObject("poEmitLogo")).Image = configuracaoDanfeNfce.ObterLogo();
-            //para:
-#if (NETSTANDARD || NETCOREAPP)
-            ((PictureObject)relatorio.FindObject("poEmitLogo")).SetImageData(configuracaoDanfeNfce.Logomarca);
-#else
-            if (configuracaoDanfeNfce.Logomarca != null && configuracaoDanfeNfce.Logomarca.Length > 0)
-            {
-                using (var ms = new MemoryStream(configuracaoDanfeNfce.Logomarca))
-                {
-                    var image = Image.FromStream(ms);
-                    ((PictureObject)relatorio.FindObject("poEmitLogo")).Image = image;
-                }
-            }
-#endif
+            var logomarcaEmitDefinida = configuracaoDanfeNfce.Logomarca != null && configuracaoDanfeNfce.Logomarca.Length > 0;
+            ((ReportTitleBand)relatorio.FindObject("rtbEmitLogo")).Visible = logomarcaEmitDefinida;
+            if (logomarcaEmitDefinida)
+                ((PictureObject)relatorio.FindObject("poEmitLogo")).SetImageData(configuracaoDanfeNfce.Logomarca);
 
             ((TextObject)relatorio.FindObject("txtUrl")).Text = string.IsNullOrEmpty(proc.NFe.infNFeSupl.urlChave) ? proc.NFe.infNFeSupl.ObterUrlConsulta(proc.NFe, configuracaoDanfeNfce.VersaoQrCode) : proc.NFe.infNFeSupl.urlChave;
             ((BarcodeObject)relatorio.FindObject("bcoQrCode")).Text = proc.NFe.infNFeSupl == null ? proc.NFe.infNFeSupl.ObterUrlQrCode(proc.NFe, configuracaoDanfeNfce.VersaoQrCode, cIdToken, csc) : proc.NFe.infNFeSupl.qrCode;


### PR DESCRIPTION
- Atualizados schemas de XML NF-e/NFC-e - Pacote de Liberação nº 9i (Novo leiaute da NF-e, NT 2021.004 v.1.00d). Publicado em 17/05/22;
- Correção de erro na serialização dos objetos das classes obsCont e obsFisco. Como essas classes estão duplicadas e em namespaces distintos, ocorria erro de serialização: System.InvalidOperationException: Tipos 'NFe.Classes.Informacoes.Observacoes.obsCont e 'NFe.Classes.Informacoes.Detalhe.Observacao.obsCont' usam nome tipo XML, 'obsCont', no espaço para nomes 'http://www.portalfiscal.inf.br/nfe';
- Invertida ordem dos atributos infAdProd e obsItem na classe det;
- Substituídas strings usadas em XmlElement por nameof;
- Removida anotação XmlAttribute de obsCont.xCampo;
- Ajuste na classe Assinador para facilitar depuração do método ObterAssinatura;
- Correção: a verificação de logomarca não nula no evento beforeprint no próprio fastReports, falhava as vezes. A checagem foi movida para o código do projeto c#;
- No arquivo de impressão do DANFE da NFCe foi renomeada banda de título para indicar que é usada somente para logomarca;
- Removida análise das diretivas NETSTANDARD e NETCOREAPP para impressão da logomarca no DANFE da NFCe em DanfeSharedHelper. A abordagem empregada para .NET standard e Core também funciona para .NET tradicional.

