### PR TITLE
Adicionado campo cSitConf na DistribuiçãoDFe referente ao schema 1.35

### DIFF
--- a/DFe.Classes/Flags/VersaoServico.cs
+++ b/DFe.Classes/Flags/VersaoServico.cs
@@ -40,6 +40,9 @@ namespace DFe.Classes.Flags
         [XmlEnum("1.00")]
         Versao100 = 100,
 
+        [XmlEnum("1.35")]
+        Versao135 = 135,
+
         [XmlEnum("2.00")]
         Versao200 = 200,
 

--- a/NFe.Classes/Servicos/DistribuicaoDFe/Schemas/resNFe.cs
+++ b/NFe.Classes/Servicos/DistribuicaoDFe/Schemas/resNFe.cs
@@ -124,5 +124,10 @@ namespace NFe.Classes.Servicos.DistribuicaoDFe.Schemas
         /// C14 - Situação da NF-e: 1=Uso autorizado; 2=Uso denegado.
         /// </summary>
         public byte cSitNFe { get; set; }
+
+        /// <summary>
+        /// C15 - 0 = Sem manifestação do destinatário; 1 = Confirma operação; 2 = Desconhecida; 3 = Operação não realizada; 4 = Ciência
+        /// </summary>
+        public byte cSitConf { get; set; }
     }
 }

--- a/NFe.Utils/Conversao.cs
+++ b/NFe.Utils/Conversao.cs
@@ -68,6 +68,8 @@ namespace NFe.Utils
                             return "1.01";
                     }
                     return "1.00";
+                case VersaoServico.Versao135:
+                    return "1.35";
                 case VersaoServico.Versao200:
                     switch (servicoNFe)
                     {

--- a/NFe.Utils/Validacao/Validador.cs
+++ b/NFe.Utils/Validacao/Validador.cs
@@ -111,8 +111,14 @@ namespace NFe.Utils.Validacao
                 case ServicoNFe.NfeDownloadNF:
                     return "downloadNFe_v1.00.xsd";
                 case ServicoNFe.NFeDistribuicaoDFe:
-                    return "distDFeInt_v1.01.xsd"; // "distDFeInt_v1.00.xsd";
-            }
+                    switch (versaoServico)
+                    {
+                        case VersaoServico.Versao135:
+                            return "distDFeInt_v1.35.xsd";
+                        default:
+                            return "distDFeInt_v1.01.xsd";
+                    }
+        }
             return null;
         }
 


### PR DESCRIPTION
Bom dia.
Descobri junto ao grupo da Unimake que o Webservice de DistribuiçãoDFe possui uma versão 1.35 a qual retorna o status da NFe, se ela já foi manifestada pelo cliente.
Adicionei no Zeus para trazer essa informação.

https://juvenal.com.br/Download/Schemas_DFe_1.35.rar

Segue o link com os schemas que utilizei