### PR TITLE
Implementação MDFeConfiguracao sem propriedades estáticas

### DIFF
--- a/MDFe.Classes/Extensoes/ExtMDFeEnviMDFe.cs
+++ b/MDFe.Classes/Extensoes/ExtMDFeEnviMDFe.cs
@@ -46,21 +46,12 @@ namespace MDFe.Classes.Extencoes
     {
         public static void Valida(this MDFeEnviMDFe enviMDFe)
         {
-            if (enviMDFe == null) throw new ArgumentException("Erro de assinatura, EnviMDFe esta null");
+            ValidaInternal(enviMDFe, MDFeConfiguracao.VersaoWebService.VersaoLayout);
+        }
 
-            var xmlMdfe = FuncoesXml.ClasseParaXmlString(enviMDFe);
-
-            switch (MDFeConfiguracao.VersaoWebService.VersaoLayout)
-            {
-                case VersaoServico.Versao100:
-                    Validador.Valida(xmlMdfe, "enviMDFe_v1.00.xsd");
-                    break;
-                case VersaoServico.Versao300:
-                    Validador.Valida(xmlMdfe, "enviMDFe_v3.00.xsd");
-                    break;
-            }
-
-            enviMDFe.MDFe.Valida();
+        public static void Valida(this MDFeEnviMDFe enviMDFe, MDFeServicoConfiguracao servicoConfiguracao)
+        {
+            ValidaInternal(enviMDFe, servicoConfiguracao.VersaoWebService.VersaoLayout);
         }
 
         public static XmlDocument CriaXmlRequestWs(this MDFeEnviMDFe enviMDFe)
@@ -80,15 +71,42 @@ namespace MDFe.Classes.Extencoes
 
         public static void SalvarXmlEmDisco(this MDFeEnviMDFe enviMDFe)
         {
-            if (MDFeConfiguracao.NaoSalvarXml()) return;
+            SalvarXmlEmDiscoInternal(enviMDFe, MDFeConfiguracao.CaminhoSalvarXml, MDFeConfiguracao.IsSalvarXml);
+        }
 
-            var caminhoXml = MDFeConfiguracao.CaminhoSalvarXml;
+        public static void SalvarXmlEmDisco(this MDFeEnviMDFe enviMDFe, MDFeServicoConfiguracao servicoConfiguracao)
+        {
+            SalvarXmlEmDiscoInternal(enviMDFe, servicoConfiguracao.CaminhoSalvarXml, servicoConfiguracao.IsSalvarXml);
+        }
 
-            var arquivoSalvar = Path.Combine(caminhoXml, enviMDFe.MDFe.Chave() + "-completo-mdfe.xml");
+        private static void ValidaInternal(MDFeEnviMDFe enviMDFe, VersaoServico versaoLayout)
+        {
+            if (enviMDFe == null) throw new ArgumentException("Erro de assinatura, EnviMDFe esta null");
+
+            var xmlMdfe = FuncoesXml.ClasseParaXmlString(enviMDFe);
+
+            switch (versaoLayout)
+            {
+                case VersaoServico.Versao100:
+                    Validador.Valida(xmlMdfe, "enviMDFe_v1.00.xsd");
+                    break;
+                case VersaoServico.Versao300:
+                    Validador.Valida(xmlMdfe, "enviMDFe_v3.00.xsd");
+                    break;
+            }
+
+            enviMDFe.MDFe.Valida(versaoLayout);
+        }
+
+        private static void SalvarXmlEmDiscoInternal(MDFeEnviMDFe enviMDFe, string caminhoSalvarXml, bool salvarXml)
+        {
+            if (!salvarXml) return;
+
+            var arquivoSalvar = Path.Combine(caminhoSalvarXml, enviMDFe.MDFe.Chave() + "-completo-mdfe.xml");
 
             FuncoesXml.ClasseParaArquivoXml(enviMDFe, arquivoSalvar);
 
-            enviMDFe.MDFe.SalvarXmlEmDisco();
+            enviMDFe.MDFe.SalvarXmlEmDisco(caminhoSalvarXml, salvarXml);
         }
     }
 }

--- a/MDFe.Classes/Extensoes/ExtMDFeRetEnviMDFe.cs
+++ b/MDFe.Classes/Extensoes/ExtMDFeRetEnviMDFe.cs
@@ -42,11 +42,19 @@ namespace MDFe.Classes.Extencoes
     {
         public static void SalvarXmlEmDisco(this MDFeRetEnviMDFe retEnviMDFe)
         {
-            if (MDFeConfiguracao.NaoSalvarXml()) return;
+            SalvarXmlEmDiscoInternal(retEnviMDFe, MDFeConfiguracao.IsSalvarXml, MDFeConfiguracao.CaminhoSalvarXml);
+        }
 
-            var caminhoXml = MDFeConfiguracao.CaminhoSalvarXml;
+        public static void SalvarXmlEmDisco(this MDFeRetEnviMDFe retEnviMDFe, MDFeServicoConfiguracao servicoConfiguracao)
+        {
+            SalvarXmlEmDiscoInternal(retEnviMDFe, servicoConfiguracao.IsSalvarXml, servicoConfiguracao.CaminhoSalvarXml);
+        }
 
-            var arquivoSalvar = Path.Combine(caminhoXml, retEnviMDFe.InfRec.NRec + "-rec.xml");
+        private static void SalvarXmlEmDiscoInternal(MDFeRetEnviMDFe retEnviMDFe, bool salvarXml, string caminhoSalvarXml)
+        {
+            if (!salvarXml) return;
+
+            var arquivoSalvar = Path.Combine(caminhoSalvarXml, retEnviMDFe.InfRec.NRec + "-rec.xml");
 
             FuncoesXml.ClasseParaArquivoXml(retEnviMDFe, arquivoSalvar);
         }

--- a/MDFe.Servicos/Factory/ClassesFactory.cs
+++ b/MDFe.Servicos/Factory/ClassesFactory.cs
@@ -50,26 +50,12 @@ namespace MDFe.Servicos.Factory
     {
         public static MDFeCosMDFeNaoEnc CriarConsMDFeNaoEnc(string cnpjCpf)
         {
-            var documentoUnico = cnpjCpf;
+            return CriarConsMDFeNaoEncInternal(cnpjCpf, MDFeConfiguracao.VersaoWebService);
+        }
 
-            var consMDFeNaoEnc = new MDFeCosMDFeNaoEnc
-            {
-                TpAmb = MDFeConfiguracao.VersaoWebService.TipoAmbiente,
-                Versao = MDFeConfiguracao.VersaoWebService.VersaoLayout,
-                XServ = "CONSULTAR NÃO ENCERRADOS"
-            };
-
-            if (documentoUnico.Length == 11)
-            {
-                consMDFeNaoEnc.CPF = cnpjCpf;
-            }
-
-            if (documentoUnico.Length == 14)
-            {
-                consMDFeNaoEnc.CNPJ = cnpjCpf;
-            }
-
-            return consMDFeNaoEnc;
+        public static MDFeCosMDFeNaoEnc CriarConsMDFeNaoEnc(string cnpjCpf, MDFeServicoConfiguracao configuracaoServico)
+        {
+            return CriarConsMDFeNaoEncInternal(cnpjCpf, configuracaoServico.VersaoWebService);
         }
 
         public static MDFeEvIncDFeMDFe CriaEvIncDFeMDFe(string protocolo, string codigoMunicipioCarregamento, string nomeMunicipioCarregamento, List<MDFeInfDocInc> informacoesDocumentos)
@@ -85,15 +71,12 @@ namespace MDFe.Servicos.Factory
 
         public static MDFeConsSitMDFe CriarConsSitMDFe(string chave)
         {
-            var consSitMdfe = new MDFeConsSitMDFe
-            {
-                Versao = MDFeConfiguracao.VersaoWebService.VersaoLayout,
-                TpAmb = MDFeConfiguracao.VersaoWebService.TipoAmbiente,
-                XServ = "CONSULTAR",
-                ChMDFe = chave
-            };
+            return CriarConsSitMDFeInternal(chave, MDFeConfiguracao.VersaoWebService);
+        }
 
-            return consSitMdfe;
+        public static MDFeConsSitMDFe CriarConsSitMDFe(string chave, MDFeServicoConfiguracao servicoConfiguracao)
+        {
+            return CriarConsSitMDFeInternal(chave, servicoConfiguracao.VersaoWebService);
         }
 
         public static MDFeEvCancMDFe CriaEvCancMDFe(string protocolo, string justificativa)
@@ -155,36 +138,32 @@ namespace MDFe.Servicos.Factory
 
         public static MDFeEnviMDFe CriaEnviMDFe(long lote, MDFeEletronico mdfe)
         {
-            var enviMdfe = new MDFeEnviMDFe
-            {
-                MDFe = mdfe,
-                IdLote = lote.ToString(),
-                Versao = MDFeConfiguracao.VersaoWebService.VersaoLayout
-            };
+            return CriaEnviMDFeInternal(lote, mdfe, MDFeConfiguracao.VersaoWebService.VersaoLayout);
+        }
 
-            return enviMdfe;
+        public static MDFeEnviMDFe CriaEnviMDFe(long lote, MDFeEletronico mdfe, MDFeServicoConfiguracao servicoConfiguracao)
+        {
+            return CriaEnviMDFeInternal(lote, mdfe, servicoConfiguracao.VersaoWebService.VersaoLayout);
         }
 
         public static MDFeConsReciMDFe CriaConsReciMDFe(string numeroRecibo)
         {
-            var consReciMDFe = new MDFeConsReciMDFe
-            {
-                Versao = MDFeConfiguracao.VersaoWebService.VersaoLayout,
-                TpAmb = MDFeConfiguracao.VersaoWebService.TipoAmbiente,
-                NRec = numeroRecibo
-            };
+            return CriaConsReciMDFeInternal(numeroRecibo, MDFeConfiguracao.VersaoWebService);
+        }
 
-            return consReciMDFe;
+        public static MDFeConsReciMDFe CriaConsReciMDFe(string numeroRecibo, MDFeServicoConfiguracao servicoConfiguracao)
+        {
+            return CriaConsReciMDFeInternal(numeroRecibo, servicoConfiguracao.VersaoWebService);
         }
 
         public static MDFeConsStatServMDFe CriaConsStatServMDFe()
         {
-            return new MDFeConsStatServMDFe
-            {
-                TpAmb = MDFeConfiguracao.VersaoWebService.TipoAmbiente,
-                Versao = MDFeConfiguracao.VersaoWebService.VersaoLayout,
-                XServ = "STATUS"
-            };
+            return CriaConsStatServMDFe(MDFeConfiguracao.VersaoWebService);
+        }
+
+        public static MDFeConsStatServMDFe CriaConsStatServMDFe(MDFeServicoConfiguracao servicoConfiguracao)
+        {
+            return CriaConsStatServMDFe(servicoConfiguracao);
         }
 
         public static evPagtoOperMDFe CriaEvPagtoOperMDFe(string protocolo, infViagens infViagens, List<infPag> infPagamentos)
@@ -196,5 +175,79 @@ namespace MDFe.Servicos.Factory
                 infPag = infPagamentos
             };
         }
+
+        #region Métodos internos
+
+        private static MDFeCosMDFeNaoEnc CriarConsMDFeNaoEncInternal(string cnpjCpf, MDFeVersaoWebService versaoWebService)
+        {
+            var documentoUnico = cnpjCpf;
+
+            var consMDFeNaoEnc = new MDFeCosMDFeNaoEnc
+            {
+                TpAmb = versaoWebService.TipoAmbiente,
+                Versao = versaoWebService.VersaoLayout,
+                XServ = "CONSULTAR NÃO ENCERRADOS"
+            };
+
+            if (documentoUnico.Length == 11)
+            {
+                consMDFeNaoEnc.CPF = cnpjCpf;
+            }
+
+            if (documentoUnico.Length == 14)
+            {
+                consMDFeNaoEnc.CNPJ = cnpjCpf;
+            }
+
+            return consMDFeNaoEnc;
+        }
+
+        private static MDFeConsSitMDFe CriarConsSitMDFeInternal(string chave, MDFeVersaoWebService versaoWebService)
+        {
+            var consSitMdfe = new MDFeConsSitMDFe
+            {
+                Versao = versaoWebService.VersaoLayout,
+                TpAmb = versaoWebService.TipoAmbiente,
+                XServ = "CONSULTAR",
+                ChMDFe = chave
+            };
+
+            return consSitMdfe;
+        }
+
+        private static MDFeEnviMDFe CriaEnviMDFeInternal(long lote, MDFeEletronico mdfe, Utils.Flags.VersaoServico versao)
+        {
+            var enviMdfe = new MDFeEnviMDFe
+            {
+                MDFe = mdfe,
+                IdLote = lote.ToString(),
+                Versao = versao,
+            };
+
+            return enviMdfe;
+        }
+
+        private static MDFeConsReciMDFe CriaConsReciMDFeInternal(string numeroRecibo, MDFeVersaoWebService versaoWebService)
+        {
+            var consReciMDFe = new MDFeConsReciMDFe
+            {
+                Versao = versaoWebService.VersaoLayout,
+                TpAmb = versaoWebService.TipoAmbiente,
+                NRec = numeroRecibo
+            };
+
+            return consReciMDFe;
+        }
+        private static MDFeConsStatServMDFe CriaConsStatServMDFe(MDFeVersaoWebService versaoWebService)
+        {
+            return new MDFeConsStatServMDFe
+            {
+                TpAmb = versaoWebService.TipoAmbiente,
+                Versao = versaoWebService.VersaoLayout,
+                XServ = "STATUS"
+            };
+        }
+
+        #endregion
     }
 }

--- a/MDFe.Servicos/Factory/WsdlFactory.cs
+++ b/MDFe.Servicos/Factory/WsdlFactory.cs
@@ -42,6 +42,7 @@ using MDFe.Wsdl.MDFeConsultaProtoloco;
 using MDFe.Wsdl.MDFeEventos;
 using MDFe.Wsdl.MDFeRecepcao;
 using MDFe.Wsdl.MDFeRetRecepcao;
+using System.Security.Cryptography.X509Certificates;
 
 namespace MDFe.Servicos.Factory
 {
@@ -49,68 +50,129 @@ namespace MDFe.Servicos.Factory
     {
         public static MDFeConsNaoEnc CriaWsdlMDFeConsNaoEnc()
         {
-            var url = UrlHelper.ObterUrlServico(MDFeConfiguracao.VersaoWebService.TipoAmbiente).MDFeConsNaoEnc;
-            var versao = MDFeConfiguracao.VersaoWebService.VersaoLayout.GetVersaoString();
-            var configuracaoWsdl = CriaConfiguracao(url, versao);
+            return CriaWsdlMDFeConsNaoEncInternal(MDFeConfiguracao.VersaoWebService, MDFeConfiguracao.X509Certificate2);
+        }
+
+        public static MDFeConsNaoEnc CriaWsdlMDFeConsNaoEnc(MDFeServicoConfiguracao servicoConfiguracao)
+        {
+            return CriaWsdlMDFeConsNaoEncInternal(servicoConfiguracao.VersaoWebService, servicoConfiguracao.X509Certificate2);
+        }
+
+        public static MDFeConsulta CriaWsdlMDFeConsulta()
+        {
+            return CriaWsdlMDFeConsultaInternal(MDFeConfiguracao.VersaoWebService, MDFeConfiguracao.X509Certificate2);
+        }
+
+        public static MDFeConsulta CriaWsdlMDFeConsulta(MDFeServicoConfiguracao servicoConfiguracao)
+        {
+            return CriaWsdlMDFeConsultaInternal(servicoConfiguracao.VersaoWebService, servicoConfiguracao.X509Certificate2);
+        }
+
+        public static MDFeRecepcaoEvento CriaWsdlMDFeRecepcaoEvento()
+        {
+            return CriaWsdlMDFeRecepcaoEventoInternal(MDFeConfiguracao.VersaoWebService, MDFeConfiguracao.X509Certificate2);
+        }
+        public static MDFeRecepcaoEvento CriaWsdlMDFeRecepcaoEvento(MDFeServicoConfiguracao servicoConfiguracao)
+        {
+            return CriaWsdlMDFeRecepcaoEventoInternal(servicoConfiguracao.VersaoWebService, servicoConfiguracao.X509Certificate2);
+        }
+
+        public static MDFeRecepcao CriaWsdlMDFeRecepcao()
+        {
+            return CriaWsdlMDFeRecepcaoInternal(MDFeConfiguracao.VersaoWebService, MDFeConfiguracao.X509Certificate2);
+        }
+
+        public static MDFeRecepcao CriaWsdlMDFeRecepcao(MDFeServicoConfiguracao servicoConfiguracao)
+        {
+            return CriaWsdlMDFeRecepcaoInternal(servicoConfiguracao.VersaoWebService, servicoConfiguracao.X509Certificate2);
+        }
+
+        public static MDFeRetRecepcao CriaWsdlMDFeRetRecepcao()
+        {
+            return CriaWsdlMDFeRetRecepcaoInternal(MDFeConfiguracao.VersaoWebService, MDFeConfiguracao.X509Certificate2);
+        }
+
+        public static MDFeRetRecepcao CriaWsdlMDFeRetRecepcao(MDFeServicoConfiguracao servicoConfiguracao)
+        {
+            return CriaWsdlMDFeRetRecepcaoInternal(servicoConfiguracao.VersaoWebService, servicoConfiguracao.X509Certificate2);
+        }
+
+        public static MDFeStatusServico CriaWsdlMDFeStatusServico()
+        {
+            return CriaWsdlMDFeStatusServicoInternal(MDFeConfiguracao.VersaoWebService, MDFeConfiguracao.X509Certificate2);
+        }
+
+        public static MDFeStatusServico CriaWsdlMDFeStatusServico(MDFeServicoConfiguracao servicoConfiguracao)
+        {
+            return CriaWsdlMDFeStatusServicoInternal(servicoConfiguracao.VersaoWebService, servicoConfiguracao.X509Certificate2);
+        }
+
+        #region Métodos privados
+
+        private static MDFeConsNaoEnc CriaWsdlMDFeConsNaoEncInternal(MDFeVersaoWebService versaoWebService, X509Certificate2 certificado)
+        {
+            var url = UrlHelper.ObterUrlServico(versaoWebService.TipoAmbiente).MDFeConsNaoEnc;
+            var versao = versaoWebService.VersaoLayout.GetVersaoString();
+            var configuracaoWsdl = CriaConfiguracao(url, versao, versaoWebService, certificado);
 
             var ws = new MDFeConsNaoEnc(configuracaoWsdl);
             return ws;
         }
 
-        public static MDFeConsulta CriaWsdlMDFeConsulta()
+        private static MDFeConsulta CriaWsdlMDFeConsultaInternal(MDFeVersaoWebService versaoWebService, X509Certificate2 certificado)
         {
-            var url = UrlHelper.ObterUrlServico(MDFeConfiguracao.VersaoWebService.TipoAmbiente).MDFeConsulta;
-            var versao = MDFeConfiguracao.VersaoWebService.VersaoLayout.GetVersaoString();
+            var url = UrlHelper.ObterUrlServico(versaoWebService.TipoAmbiente).MDFeConsulta;
+            var versao = versaoWebService.VersaoLayout.GetVersaoString();
 
-            var configuracaoWsdl = CriaConfiguracao(url, versao);
+            var configuracaoWsdl = CriaConfiguracao(url, versao, versaoWebService, certificado);
 
             return new MDFeConsulta(configuracaoWsdl);
         }
 
-        public static MDFeRecepcaoEvento CriaWsdlMDFeRecepcaoEvento()
+        private static MDFeRecepcaoEvento CriaWsdlMDFeRecepcaoEventoInternal(MDFeVersaoWebService versaoWebService, X509Certificate2 certificado)
         {
-            var url = UrlHelper.ObterUrlServico(MDFeConfiguracao.VersaoWebService.TipoAmbiente).MDFeRecepcaoEvento;
-            var versao = MDFeConfiguracao.VersaoWebService.VersaoLayout.GetVersaoString();
+            var url = UrlHelper.ObterUrlServico(versaoWebService.TipoAmbiente).MDFeRecepcaoEvento;
+            var versao = versaoWebService.VersaoLayout.GetVersaoString();
 
-            var configuracaoWsdl = CriaConfiguracao(url, versao);
+            var configuracaoWsdl = CriaConfiguracao(url, versao, versaoWebService, certificado);
 
             return new MDFeRecepcaoEvento(configuracaoWsdl);
         }
 
-        public static MDFeRecepcao CriaWsdlMDFeRecepcao()
+        private static MDFeRecepcao CriaWsdlMDFeRecepcaoInternal(MDFeVersaoWebService versaoWebService, X509Certificate2 certificado)
         {
-            var url = UrlHelper.ObterUrlServico(MDFeConfiguracao.VersaoWebService.TipoAmbiente).MDFeRecepcao;
-            var versaoServico = MDFeConfiguracao.VersaoWebService.VersaoLayout.GetVersaoString();
+            var url = UrlHelper.ObterUrlServico(versaoWebService.TipoAmbiente).MDFeRecepcao;
+            var versaoDoServico = versaoWebService.VersaoLayout.GetVersaoString();
 
-            var configuracaoWsdl = CriaConfiguracao(url, versaoServico);
+            var configuracaoWsdl = CriaConfiguracao(url, versaoDoServico, versaoWebService, certificado);
 
-            return new MDFeRecepcao(configuracaoWsdl); ;
+            return new MDFeRecepcao(configuracaoWsdl);
         }
 
-        public static MDFeRetRecepcao CriaWsdlMDFeRetRecepcao()
+        private static MDFeRetRecepcao CriaWsdlMDFeRetRecepcaoInternal(MDFeVersaoWebService versaoWebService, X509Certificate2 certificado)
         {
-            var url = UrlHelper.ObterUrlServico(MDFeConfiguracao.VersaoWebService.TipoAmbiente).MDFeRetRecepcao;
-            var versao = MDFeConfiguracao.VersaoWebService.VersaoLayout.GetVersaoString();
+            var url = UrlHelper.ObterUrlServico(versaoWebService.TipoAmbiente).MDFeRetRecepcao;
+            var versao = versaoWebService.VersaoLayout.GetVersaoString();
 
-            var configuracaoWsdl = CriaConfiguracao(url, versao);
+            var configuracaoWsdl = CriaConfiguracao(url, versao, versaoWebService, certificado);
 
             return new MDFeRetRecepcao(configuracaoWsdl);
         }
 
-        public static MDFeStatusServico CriaWsdlMDFeStatusServico()
+        private static MDFeStatusServico CriaWsdlMDFeStatusServicoInternal(MDFeVersaoWebService versaoWebService, X509Certificate2 certificado)
         {
-            var url = UrlHelper.ObterUrlServico(MDFeConfiguracao.VersaoWebService.TipoAmbiente).MDFeStatusServico;
-            var versao = MDFeConfiguracao.VersaoWebService.VersaoLayout.GetVersaoString();
+            var url = UrlHelper.ObterUrlServico(versaoWebService.TipoAmbiente).MDFeStatusServico;
+            var versao = versaoWebService.VersaoLayout.GetVersaoString();
 
-            var configuracaoWsdl = CriaConfiguracao(url, versao);
+            var configuracaoWsdl = CriaConfiguracao(url, versao, versaoWebService, certificado);
 
             return new MDFeStatusServico(configuracaoWsdl);
         }
 
-        private static WsdlConfiguracao CriaConfiguracao(string url, string versao)
+        private static WsdlConfiguracao CriaConfiguracao(string url, string versao, MDFeVersaoWebService versaoWebService, X509Certificate2 certificado)
         {
-            var codigoEstado = MDFeConfiguracao.VersaoWebService.UfEmitente.GetCodigoIbgeEmString();
-            var certificadoDigital = MDFeConfiguracao.X509Certificate2;
+            var codigoEstado = versaoWebService.UfEmitente.GetCodigoIbgeEmString();
+            var certificadoDigital = certificado;
 
             return new WsdlConfiguracao
             {
@@ -118,8 +180,10 @@ namespace MDFe.Servicos.Factory
                 Versao = versao,
                 CodigoIbgeEstado = codigoEstado,
                 Url = url,
-                TimeOut = MDFeConfiguracao.VersaoWebService.TimeOut
+                TimeOut = versaoWebService.TimeOut
             };
         }
+
+        #endregion
     }
 }

--- a/MDFe.Utils/Configuracoes/MDFeServicoConfiguracao.cs
+++ b/MDFe.Utils/Configuracoes/MDFeServicoConfiguracao.cs
@@ -1,0 +1,74 @@
+﻿using DFe.Utils;
+using DFe.Utils.Assinatura;
+using System;
+using System.Security.Cryptography.X509Certificates;
+
+namespace MDFe.Utils.Configuracoes
+{
+    public class MDFeServicoConfiguracao : IDisposable
+    {
+        private MDFeVersaoWebService _versaoWebService;
+
+        private X509Certificate2 _certificado;
+
+        public bool IsSalvarXml { get; set; }
+        public string CaminhoSchemas { get; set; }
+        public string CaminhoSalvarXml { get; set; }
+        public bool IsAdicionaQrCode { get; set; }
+        public ConfiguracaoCertificado ConfiguracaoCertificado { get; set; }
+
+        public MDFeVersaoWebService VersaoWebService
+        {
+            get { return GetMdfeVersaoWebService(); }
+            set { _versaoWebService = value; }
+        }
+
+        public X509Certificate2 X509Certificate2
+        {
+            get
+            {
+                if (_certificado != null)
+                    if (!ConfiguracaoCertificado.ManterDadosEmCache)
+                        _certificado.Reset();
+                _certificado = ObterCertificado();
+                return _certificado;
+            }
+        }
+
+        private X509Certificate2 ObterCertificado()
+        {
+            return CertificadoDigital.ObterCertificado(ConfiguracaoCertificado);
+        }
+
+        public bool NaoSalvarXml()
+        {
+            return !IsSalvarXml;
+        }
+
+        private MDFeVersaoWebService GetMdfeVersaoWebService()
+        {
+            if (_versaoWebService == null)
+                _versaoWebService = new MDFeVersaoWebService();
+
+            return _versaoWebService;
+        }
+
+        public void Dispose()
+        {
+            if (!ConfiguracaoCertificado.ManterDadosEmCache && _certificado != null)
+            {
+                _certificado.Reset();
+                _certificado = null;
+            }
+        }
+
+        ~MDFeServicoConfiguracao()
+        {
+            if (!ConfiguracaoCertificado.ManterDadosEmCache && _certificado != null)
+            {
+                _certificado.Reset();
+                _certificado = null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Diante da issue #1423 fiz uma pequena implementação no serviço de envio de MDFe (classe `ServicoMDFeRecepcao`) tratando a questão das propriedades estáticas para configuração do serviço. Foi tomado o devido cuidado para não quebrar a lib para as pessoas que já utilizam.

Implementei somente no envio para ver se é aceito dessa forma. Caso seja, irei implementar nos demais serviços, para tratar igualmente.