### PR TITLE
CTeDistribuicaoDFe

### DIFF
--- a/CTe.Servicos/Factory/WsdlFactory.cs
+++ b/CTe.Servicos/Factory/WsdlFactory.cs
@@ -46,109 +46,110 @@ using CTe.CTeOSDocumento.Common;
 using CTe.Wsdl.ConsultaProtocolo.V4;
 using CTe.Wsdl.Evento.V4;
 using CTe.Wsdl.Recepcao.Sincrono;
+using System.Security.Cryptography.X509Certificates;
 
 namespace CTe.Servicos.Factory
 {
     public class WsdlFactory
     {
-        public static CteStatusServico CriaWsdlCteStatusServico(ConfiguracaoServico configuracaoServico = null)
+        public static CteStatusServico CriaWsdlCteStatusServico(ConfiguracaoServico configuracaoServico = null, X509Certificate2 certificado = null)
         {
             var url = UrlHelper.ObterUrlServico(configuracaoServico).CteStatusServico;
 
-            var configuracaoWsdl = CriaConfiguracao(url, configuracaoServico);
+            var configuracaoWsdl = CriaConfiguracao(url, configuracaoServico, certificado);
 
             return new CteStatusServico(configuracaoWsdl);
         }
 
-        public static CteConsulta CriaWsdlConsultaProtocolo(ConfiguracaoServico configuracaoServico = null)
+        public static CteConsulta CriaWsdlConsultaProtocolo(ConfiguracaoServico configuracaoServico = null, X509Certificate2 certificado = null)
         {
             var url = UrlHelper.ObterUrlServico(configuracaoServico).CteConsulta;
 
-            var configuracaoWsdl = CriaConfiguracao(url, configuracaoServico);
+            var configuracaoWsdl = CriaConfiguracao(url, configuracaoServico, certificado);
 
             return new CteConsulta(configuracaoWsdl);
         }
 
-        public static CteConsultaV4 CriaWsdlConsultaProtocoloV4(ConfiguracaoServico configuracaoServico = null)
+        public static CteConsultaV4 CriaWsdlConsultaProtocoloV4(ConfiguracaoServico configuracaoServico = null, X509Certificate2 certificado = null)
         {
             var url = UrlHelper.ObterUrlServico(configuracaoServico).CteConsulta;
 
-            var configuracaoWsdl = CriaConfiguracao(url, configuracaoServico);
+            var configuracaoWsdl = CriaConfiguracao(url, configuracaoServico, certificado);
 
             return new CteConsultaV4(configuracaoWsdl);
         }
 
-        public static CteInutilizacao CriaWsdlCteInutilizacao(ConfiguracaoServico configuracaoServico = null)
+        public static CteInutilizacao CriaWsdlCteInutilizacao(ConfiguracaoServico configuracaoServico = null, X509Certificate2 certificado = null)
         {
             var url = UrlHelper.ObterUrlServico(configuracaoServico).CteInutilizacao;
 
-            var configuracaoWsdl = CriaConfiguracao(url, configuracaoServico);
+            var configuracaoWsdl = CriaConfiguracao(url, configuracaoServico, certificado);
 
             return new CteInutilizacao(configuracaoWsdl);
         }
 
-        public static CteRetRecepcao CriaWsdlCteRetRecepcao(ConfiguracaoServico configuracaoServico = null)
+        public static CteRetRecepcao CriaWsdlCteRetRecepcao(ConfiguracaoServico configuracaoServico = null, X509Certificate2 certificado = null)
         {
             var url = UrlHelper.ObterUrlServico(configuracaoServico).CteRetRecepcao;
 
-            var configuracaoWsdl = CriaConfiguracao(url, configuracaoServico);
+            var configuracaoWsdl = CriaConfiguracao(url, configuracaoServico, certificado);
 
             return new CteRetRecepcao(configuracaoWsdl);
         }
 
-        public static CteRecepcao CriaWsdlCteRecepcao(ConfiguracaoServico configuracaoServico = null)
+        public static CteRecepcao CriaWsdlCteRecepcao(ConfiguracaoServico configuracaoServico = null, X509Certificate2 certificado = null)
         {
             var url = UrlHelper.ObterUrlServico(configuracaoServico).CteRecepcao;
 
-            var configuracaoWsdl = CriaConfiguracao(url, configuracaoServico);
+            var configuracaoWsdl = CriaConfiguracao(url, configuracaoServico, certificado);
 
             return new CteRecepcao(configuracaoWsdl);
         }
 
-        public static CteRecepcaoSincronoV4 CriaWsdlCteRecepcaoSincronoV4(ConfiguracaoServico configuracaoServico = null)
+        public static CteRecepcaoSincronoV4 CriaWsdlCteRecepcaoSincronoV4(ConfiguracaoServico configuracaoServico = null, X509Certificate2 certificado = null)
         {
             var url = UrlHelper.ObterUrlServico(configuracaoServico).CteRecepcaoSinc;
 
-            var configuracaoWsdl = CriaConfiguracao(url, configuracaoServico);
+            var configuracaoWsdl = CriaConfiguracao(url, configuracaoServico, certificado);
 
             return new CteRecepcaoSincronoV4(configuracaoWsdl);
         }
 
-        public static CteRecepcaoEvento CriaWsdlCteEvento(ConfiguracaoServico configuracaoServico = null)
+        public static CteRecepcaoEvento CriaWsdlCteEvento(ConfiguracaoServico configuracaoServico = null, X509Certificate2 certificado = null)
         {
             var url = UrlHelper.ObterUrlServico(configuracaoServico).CteRecepcaoEvento;
 
-            var configuracaoWsdl = CriaConfiguracao(url, configuracaoServico);
+            var configuracaoWsdl = CriaConfiguracao(url, configuracaoServico, certificado);
 
             return new CteRecepcaoEvento(configuracaoWsdl);
         }
 
-        public static CteRecepcaoEventoV4 CriaWsdlCteEventoV4(ConfiguracaoServico configuracaoServico = null)
+        public static CteRecepcaoEventoV4 CriaWsdlCteEventoV4(ConfiguracaoServico configuracaoServico = null, X509Certificate2 certificado = null)
         {
             var url = UrlHelper.ObterUrlServico(configuracaoServico).CteRecepcaoEvento;
 
-            var configuracaoWsdl = CriaConfiguracao(url, configuracaoServico);
+            var configuracaoWsdl = CriaConfiguracao(url, configuracaoServico, certificado);
 
             return new CteRecepcaoEventoV4(configuracaoWsdl);
         }
 
 
-        public static CTeDistDFeInteresse CriaWsdlCTeDistDFeInteresse(ConfiguracaoServico configuracaoServico = null)
+        public static CTeDistDFeInteresse CriaWsdlCTeDistDFeInteresse(ConfiguracaoServico configuracaoServico = null, X509Certificate2 certificado = null)
         {
             var url = UrlHelper.ObterUrlServico(configuracaoServico).CTeDistribuicaoDFe;
 
-            var configuracaoWsdl = CriaConfiguracao(url, configuracaoServico);
+            var configuracaoWsdl = CriaConfiguracao(url, configuracaoServico, certificado);
 
             return new CTeDistDFeInteresse(configuracaoWsdl);
         }
 
 
-        private static WsdlConfiguracao CriaConfiguracao(string url, ConfiguracaoServico configuracaoServico = null)
+        private static WsdlConfiguracao CriaConfiguracao(string url, ConfiguracaoServico configuracaoServico, X509Certificate2 certificado)
         {
             var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
 
             var codigoEstado = configServico.cUF.GetCodigoIbgeEmString();
-            var certificadoDigital = configServico.X509Certificate2;
+            var certificadoDigital = certificado ?? configServico.X509Certificate2;
             var versaoEmString = configServico.VersaoLayout.GetString();
             var timeOut = configServico.TimeOut;
 

--- a/DFe.Utils/StringExtencoes.cs
+++ b/DFe.Utils/StringExtencoes.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.RegularExpressions;
+﻿using System;
+using System.Text.RegularExpressions;
 
 namespace Shared.DFe.Utils
 {
@@ -24,5 +25,19 @@ namespace Shared.DFe.Utils
 
             return valor;
         }
+
+        public static string RemoverDeclaracaoXml(this string xml)
+        {
+            if (string.IsNullOrEmpty(xml))
+                return xml;
+
+            var posIni = xml.IndexOf("<?", StringComparison.Ordinal);
+            if (posIni < 0) 
+                return xml;
+
+            var posFinal = xml.IndexOf("?>", StringComparison.Ordinal);
+            return posFinal < 0 ? xml : xml.Remove(posIni, (posFinal + 2) - posIni);
+        }
+
     }
 }


### PR DESCRIPTION
. Novo construtor na classe ServicoCTeDistribuicaoDFe para permitir enviar as configurações do serviço e certificado, pois em alguns computadores o método de obtercertificado a partir do array de bytes retornava erro de acesso negado. 

. Novo método de extensão para strings que remove a declaração do xml, pois os métodos CTeDistDFeInteresse e CTeDistDFeInteresseAsync verificam o início da string para identificar o tipo de retorno do ws.