### PR TITLE
Corrigido a forma de obter a chave privada do certificado para CTe e MDFe / Adicionado order nas propriedades do CTe infOutros e infNF

### DIFF
--- a/CTe.Classes/Informacoes/infCTeNormal/infDocumentos/infNF.cs
+++ b/CTe.Classes/Informacoes/infCTeNormal/infDocumentos/infNF.cs
@@ -42,10 +42,15 @@ namespace CTe.Classes.Informacoes.infCTeNormal.infDocumentos
 {
     public class infNF
     {
+        [XmlElement(Order = 1)]
         public string nRoma { get; set; }
+        [XmlElement(Order = 2)]
         public string nPed { get; set; }
+        [XmlElement(Order = 3)]
         public mod mod { get; set; }
+        [XmlElement(Order = 4)]
         public string serie { get; set; }
+        [XmlElement(Order = 5)]
         public string nDoc { get; set; }
 
         [XmlIgnore]
@@ -54,7 +59,7 @@ namespace CTe.Classes.Informacoes.infCTeNormal.infDocumentos
         /// <summary>
         /// Proxy para dEmi no formato AAAA-MM-DD
         /// </summary>
-        [XmlElement(ElementName = "dEmi")]
+        [XmlElement(ElementName = "dEmi", Order = 6)]
         public string ProxyddEmi
         {
             get
@@ -65,53 +70,53 @@ namespace CTe.Classes.Informacoes.infCTeNormal.infDocumentos
 
         }
 
-
+        [XmlElement(Order = 7)]
         public decimal vBC
         {
             get { return _vBc.Arredondar(2); }
             set { _vBc = value.Arredondar(2); }
         }
-
+        [XmlElement(Order = 8)]
         public decimal vICMS
         {
             get { return _vIcms.Arredondar(2); }
             set { _vIcms = value.Arredondar(2); }
         }
-
+        [XmlElement(Order = 9)]
         public decimal vBCST
         {
             get { return _vBcst.Arredondar(2); }
             set { _vBcst = value.Arredondar(2); }
         }
-
+        [XmlElement(Order = 10)]
         public decimal vST
         {
             get { return _vSt.Arredondar(2); }
             set { _vSt = value.Arredondar(2); }
         }
-
+        [XmlElement(Order = 11)]
         public decimal vProd
         {
             get { return _vProd.Arredondar(2); }
             set { _vProd = value.Arredondar(2); }
         }
-
+        [XmlElement(Order = 12)]
         public decimal vNF
         {
             get { return _vNf.Arredondar(2); }
             set { _vNf = value.Arredondar(2); }
         }
-
+        [XmlElement(Order = 13)]
         public int nCFOP { get; set; }
-
+        [XmlElement(Order = 14)]
         public decimal? nPeso
         {
             get { return _nPeso.Arredondar(3); }
             set { _nPeso = value.Arredondar(3); }
         }
-        
+        [XmlElement(Order = 15)]
         public bool nPesoSpecified { get { return _nPeso.HasValue; } }
-
+        [XmlElement(Order = 16)]
         public string PIN { get; set; }
 
         [XmlIgnore]
@@ -120,7 +125,7 @@ namespace CTe.Classes.Informacoes.infCTeNormal.infDocumentos
         /// <summary>
         /// Proxy para dPrev no formato AAAA-MM-DD
         /// </summary>
-        [XmlElement(ElementName = "dPrev")]
+        [XmlElement(ElementName = "dPrev", Order = 17)]
         public string ProxyddPrev
         {
             get
@@ -134,10 +139,10 @@ namespace CTe.Classes.Informacoes.infCTeNormal.infDocumentos
             set { dPrev = DateTime.Parse(value); }
         }
 
-        [XmlElement("infUnidTransp")]
+        [XmlElement("infUnidTransp", Order = 18)]
         public List<infUnidTransp> infUnidTransp;
 
-        [XmlElement("infUnidCarga")]
+        [XmlElement("infUnidCarga", Order = 19)]
         public List<infUnidCarga> infUnidCarga;
 
         private decimal _vBc;

--- a/CTe.Classes/Informacoes/infCTeNormal/infDocumentos/infOutros.cs
+++ b/CTe.Classes/Informacoes/infCTeNormal/infDocumentos/infOutros.cs
@@ -42,8 +42,11 @@ namespace CTe.Classes.Informacoes.infCTeNormal.infDocumentos
 {
     public class infOutros
     {
+        [XmlElement(Order = 1)]
         public tpDoc tpDoc { get; set; }
+        [XmlElement(Order = 2)]
         public string descOutros { get; set; }
+        [XmlElement(Order = 3)]
         public string nDoc { get; set; }
 
         [XmlIgnore]
@@ -52,7 +55,7 @@ namespace CTe.Classes.Informacoes.infCTeNormal.infDocumentos
         /// <summary>
         /// Proxy para dPrev no formato AAAA-MM-DD
         /// </summary>
-        [XmlElement(ElementName = "dEmi")]
+        [XmlElement(ElementName = "dEmi", Order = 4)]
         public string ProxyddEmi
         {
             get
@@ -66,7 +69,7 @@ namespace CTe.Classes.Informacoes.infCTeNormal.infDocumentos
             set { dEmi = DateTime.Parse(value); }
         }
 
-
+        [XmlElement(Order = 5)]
         public decimal? vDocFisc
         {
             get { return _vDocFisc.Arredondar(2); }
@@ -81,7 +84,7 @@ namespace CTe.Classes.Informacoes.infCTeNormal.infDocumentos
         /// <summary>
         /// Proxy para dPrev no formato AAAA-MM-DD
         /// </summary>
-        [XmlElement(ElementName = "dPrev")]
+        [XmlElement(ElementName = "dPrev", Order = 6)]
         public string ProxyddPrev
         {
             get
@@ -95,10 +98,10 @@ namespace CTe.Classes.Informacoes.infCTeNormal.infDocumentos
             set { dPrev = DateTime.Parse(value); }
         }
 
-        [XmlElement("infUnidTransp")]
+        [XmlElement("infUnidTransp", Order = 7)]
         public List<infUnidTransp> infUnidTransp;
 
-        [XmlElement("infUnidCarga")]
+        [XmlElement("infUnidCarga", Order = 8)]
         public List<infUnidCarga> infUnidCarga;
 
         private decimal? _vDocFisc;

--- a/CTe.Utils/CTe/ExtCTe.cs
+++ b/CTe.Utils/CTe/ExtCTe.cs
@@ -263,7 +263,7 @@ namespace CTe.Utils.CTe
 
         private static byte[] CreateSignaturePkcs1(X509Certificate2 certificadoDigital, byte[] Value)
         {
-            RSACryptoServiceProvider rsa = (RSACryptoServiceProvider)certificadoDigital.PrivateKey;
+            var rsa = certificadoDigital.GetRSAPrivateKey();
 
             RSAPKCS1SignatureFormatter rsaF = new RSAPKCS1SignatureFormatter(rsa);
 

--- a/MDFe.Classes/Extensoes/ExtMDFe.cs
+++ b/MDFe.Classes/Extensoes/ExtMDFe.cs
@@ -254,9 +254,8 @@ namespace MDFe.Classes.Extencoes
         }
 
         private static byte[] CreateSignaturePkcs1(X509Certificate2 certificado, byte[] Value)
-
         {
-            RSACryptoServiceProvider rsa = (RSACryptoServiceProvider)certificado.PrivateKey;
+            var rsa = certificado.GetRSAPrivateKey();
 
             RSAPKCS1SignatureFormatter rsaF = new RSAPKCS1SignatureFormatter(rsa);
 


### PR DESCRIPTION
Alterado a forma de obter a chave privada do certificado para CTe e MDFe para correção do erro Unable to cast object of type 'System.Security.Cryptography.RSACng' to type 'System.Security.Cryptography.RSACryptoServiceProvider'." #1430 

Adicionado order nas propriedades do CTe infOutros onde resultava em erro na validação do schema por conta das tags desordenadas