### PR TITLE
Correção do tratamento de retorno quando a tag possui namespace

### DIFF
--- a/DFe.Wsdl/Common/RequestBuilderAndSender.cs
+++ b/DFe.Wsdl/Common/RequestBuilderAndSender.cs
@@ -73,7 +73,7 @@ namespace CTe.CTeOSDocumento.Common
             string tes = soapUtils.SendRequest(xmlEnvelop, configuration.CertificadoDigital, configuration.Url, configuration.TimeOut, actionUrn: actionUrn);
             xmlResult.LoadXml(tes);
 
-            return xmlResult.GetElementsByTagName(responseElementName)[0];
+            return xmlResult.SelectSingleNode($"//*[local-name()='{responseElementName}']");
         }
     }
 }


### PR DESCRIPTION
Correção do problema reportado na issue #1361. 

Alguns estados a tag de resultado (nfeResultMsg) possui namespace. O método utilizado anteriormente para retornar a tag de resultado só considera as tags no namespace default do XML, por isso retorna nulo e ocorre o erro.

Alterei para SelectSingleNode, que retorna a primeira tag. Esse método é recomendado pela MS no lugar de GetElementsByTagName.
https://docs.microsoft.com/pt-br/dotnet/api/system.xml.xmldocument.getelementsbytagname?view=net-6.0