### PR TITLE
Ajustada biblioteca DFe para o ICMS Basico aceitar o ICMS da CST 61 no Simples Nacional

### DIFF
--- a/DFe.Testes/Impostos/DadosDeTeste/ICMSGeralDadosDeTeste.cs
+++ b/DFe.Testes/Impostos/DadosDeTeste/ICMSGeralDadosDeTeste.cs
@@ -2,11 +2,11 @@
 using NFe.Classes.Informacoes.Emitente;
 using System.Collections.Generic;
 
-namespace DFe.Testes.Impostos.TestData
+namespace DFe.Testes.Impostos.DadosDeTeste
 {
-    public class ICMSGeralTestData
+    public class ICMSGeralDadosDeTeste
     {
-        public static IEnumerable<object[]> ObterRegimesTributariosComOrigemECamposParaCst61()
+        public static IEnumerable<object[]> ObterRegimesTributariosParaCst61()
         {
             yield return new object[] { CRT.RegimeNormal, OrigemMercadoria.OmNacional, 1000, 18, 180 };
             yield return new object[] { CRT.RegimeNormal, OrigemMercadoria.OmEstrangeiraImportacaoDireta, 1001, 180, 18 };

--- a/DFe.Testes/Impostos/ICMSGeral_Teste.cs
+++ b/DFe.Testes/Impostos/ICMSGeral_Teste.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual;
 using NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual.Tipos;
@@ -113,6 +114,44 @@ namespace DFe.Testes.Impostos
             Assert.AreEqual(Convert.ToDecimal(vFCPST), tagICMSGerada.vFCPST);
         }
 
+        [TestMethod]
+        [DataTestMethod]
+        [DataRow(CRT.RegimeNormal, OrigemMercadoria.OmNacional, 1000, 18, 180)]
+        [DataRow(CRT.RegimeNormal, OrigemMercadoria.OmEstrangeiraImportacaoDireta, 1001, 180, 18)]
+        [DataRow(CRT.RegimeNormal, OrigemMercadoria.OmEstrangeiraAdquiridaBrasil, 1000, 180, 10)]
+        [DataRow(CRT.RegimeNormal, OrigemMercadoria.OmNacionalConteudoImportacaoSuperior40, 1200, 18, 180)]
+        [DataRow(CRT.RegimeNormal, OrigemMercadoria.OmNacionalProcessosBasicos, 1100, 18, 180)]
+        [DataRow(CRT.RegimeNormal, OrigemMercadoria.OmNacionalConteudoImportacaoInferiorIgual40, 1010, 12, 10)]
+        [DataRow(CRT.RegimeNormal, OrigemMercadoria.OmEstrangeiraImportacaoDiretaSemSimilar, 101, 17, 11)]
+        [DataRow(CRT.RegimeNormal, OrigemMercadoria.OmEstrangeiraAdquiridaBrasilSemSimilar, 105, 19, 15)]
+        [DataRow(CRT.RegimeNormal, OrigemMercadoria.OmNacionalConteudoImportacaoSuperior70, 103, 18, 15)]
+        public void ObterICMSBasico_ICMS61_Teste(CRT crt, OrigemMercadoria origem, object vICMSMonoRet, object adRemICMSRet, object qBCMonoRet)
+        {
+            /** 1) Preparação **/
+            var icmsGeral = new ICMSGeral()
+            {
+                orig = origem,
+                CST = Csticms.Cst61,
+                vICMSMonoRet = Convert.ToDecimal(vICMSMonoRet),
+                adRemICMSRet = Convert.ToDecimal(adRemICMSRet),
+                qBCMonoRet = Convert.ToDecimal(qBCMonoRet)
+            };
+
+            /** 2) Execução **/
+            var tagGerada = icmsGeral.ObterICMSBasico(crt);
+
+            /** 2) Veerificação **/
+            /** 2.1) Garante que o tipo da classe gerada foi correta**/
+            Assert.IsInstanceOfType(tagGerada, typeof(ICMS61));
+
+            /** 2.2) Garante que o conteúdo repassado para as propriedades estejam corretos **/
+            var tagICMSGerada = (tagGerada as ICMS61);
+            Assert.AreEqual(origem, tagICMSGerada.orig);
+            Assert.AreEqual(Csticms.Cst61, tagICMSGerada.CST);
+            Assert.AreEqual(Convert.ToDecimal(vICMSMonoRet), tagICMSGerada.vICMSMonoRet);
+            Assert.AreEqual(Convert.ToDecimal(adRemICMSRet), tagICMSGerada.adRemICMSRet);
+            Assert.AreEqual(Convert.ToDecimal(qBCMonoRet), tagICMSGerada.qBCMonoRet);
+        }
         //TODO: Falta criar os métodos de testes dos demais CSTs do ICMS (CTR = Normal)
 
         #endregion
@@ -147,9 +186,113 @@ namespace DFe.Testes.Impostos
             Assert.AreEqual(Convert.ToDecimal(pCredSN), tagICMSGerada.pCredSN);
             Assert.AreEqual(Convert.ToDecimal(vCredICMSSN), tagICMSGerada.vCredICMSSN);
         }
-        
         //TODO: Falta criar os métodos de testes dos demais CSOSNs do ICMS (CTR = Simples)
 
+        #endregion
+
+        #region CRT - Simples Nacional com CST 61
+
+        [TestMethod]
+        [DataTestMethod]
+        [DataRow(CRT.SimplesNacional, OrigemMercadoria.OmEstrangeiraAdquiridaBrasil, 100, 18, 5)]
+        [DataRow(CRT.SimplesNacional, OrigemMercadoria.OmEstrangeiraAdquiridaBrasilSemSimilar, 5, 100, 18)]
+        [DataRow(CRT.SimplesNacional, OrigemMercadoria.OmNacionalConteudoImportacaoInferiorIgual40, 18, 5, 100)]
+        [DisplayName ("Dado Simples Nacional com CST 61 deve obter ICMSBasico com ICMS61")]
+        public void DadoSimplesNacionalComCst61DeveObterIcmsBasicoComIcms61(CRT crt, OrigemMercadoria origem, object vICMSMonoRet, object adRemICMSRet, object qBCMonoRet)
+        {
+            /** 1) Preparação **/
+            var icmsGeral = new ICMSGeral()
+            {
+                orig = origem,
+                CST = Csticms.Cst61,
+                vICMSMonoRet = Convert.ToDecimal(vICMSMonoRet),
+                adRemICMSRet = Convert.ToDecimal(adRemICMSRet),
+                qBCMonoRet = Convert.ToDecimal(qBCMonoRet)
+            };
+
+            /** 2) Execução **/
+            var tagGerada = icmsGeral.ObterICMSBasico(crt);
+
+            /** 2) Verificação **/
+            /** 2.1) Garante que o tipo da classe gerada foi correta**/
+            Assert.IsInstanceOfType(tagGerada, typeof(ICMS61));
+
+            /** 2.2) Garante que o conteúdo repassado para as propriedades estejam corretos **/
+            var tagICMSGerada = (tagGerada as ICMS61);
+            Assert.AreEqual(origem, tagICMSGerada.orig);
+            Assert.AreEqual(Csticms.Cst61, tagICMSGerada.CST);
+            Assert.AreEqual(Convert.ToDecimal(vICMSMonoRet), tagICMSGerada.vICMSMonoRet);
+            Assert.AreEqual(Convert.ToDecimal(adRemICMSRet), tagICMSGerada.adRemICMSRet);
+            Assert.AreEqual(Convert.ToDecimal(qBCMonoRet), tagICMSGerada.qBCMonoRet);
+        }
+
+        [TestMethod]
+        [DataTestMethod]
+        [DataRow(CRT.SimplesNacional, OrigemMercadoria.OmNacional, 100, 18, 5)]
+        [DisplayName("Não deve preencher campos que não sejam da CST 61 quando dado Simples Nacional com CST 61")]
+        public void NaoDevePreencherCamposQueNaoSejamDaCst61QuandoDadoSimplesNacionalComCst61(CRT crt, OrigemMercadoria origem, object vICMSMonoRet, object adRemICMSRet, object qBCMonoRet)
+        {
+            /** 1) Preparação **/
+            var icmsGeral = new ICMSGeral()
+            {
+                orig = origem,
+                CST = Csticms.Cst61,
+                vICMSMonoRet = Convert.ToDecimal(vICMSMonoRet),
+                adRemICMSRet = Convert.ToDecimal(adRemICMSRet),
+                qBCMonoRet = Convert.ToDecimal(qBCMonoRet)
+            };
+
+            /** 2) Execução **/
+            icmsGeral.ObterICMSBasico(crt);
+
+            /** 2) Verificação **/
+            Assert.IsTrue(icmsGeral.pCredSN == 0);
+            Assert.IsTrue(icmsGeral.vCredICMSSN == 0);
+            Assert.IsTrue(icmsGeral.vBC == 0);
+            Assert.IsTrue(icmsGeral.pICMS == 0);
+            Assert.IsTrue(icmsGeral.vICMS == 0);
+            Assert.IsNull(icmsGeral.pFCP);
+            Assert.IsNull(icmsGeral.vFCP);
+            Assert.IsNull(icmsGeral.vBCFCP);
+        }
+
+        [TestMethod]
+        [DataTestMethod]
+        [DataRow(CRT.SimplesNacional)]
+        [DisplayName("Não deve gerar outro tipo de ICMS que não seja ICMS 61 quando dado Simples Nacional com CST 61")]
+        public void NaoDeveGerarOutroTipoDeIcmsQueNaoSejaIcms61QuandoDadoSimplesNacionalComCst61(CRT crt)
+        {
+            /** 1) Preparação **/
+            var icmsGeral = new ICMSGeral()
+            {
+                CST = Csticms.Cst61
+            };
+
+            /** 2) Execução **/
+            var tagGerada = icmsGeral.ObterICMSBasico(crt);
+
+            /** 2) Verificação **/
+            Assert.IsNotInstanceOfType(tagGerada, typeof(ICMS00));
+            Assert.IsNotInstanceOfType(tagGerada, typeof(ICMS02));
+            Assert.IsNotInstanceOfType(tagGerada, typeof(ICMS10));
+            Assert.IsNotInstanceOfType(tagGerada, typeof(ICMS15));
+            Assert.IsNotInstanceOfType(tagGerada, typeof(ICMS20));
+            Assert.IsNotInstanceOfType(tagGerada, typeof(ICMS30));
+            Assert.IsNotInstanceOfType(tagGerada, typeof(ICMS40));
+            Assert.IsNotInstanceOfType(tagGerada, typeof(ICMS51));
+            Assert.IsNotInstanceOfType(tagGerada, typeof(ICMS53));
+            Assert.IsNotInstanceOfType(tagGerada, typeof(ICMS51));
+            Assert.IsNotInstanceOfType(tagGerada, typeof(ICMS60));
+            Assert.IsNotInstanceOfType(tagGerada, typeof(ICMS70));
+            Assert.IsNotInstanceOfType(tagGerada, typeof(ICMS90));
+
+            Assert.IsNotInstanceOfType(tagGerada, typeof(ICMSSN101));
+            Assert.IsNotInstanceOfType(tagGerada, typeof(ICMSSN102));
+            Assert.IsNotInstanceOfType(tagGerada, typeof(ICMSSN201));
+            Assert.IsNotInstanceOfType(tagGerada, typeof(ICMSSN202));
+            Assert.IsNotInstanceOfType(tagGerada, typeof(ICMSSN500));
+            Assert.IsNotInstanceOfType(tagGerada, typeof(ICMSSN900));
+        }
         #endregion
     }
 }

--- a/DFe.Testes/Impostos/ICMSGeral_Teste.cs
+++ b/DFe.Testes/Impostos/ICMSGeral_Teste.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using DFe.Testes.Impostos.TestData;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual;
 using NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual.Tipos;
@@ -114,44 +115,6 @@ namespace DFe.Testes.Impostos
             Assert.AreEqual(Convert.ToDecimal(vFCPST), tagICMSGerada.vFCPST);
         }
 
-        [TestMethod]
-        [DataTestMethod]
-        [DataRow(CRT.RegimeNormal, OrigemMercadoria.OmNacional, 1000, 18, 180)]
-        [DataRow(CRT.RegimeNormal, OrigemMercadoria.OmEstrangeiraImportacaoDireta, 1001, 180, 18)]
-        [DataRow(CRT.RegimeNormal, OrigemMercadoria.OmEstrangeiraAdquiridaBrasil, 1000, 180, 10)]
-        [DataRow(CRT.RegimeNormal, OrigemMercadoria.OmNacionalConteudoImportacaoSuperior40, 1200, 18, 180)]
-        [DataRow(CRT.RegimeNormal, OrigemMercadoria.OmNacionalProcessosBasicos, 1100, 18, 180)]
-        [DataRow(CRT.RegimeNormal, OrigemMercadoria.OmNacionalConteudoImportacaoInferiorIgual40, 1010, 12, 10)]
-        [DataRow(CRT.RegimeNormal, OrigemMercadoria.OmEstrangeiraImportacaoDiretaSemSimilar, 101, 17, 11)]
-        [DataRow(CRT.RegimeNormal, OrigemMercadoria.OmEstrangeiraAdquiridaBrasilSemSimilar, 105, 19, 15)]
-        [DataRow(CRT.RegimeNormal, OrigemMercadoria.OmNacionalConteudoImportacaoSuperior70, 103, 18, 15)]
-        public void ObterICMSBasico_ICMS61_Teste(CRT crt, OrigemMercadoria origem, object vICMSMonoRet, object adRemICMSRet, object qBCMonoRet)
-        {
-            /** 1) Preparação **/
-            var icmsGeral = new ICMSGeral()
-            {
-                orig = origem,
-                CST = Csticms.Cst61,
-                vICMSMonoRet = Convert.ToDecimal(vICMSMonoRet),
-                adRemICMSRet = Convert.ToDecimal(adRemICMSRet),
-                qBCMonoRet = Convert.ToDecimal(qBCMonoRet)
-            };
-
-            /** 2) Execução **/
-            var tagGerada = icmsGeral.ObterICMSBasico(crt);
-
-            /** 2) Veerificação **/
-            /** 2.1) Garante que o tipo da classe gerada foi correta**/
-            Assert.IsInstanceOfType(tagGerada, typeof(ICMS61));
-
-            /** 2.2) Garante que o conteúdo repassado para as propriedades estejam corretos **/
-            var tagICMSGerada = (tagGerada as ICMS61);
-            Assert.AreEqual(origem, tagICMSGerada.orig);
-            Assert.AreEqual(Csticms.Cst61, tagICMSGerada.CST);
-            Assert.AreEqual(Convert.ToDecimal(vICMSMonoRet), tagICMSGerada.vICMSMonoRet);
-            Assert.AreEqual(Convert.ToDecimal(adRemICMSRet), tagICMSGerada.adRemICMSRet);
-            Assert.AreEqual(Convert.ToDecimal(qBCMonoRet), tagICMSGerada.qBCMonoRet);
-        }
         //TODO: Falta criar os métodos de testes dos demais CSTs do ICMS (CTR = Normal)
 
         #endregion
@@ -186,19 +149,17 @@ namespace DFe.Testes.Impostos
             Assert.AreEqual(Convert.ToDecimal(pCredSN), tagICMSGerada.pCredSN);
             Assert.AreEqual(Convert.ToDecimal(vCredICMSSN), tagICMSGerada.vCredICMSSN);
         }
+
         //TODO: Falta criar os métodos de testes dos demais CSOSNs do ICMS (CTR = Simples)
 
         #endregion
 
-        #region CRT - Simples Nacional com CST 61
+        #region CST 61 - Tributação Monofásica Sobre os Combustíveis
 
         [TestMethod]
-        [DataTestMethod]
-        [DataRow(CRT.SimplesNacional, OrigemMercadoria.OmEstrangeiraAdquiridaBrasil, 100, 18, 5)]
-        [DataRow(CRT.SimplesNacional, OrigemMercadoria.OmEstrangeiraAdquiridaBrasilSemSimilar, 5, 100, 18)]
-        [DataRow(CRT.SimplesNacional, OrigemMercadoria.OmNacionalConteudoImportacaoInferiorIgual40, 18, 5, 100)]
-        [DisplayName ("Dado Simples Nacional com CST 61 deve obter ICMSBasico com ICMS61")]
-        public void DadoSimplesNacionalComCst61DeveObterIcmsBasicoComIcms61(CRT crt, OrigemMercadoria origem, object vICMSMonoRet, object adRemICMSRet, object qBCMonoRet)
+        [DynamicData(nameof(ICMSGeralTestData.ObterRegimesTributariosComOrigemECamposParaCst61), typeof(ICMSGeralTestData), DynamicDataSourceType.Method)]
+        [DisplayName("Dado CST 61 quando obter ICMS então ICMS deve conter campos de tributação monofásica sobre combustíveis preenchidos")]
+        public void DadoCST61QuandoObterICMSEntaoICMSDeveConterCamposDeTributacaoMonofasicaSobreCombustiveisPreenchidos(CRT crt, OrigemMercadoria origem, object vICMSMonoRet, object adRemICMSRet, object qBCMonoRet)
         {
             /** 1) Preparação **/
             var icmsGeral = new ICMSGeral()
@@ -213,7 +174,7 @@ namespace DFe.Testes.Impostos
             /** 2) Execução **/
             var tagGerada = icmsGeral.ObterICMSBasico(crt);
 
-            /** 2) Verificação **/
+            /** 2) Veerificação **/
             /** 2.1) Garante que o tipo da classe gerada foi correta**/
             Assert.IsInstanceOfType(tagGerada, typeof(ICMS61));
 
@@ -227,10 +188,9 @@ namespace DFe.Testes.Impostos
         }
 
         [TestMethod]
-        [DataTestMethod]
-        [DataRow(CRT.SimplesNacional, OrigemMercadoria.OmNacional, 100, 18, 5)]
-        [DisplayName("Não deve preencher campos que não sejam da CST 61 quando dado Simples Nacional com CST 61")]
-        public void NaoDevePreencherCamposQueNaoSejamDaCst61QuandoDadoSimplesNacionalComCst61(CRT crt, OrigemMercadoria origem, object vICMSMonoRet, object adRemICMSRet, object qBCMonoRet)
+        [DynamicData(nameof(ICMSGeralTestData.ObterRegimesTributariosComOrigemECamposParaCst61), typeof(ICMSGeralTestData), DynamicDataSourceType.Method)]
+        [DisplayName("Não deve preencher campos que não sejam da tributação monofásica sobre combustíves quando dado CST 61")]
+        public void NaoDevePreencherCamposQueNaoSejamDaTributacaoMonofasicaSobreCombustiveisQuandoDadoCst61(CRT crt, OrigemMercadoria origem, object vICMSMonoRet, object adRemICMSRet, object qBCMonoRet)
         {
             /** 1) Preparação **/
             var icmsGeral = new ICMSGeral()
@@ -246,21 +206,25 @@ namespace DFe.Testes.Impostos
             icmsGeral.ObterICMSBasico(crt);
 
             /** 2) Verificação **/
-            Assert.IsTrue(icmsGeral.pCredSN == 0);
-            Assert.IsTrue(icmsGeral.vCredICMSSN == 0);
-            Assert.IsTrue(icmsGeral.vBC == 0);
-            Assert.IsTrue(icmsGeral.pICMS == 0);
-            Assert.IsTrue(icmsGeral.vICMS == 0);
-            Assert.IsNull(icmsGeral.pFCP);
-            Assert.IsNull(icmsGeral.vFCP);
-            Assert.IsNull(icmsGeral.vBCFCP);
+            VerificarSeNaoFoiPreenchidaOutroCampoQueNaoSejaCamposDaCst61(icmsGeral);
+        }
+
+        private void VerificarSeNaoFoiPreenchidaOutroCampoQueNaoSejaCamposDaCst61(ICMSGeral icmsGeral)
+        {
+            Assert.AreEqual(icmsGeral.pCredSN, 0);
+            Assert.AreEqual(icmsGeral.vCredICMSSN, 0);
+            Assert.AreEqual(icmsGeral.vBC, 0);
+            Assert.AreEqual(icmsGeral.pICMS, 0);
+            Assert.AreEqual(icmsGeral.vICMS, 0);
+            Assert.AreEqual(icmsGeral.pFCP, null);
+            Assert.AreEqual(icmsGeral.vFCP, null);
+            Assert.AreEqual(icmsGeral.vBCFCP, null);
         }
 
         [TestMethod]
-        [DataTestMethod]
-        [DataRow(CRT.SimplesNacional)]
-        [DisplayName("Não deve gerar outro tipo de ICMS que não seja ICMS 61 quando dado Simples Nacional com CST 61")]
-        public void NaoDeveGerarOutroTipoDeIcmsQueNaoSejaIcms61QuandoDadoSimplesNacionalComCst61(CRT crt)
+        [DynamicData(nameof(ICMSGeralTestData.ObterRegimesTributarios), typeof(ICMSGeralTestData), DynamicDataSourceType.Method)]
+        [DisplayName("Dado CST 61 quando gerar ICMS então ICMS deve ser do tipo ICMS 61 e nenhum outro")]
+        public void DadoCST61QuandoGerarICMSEntaoICMSDeveSerDoTipoICMS61ENenhumOutro(CRT crt)
         {
             /** 1) Preparação **/
             var icmsGeral = new ICMSGeral()
@@ -272,6 +236,11 @@ namespace DFe.Testes.Impostos
             var tagGerada = icmsGeral.ObterICMSBasico(crt);
 
             /** 2) Verificação **/
+            VerificarSeNaoFoiGeradaOutroTipoDeIcmsQueNaoSejaOIcms61(tagGerada);
+        }
+
+        private void VerificarSeNaoFoiGeradaOutroTipoDeIcmsQueNaoSejaOIcms61(ICMSBasico tagGerada)
+        {
             Assert.IsNotInstanceOfType(tagGerada, typeof(ICMS00));
             Assert.IsNotInstanceOfType(tagGerada, typeof(ICMS02));
             Assert.IsNotInstanceOfType(tagGerada, typeof(ICMS10));

--- a/DFe.Testes/Impostos/ICMSGeral_Teste.cs
+++ b/DFe.Testes/Impostos/ICMSGeral_Teste.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
-using DFe.Testes.Impostos.TestData;
+using DFe.Testes.Impostos.DadosDeTeste;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual;
 using NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual.Tipos;
@@ -157,7 +157,7 @@ namespace DFe.Testes.Impostos
         #region CST 61 - Tributação Monofásica Sobre os Combustíveis
 
         [TestMethod]
-        [DynamicData(nameof(ICMSGeralTestData.ObterRegimesTributariosComOrigemECamposParaCst61), typeof(ICMSGeralTestData), DynamicDataSourceType.Method)]
+        [DynamicData(nameof(ICMSGeralDadosDeTeste.ObterRegimesTributariosParaCst61), typeof(ICMSGeralDadosDeTeste), DynamicDataSourceType.Method)]
         [DisplayName("Dado CST 61 quando obter ICMS então ICMS deve conter campos de tributação monofásica sobre combustíveis preenchidos")]
         public void DadoCST61QuandoObterICMSEntaoICMSDeveConterCamposDeTributacaoMonofasicaSobreCombustiveisPreenchidos(CRT crt, OrigemMercadoria origem, object vICMSMonoRet, object adRemICMSRet, object qBCMonoRet)
         {
@@ -188,9 +188,9 @@ namespace DFe.Testes.Impostos
         }
 
         [TestMethod]
-        [DynamicData(nameof(ICMSGeralTestData.ObterRegimesTributariosComOrigemECamposParaCst61), typeof(ICMSGeralTestData), DynamicDataSourceType.Method)]
-        [DisplayName("Não deve preencher campos que não sejam da tributação monofásica sobre combustíves quando dado CST 61")]
-        public void NaoDevePreencherCamposQueNaoSejamDaTributacaoMonofasicaSobreCombustiveisQuandoDadoCst61(CRT crt, OrigemMercadoria origem, object vICMSMonoRet, object adRemICMSRet, object qBCMonoRet)
+        [DynamicData(nameof(ICMSGeralDadosDeTeste.ObterRegimesTributariosParaCst61), typeof(ICMSGeralDadosDeTeste), DynamicDataSourceType.Method)]
+        [DisplayName("Dado CST 61 quando obter ICMS então ICMS não deve ter campos que não sejam da tributação monofásica sobre combustíveis preenchidos")]
+        public void DadoCST61QuandoObterIcmsEntaoIcmsNaoDeveTerCamposQueNaoSejamDaTributacaoMonofasicaSobreCombustiveisPreenchidos(CRT crt, OrigemMercadoria origem, object vICMSMonoRet, object adRemICMSRet, object qBCMonoRet)
         {
             /** 1) Preparação **/
             var icmsGeral = new ICMSGeral()
@@ -216,13 +216,13 @@ namespace DFe.Testes.Impostos
             Assert.AreEqual(icmsGeral.vBC, 0);
             Assert.AreEqual(icmsGeral.pICMS, 0);
             Assert.AreEqual(icmsGeral.vICMS, 0);
-            Assert.AreEqual(icmsGeral.pFCP, null);
-            Assert.AreEqual(icmsGeral.vFCP, null);
-            Assert.AreEqual(icmsGeral.vBCFCP, null);
+            Assert.IsNull(icmsGeral.pFCP);
+            Assert.IsNull(icmsGeral.vFCP);
+            Assert.IsNull(icmsGeral.vBCFCP);
         }
 
         [TestMethod]
-        [DynamicData(nameof(ICMSGeralTestData.ObterRegimesTributarios), typeof(ICMSGeralTestData), DynamicDataSourceType.Method)]
+        [DynamicData(nameof(ICMSGeralDadosDeTeste.ObterRegimesTributarios), typeof(ICMSGeralDadosDeTeste), DynamicDataSourceType.Method)]
         [DisplayName("Dado CST 61 quando gerar ICMS então ICMS deve ser do tipo ICMS 61 e nenhum outro")]
         public void DadoCST61QuandoGerarICMSEntaoICMSDeveSerDoTipoICMS61ENenhumOutro(CRT crt)
         {
@@ -236,11 +236,13 @@ namespace DFe.Testes.Impostos
             var tagGerada = icmsGeral.ObterICMSBasico(crt);
 
             /** 2) Verificação **/
-            VerificarSeNaoFoiGeradaOutroTipoDeIcmsQueNaoSejaOIcms61(tagGerada);
+            VerificarSeFoiGeradoIcms61(tagGerada);
         }
 
-        private void VerificarSeNaoFoiGeradaOutroTipoDeIcmsQueNaoSejaOIcms61(ICMSBasico tagGerada)
+        private void VerificarSeFoiGeradoIcms61(ICMSBasico tagGerada)
         {
+            Assert.IsInstanceOfType(tagGerada, typeof(ICMS61));
+
             Assert.IsNotInstanceOfType(tagGerada, typeof(ICMS00));
             Assert.IsNotInstanceOfType(tagGerada, typeof(ICMS02));
             Assert.IsNotInstanceOfType(tagGerada, typeof(ICMS10));

--- a/DFe.Testes/Impostos/TestData/ICMSGeralTestData.cs
+++ b/DFe.Testes/Impostos/TestData/ICMSGeralTestData.cs
@@ -1,0 +1,49 @@
+﻿using NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual.Tipos;
+using NFe.Classes.Informacoes.Emitente;
+using System.Collections.Generic;
+
+namespace DFe.Testes.Impostos.TestData
+{
+    public class ICMSGeralTestData
+    {
+        public static IEnumerable<object[]> ObterRegimesTributariosComOrigemECamposParaCst61()
+        {
+            yield return new object[] { CRT.RegimeNormal, OrigemMercadoria.OmNacional, 1000, 18, 180 };
+            yield return new object[] { CRT.RegimeNormal, OrigemMercadoria.OmEstrangeiraImportacaoDireta, 1001, 180, 18 };
+            yield return new object[] { CRT.RegimeNormal, OrigemMercadoria.OmEstrangeiraAdquiridaBrasil, 1000, 180, 10 };
+            yield return new object[] { CRT.RegimeNormal, OrigemMercadoria.OmNacionalConteudoImportacaoSuperior40, 1200, 18, 180 };
+            yield return new object[] { CRT.RegimeNormal, OrigemMercadoria.OmNacionalProcessosBasicos, 1100, 18, 180 };
+            yield return new object[] { CRT.RegimeNormal, OrigemMercadoria.OmNacionalConteudoImportacaoInferiorIgual40, 1010, 12, 10 };
+            yield return new object[] { CRT.RegimeNormal, OrigemMercadoria.OmEstrangeiraImportacaoDiretaSemSimilar, 101, 17, 11 };
+            yield return new object[] { CRT.RegimeNormal, OrigemMercadoria.OmEstrangeiraAdquiridaBrasilSemSimilar, 105, 19, 15 };
+            yield return new object[] { CRT.RegimeNormal, OrigemMercadoria.OmNacionalConteudoImportacaoSuperior70, 103, 18, 15 };
+
+            yield return new object[] { CRT.SimplesNacional, OrigemMercadoria.OmNacional, 1000, 18, 180 };
+            yield return new object[] { CRT.SimplesNacional, OrigemMercadoria.OmEstrangeiraImportacaoDireta, 1001, 180, 18 };
+            yield return new object[] { CRT.SimplesNacional, OrigemMercadoria.OmEstrangeiraAdquiridaBrasil, 1000, 180, 10 };
+            yield return new object[] { CRT.SimplesNacional, OrigemMercadoria.OmNacionalConteudoImportacaoSuperior40, 1200, 18, 180 };
+            yield return new object[] { CRT.SimplesNacional, OrigemMercadoria.OmNacionalProcessosBasicos, 1100, 18, 180 };
+            yield return new object[] { CRT.SimplesNacional, OrigemMercadoria.OmNacionalConteudoImportacaoInferiorIgual40, 1010, 12, 10 };
+            yield return new object[] { CRT.SimplesNacional, OrigemMercadoria.OmEstrangeiraImportacaoDiretaSemSimilar, 101, 17, 11 };
+            yield return new object[] { CRT.SimplesNacional, OrigemMercadoria.OmEstrangeiraAdquiridaBrasilSemSimilar, 105, 19, 15 };
+            yield return new object[] { CRT.SimplesNacional, OrigemMercadoria.OmNacionalConteudoImportacaoSuperior70, 103, 18, 15 };
+
+            yield return new object[] { CRT.SimplesNacionalExcessoSublimite, OrigemMercadoria.OmNacional, 1000, 18, 180 };
+            yield return new object[] { CRT.SimplesNacionalExcessoSublimite, OrigemMercadoria.OmEstrangeiraImportacaoDireta, 1001, 180, 18 };
+            yield return new object[] { CRT.SimplesNacionalExcessoSublimite, OrigemMercadoria.OmEstrangeiraAdquiridaBrasil, 1000, 180, 10 };
+            yield return new object[] { CRT.SimplesNacionalExcessoSublimite, OrigemMercadoria.OmNacionalConteudoImportacaoSuperior40, 1200, 18, 180 };
+            yield return new object[] { CRT.SimplesNacionalExcessoSublimite, OrigemMercadoria.OmNacionalProcessosBasicos, 1100, 18, 180 };
+            yield return new object[] { CRT.SimplesNacionalExcessoSublimite, OrigemMercadoria.OmNacionalConteudoImportacaoInferiorIgual40, 1010, 12, 10 };
+            yield return new object[] { CRT.SimplesNacionalExcessoSublimite, OrigemMercadoria.OmEstrangeiraImportacaoDiretaSemSimilar, 101, 17, 11 };
+            yield return new object[] { CRT.SimplesNacionalExcessoSublimite, OrigemMercadoria.OmEstrangeiraAdquiridaBrasilSemSimilar, 105, 19, 15 };
+            yield return new object[] { CRT.SimplesNacionalExcessoSublimite, OrigemMercadoria.OmNacionalConteudoImportacaoSuperior70, 103, 18, 15 };
+        }
+
+        public static IEnumerable<object[]> ObterRegimesTributarios()
+        {
+            yield return new object[] { CRT.SimplesNacional };
+            yield return new object[] { CRT.SimplesNacionalExcessoSublimite };
+            yield return new object[] { CRT.RegimeNormal };
+        }
+    }
+}

--- a/NFe.Utils/Tributacao/Estadual/ICMSGeral.cs
+++ b/NFe.Utils/Tributacao/Estadual/ICMSGeral.cs
@@ -385,5 +385,19 @@ namespace NFe.Utils.Tributacao.Estadual
         public decimal? vICMSEfet { get; set; }
         #endregion
 
+        /// <summary>
+        ///     Quantidade tributada retida anteriormente
+        /// </summary>
+        public decimal? qBCMonoRet { get; set; }
+
+        /// <summary>
+        ///     Alíquota ad rem do imposto retido anteriormente
+        /// </summary>
+        public decimal? adRemICMSRet { get; set; }
+
+        /// <summary>
+        ///     Valor do ICMS retido anteriormente
+        /// </summary>
+        public decimal? vICMSMonoRet { get; set; }
     }
 }

--- a/NFe.Utils/Tributacao/Estadual/ICMSGeral.cs
+++ b/NFe.Utils/Tributacao/Estadual/ICMSGeral.cs
@@ -66,37 +66,49 @@ namespace NFe.Utils.Tributacao.Estadual
         /// <returns></returns>
         public ICMSBasico ObterICMSBasico(CRT crt)
         {
-            ICMSBasico icmsBasico;
+            ICMSBasico icmsBasico = null;
 
             switch (crt)
             {
                 case CRT.SimplesNacional:
-                    switch (CSOSN)
+                    switch (CST)
                     {
-                        case Csosnicms.Csosn101:
-                            icmsBasico = new ICMSSN101();
+                        case Csticms.Cst61:
+                            icmsBasico = new ICMS61();
                             break;
-                        case Csosnicms.Csosn102:
-                        case Csosnicms.Csosn103:
-                        case Csosnicms.Csosn300:
-                        case Csosnicms.Csosn400:
-                            icmsBasico = new ICMSSN102();
-                            break;
-                        case Csosnicms.Csosn201:
-                            icmsBasico = new ICMSSN201();
-                            break;
-                        case Csosnicms.Csosn202:
-                        case Csosnicms.Csosn203:
-                            icmsBasico = new ICMSSN202();
-                            break;
-                        case Csosnicms.Csosn500:
-                            icmsBasico = new ICMSSN500();
-                            break;
-                        case Csosnicms.Csosn900:
-                            icmsBasico = new ICMSSN900();
-                            break;
-                        default:
-                            throw new ArgumentOutOfRangeException();
+                    }
+
+                    var ehCst61 = icmsBasico != null;
+
+                    if (!ehCst61)
+                    {
+                        switch (CSOSN)
+                        {
+                            case Csosnicms.Csosn101:
+                                icmsBasico = new ICMSSN101();
+                                break;
+                            case Csosnicms.Csosn102:
+                            case Csosnicms.Csosn103:
+                            case Csosnicms.Csosn300:
+                            case Csosnicms.Csosn400:
+                                icmsBasico = new ICMSSN102();
+                                break;
+                            case Csosnicms.Csosn201:
+                                icmsBasico = new ICMSSN201();
+                                break;
+                            case Csosnicms.Csosn202:
+                            case Csosnicms.Csosn203:
+                                icmsBasico = new ICMSSN202();
+                                break;
+                            case Csosnicms.Csosn500:
+                                icmsBasico = new ICMSSN500();
+                                break;
+                            case Csosnicms.Csosn900:
+                                icmsBasico = new ICMSSN900();
+                                break;
+                            default:
+                                throw new ArgumentOutOfRangeException();
+                        }
                     }
                     break;
                 case CRT.SimplesNacionalExcessoSublimite:


### PR DESCRIPTION
- Adicionado campos da CST 61 no ICMS Geral
- Implementado geração da CST 61 para Simples Nacional no ICMSGeral
- Criado testes unitários