### PR TITLE
Update classes emitTipos e Conversao

### DIFF
--- a/NFe.Classes/Informacoes/Emitente/emitTipos.cs
+++ b/NFe.Classes/Informacoes/Emitente/emitTipos.cs
@@ -39,6 +39,7 @@ namespace NFe.Classes.Informacoes.Emitente
     ///     <para>1 – Simples Nacional;</para>
     ///     <para>2 – Simples Nacional – excesso de sublimite de receita bruta;</para>
     ///     <para>3 – Regime Normal. (v2.0).</para>
+    ///     <para>4 – Simples Nacional MEI;</para>
     /// </summary>
     public enum CRT
     {
@@ -61,6 +62,13 @@ namespace NFe.Classes.Informacoes.Emitente
         /// </summary>
         [Description("Regime Normal")]
         [XmlEnum("3")]
-        RegimeNormal = 3
+        RegimeNormal = 3,
+
+        /// <summary>
+        /// 4 – Simples Nacional MEI
+        /// </summary>
+        [Description("Simples Nacional MEI")]
+        [XmlEnum("4")]
+        SimplesNacionalMei = 4
     }
 }

--- a/NFe.Utils/Conversao.cs
+++ b/NFe.Utils/Conversao.cs
@@ -145,6 +145,8 @@ namespace NFe.Utils
                     return "Simples Nacional - sublimite excedido";
                 case CRT.RegimeNormal:
                     return "Normal";
+                case CRT.SimplesNacionalMei:
+                    return "Simples Nacional MEI";
                 default:
                     throw new ArgumentOutOfRangeException("crt", crt, null);
             }


### PR DESCRIPTION
Foi adicionado um novo  enum CRT chamado Simples Nacional MEI com a numeração "4" no caminho NFe.Classes\Informacoes\Emitente\emitTipos.cs.

Foi atualizado o método CrtParaString localizado no caminho NFe.Utils\Conversao.cs com o Case CRT.SimplesNacionalMei.

