### PR TITLE
Alterado o endereço da ws de homologação do serviço  NFeDistribuicaoDFe. #1360

### DIFF
--- a/NFe.Utils/Enderecos/Enderecador.cs
+++ b/NFe.Utils/Enderecos/Enderecador.cs
@@ -1594,7 +1594,7 @@ namespace NFe.Utils.Enderecos
                     if (estado != Estado.CE & !svanEstados.Contains(estado))
                         addServico(new[] { ServicoNFe.NfeDownloadNF }, versao2E3, hom, TipoEmissao.teNormal, estado, modelo, "https://hom.nfe.fazenda.gov.br/NfeDownloadNF/NfeDownloadNF.asmx");
                     if (modelo != ModeloDocumento.NFCe)
-                        addServico(new[] { ServicoNFe.NFeDistribuicaoDFe }, versao1, hom, TipoEmissao.teNormal, estado, modelo, "https://hom.nfe.fazenda.gov.br/NFeDistribuicaoDFe/NFeDistribuicaoDFe.asmx");
+                        addServico(new[] { ServicoNFe.NFeDistribuicaoDFe }, versao1, hom, TipoEmissao.teNormal, estado, modelo, "https://hom1.nfe.fazenda.gov.br/NFeDistribuicaoDFe/NFeDistribuicaoDFe.asmx");
                 }
             }
 


### PR DESCRIPTION
Foi alterado no ambiente de homologação o endereço do ws do serviço NFeDistribuicaoDFe
https://www.nfe.fazenda.gov.br/portal/informe.aspx?ehCTG=false&Informe=3ogS20ezQ/I=&AspxAutoDetectCookieSupport=1

Antigo
https://hom.nfe.fazenda.gov.br/NFeDistribuicaoDFe/NFeDistribuicaoDFe.asmx

Novo
https://hom1.nfe.fazenda.gov.br/NFeDistribuicaoDFe/NFeDistribuicaoDFe.asmx