### PR TITLE
Update da versao do fastreport para 2022.2.2

### DIFF
--- a/CTe.Dacte.OpenFast/CTe.Dacte.OpenFast.csproj
+++ b/CTe.Dacte.OpenFast/CTe.Dacte.OpenFast.csproj
@@ -6,8 +6,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="FastReport.OpenSource" Version="2019.3.19" />
-		<PackageReference Include="FastReport.OpenSource.Export.PdfSimple" Version="2019.3.19" />
+		<PackageReference Include="FastReport.OpenSource" Version="2022.2.2" />
+		<PackageReference Include="FastReport.OpenSource.Export.PdfSimple" Version="2022.2.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/MDFe.Damdfe.OpenFast/MDFe.Damdfe.OpenFast.csproj
+++ b/MDFe.Damdfe.OpenFast/MDFe.Damdfe.OpenFast.csproj
@@ -6,8 +6,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="FastReport.OpenSource" Version="2019.3.19" />
-		<PackageReference Include="FastReport.OpenSource.Export.PdfSimple" Version="2019.3.19" />
+		<PackageReference Include="FastReport.OpenSource" Version="2022.2.2" />
+		<PackageReference Include="FastReport.OpenSource.Export.PdfSimple" Version="2022.2.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/NFe.Danfe.OpenFast/NFe.Danfe.OpenFast.csproj
+++ b/NFe.Danfe.OpenFast/NFe.Danfe.OpenFast.csproj
@@ -6,8 +6,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="FastReport.OpenSource" Version="2019.3.19" />
-		<PackageReference Include="FastReport.OpenSource.Export.PdfSimple" Version="2019.3.19" />
+		<PackageReference Include="FastReport.OpenSource" Version="2022.2.2" />
+		<PackageReference Include="FastReport.OpenSource.Export.PdfSimple" Version="2022.2.2" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Atualização do pacote FastReport de 2019.3.19 para 2022.2.2

Eu usava um outro pacote no meu projeto que usava o fastreport 2022.2.2 e tive de remove-lo do meu projeto.
Após a remoção, estou tendo problema de compatibilidade do CoreCompat.System.Drawing com a System.Drawing.
Isso ocorre devido a versão do fastreport 2019.3.19.

Estou ciente que já existem versões do fastreport mais recentes que a 2022.2.2. Porém eu só testei e posso afirmar com certeza que não vão haver problemas até essa versão, que é a que eu uso no meu projeto atualmente e todos meus clientes emitem nota fiscal sem nenhum problema.

De qualquer forma, em 2022, são 3 anos de atualização a frente da que já estava então acho que é interessante esse update para não ficar acumulando muitas versões desatualizadas.