### PR TITLE
Criado novo parametro X509KeyStorageFlags no arquivo de configuração.

### DIFF
--- a/DFe.Testes/DFe.Testes.csproj
+++ b/DFe.Testes/DFe.Testes.csproj
@@ -7,10 +7,13 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-		<PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
-		<PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
-		<PackageReference Include="coverlet.collector" Version="3.1.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+		<PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
+		<PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+		<PackageReference Include="coverlet.collector" Version="6.0.0">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/DFe.Utils/CertificadoDigitalUtils.cs
+++ b/DFe.Utils/CertificadoDigitalUtils.cs
@@ -90,7 +90,7 @@ namespace DFe.Utils
         /// <param name="bytes">array de byte do certificado</param>
         /// <param name="password">string representando a senha do certificado</param>
         /// <returns></returns>
-        public static X509Certificate2 ObterDosBytes(byte[] bytes, string password)
+        public static X509Certificate2 ObterDosBytes(byte[] bytes, string password, X509KeyStorageFlags? keyStorageFlags)
         {
             SecureString stringSegura = null;
             try
@@ -104,7 +104,7 @@ namespace DFe.Utils
                     }
                 }
 
-                return ObterDosBytes(bytes, stringSegura);
+                return ObterDosBytes(bytes, stringSegura, keyStorageFlags);
             }
             catch
             {
@@ -118,9 +118,9 @@ namespace DFe.Utils
         /// <param name="bytes">array de byte do certificado</param>
         /// <param name="password">SecureString senha do certificado</param>
         /// <returns></returns>
-        public static X509Certificate2 ObterDosBytes(byte[] bytes, SecureString password)
+        public static X509Certificate2 ObterDosBytes(byte[] bytes, SecureString password, X509KeyStorageFlags? keyStorageFlags)
         {
-            var cert = new X509Certificate2(bytes, password, X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.PersistKeySet | X509KeyStorageFlags.Exportable);
+            var cert = new X509Certificate2(bytes, password, keyStorageFlags ?? (X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.PersistKeySet | X509KeyStorageFlags.Exportable));
             return cert;
         }
 

--- a/DFe.Utils/ConfiguracaoCertificado.cs
+++ b/DFe.Utils/ConfiguracaoCertificado.cs
@@ -33,6 +33,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Security.Cryptography.X509Certificates;
 
 namespace DFe.Utils
 {
@@ -59,9 +60,11 @@ namespace DFe.Utils
         private TipoCertificado _tipoCertificado;
         private string _cacheId;
         private byte[] _arrayBytesArquivo;
+        private X509KeyStorageFlags _keyStorageFlags;
 
         public ConfiguracaoCertificado()
         {
+            KeyStorageFlags = X509KeyStorageFlags.MachineKeySet;
             SignatureMethodSignedXml = "http://www.w3.org/2000/09/xmldsig#rsa-sha1";
             DigestMethodReference = "http://www.w3.org/2000/09/xmldsig#sha1";
         }
@@ -179,5 +182,18 @@ namespace DFe.Utils
         ///     URI para DigestMethod na Classe Reference para auxiliar para a assinatura (Padrao: http://www.w3.org/2000/09/xmldsig#sha1)
         /// </summary>
         public string DigestMethodReference { get; set; }
+
+        /// <summary>
+        ///     
+        /// </summary>
+        public X509KeyStorageFlags KeyStorageFlags
+        {
+            get { return _keyStorageFlags; }
+            set
+            {
+                if (value == _keyStorageFlags) return;
+                _keyStorageFlags = value;
+            }
+        }
     }
 }

--- a/NFe.Danfe.App.Teste.Html/NFe.Danfe.App.Teste.Html.csproj
+++ b/NFe.Danfe.App.Teste.Html/NFe.Danfe.App.Teste.Html.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Zeus.Net.NFe.NFCe" Version="2023.6.7.1227" />
+    <PackageReference Include="Zeus.Net.NFe.NFCe" Version="2024.1.15.1723" />
   </ItemGroup>
 
   <ItemGroup>

--- a/NFe.Danfe.Fast.Skia/NFe.Danfe.Fast.Skia.csproj
+++ b/NFe.Danfe.Fast.Skia/NFe.Danfe.Fast.Skia.csproj
@@ -10,7 +10,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="SkiaSharp" Version="2.88.3" />
+	  <PackageReference Include="SkiaSharp" Version="2.88.7" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/NFe.Danfe.Html/NFe.Danfe.Html.csproj
+++ b/NFe.Danfe.Html/NFe.Danfe.Html.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="NetBarcode" Version="1.7.0" />
-    <PackageReference Include="Zeus.Net.NFe.NFCe" Version="2023.6.7.1227" />
+    <PackageReference Include="Zeus.Net.NFe.NFCe" Version="2024.1.15.1723" />
   </ItemGroup>
 
   <ItemGroup>

--- a/NFe.Utils.Testes/NFe.Utils.Testes.csproj
+++ b/NFe.Utils.Testes/NFe.Utils.Testes.csproj
@@ -7,9 +7,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-		<PackageReference Include="xunit" Version="2.4.1" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+		<PackageReference Include="xunit" Version="2.6.6" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>


### PR DESCRIPTION
Resolve #1306 
Resolve também  #1296 #1271 #1238 

**Foi entendido que pode quebrar códigos antigos e tomado as devidas precauções sobre isso.**

Feito nova configuração **permitindo passar o X509KeyStorageFlags como variavel de configuração** ao gerar instancia de X509Certificate2 usando byte como certificado em memória, o mesmo funciona para certificados em arquivos. O problema resolve se você estiver enfrentando problemas relacionados a permissões de acesso ao carregar certificados, pode ser útil usar X509KeyStorageFlags.EphemeralKeySet que é possível em .net 6 +

- Possibilitando o uso de PDVs em ambientes de alta restrições de acesso.
- Possibilitando uso em AWS Lambda ou Azure Functions usando X509KeyStorageFlags.EphemeralKeySet 
- Possibilitando o uso em IIS com altos níveis de restrições de acesso.