### PR TITLE
fix: Removida declaração de simpleType TCOrgaoIBGE de alguns arquivos schemas

### DIFF
--- a/NFe.AppTeste/Schemas/eventoEPEC_v0.01.xsd
+++ b/NFe.AppTeste/Schemas/eventoEPEC_v0.01.xsd
@@ -228,40 +228,4 @@
 			<xs:pattern value="[0-9]{1,2}\.[0-9]{1,2}"/>
 		</xs:restriction>
 	</xs:simpleType> 
-    <xs:simpleType name="TCOrgaoIBGE">
-		<xs:annotation>
-			<xs:documentation>Tipo Código de orgão (UF da tabela do IBGE + 91 RFB)</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:string">
-			<xs:whiteSpace value="preserve"/>
-			<xs:enumeration value="11"/>
-			<xs:enumeration value="12"/>
-			<xs:enumeration value="13"/>
-			<xs:enumeration value="14"/>
-			<xs:enumeration value="15"/>
-			<xs:enumeration value="16"/>
-			<xs:enumeration value="17"/>
-			<xs:enumeration value="21"/>
-			<xs:enumeration value="22"/>
-			<xs:enumeration value="23"/>
-			<xs:enumeration value="24"/>
-			<xs:enumeration value="25"/>
-			<xs:enumeration value="26"/>
-			<xs:enumeration value="27"/>
-			<xs:enumeration value="28"/>
-			<xs:enumeration value="29"/>
-			<xs:enumeration value="31"/>
-			<xs:enumeration value="32"/>
-			<xs:enumeration value="33"/>
-			<xs:enumeration value="35"/>
-			<xs:enumeration value="41"/>
-			<xs:enumeration value="42"/>
-			<xs:enumeration value="43"/>
-			<xs:enumeration value="50"/>
-			<xs:enumeration value="51"/>
-			<xs:enumeration value="52"/>
-			<xs:enumeration value="53"/>
-			<xs:enumeration value="91"/>
-		</xs:restriction>
-	</xs:simpleType>
 </xs:schema>

--- a/NFe.AppTeste/Schemas/eventoEPEC_v1.00.xsd
+++ b/NFe.AppTeste/Schemas/eventoEPEC_v1.00.xsd
@@ -227,41 +227,5 @@
 			<xs:whiteSpace value="preserve"/>
 			<xs:pattern value="[0-9]{1,2}\.[0-9]{1,2}"/>
 		</xs:restriction>
-	</xs:simpleType> 
-    <xs:simpleType name="TCOrgaoIBGE">
-		<xs:annotation>
-			<xs:documentation>Tipo Código de orgão (UF da tabela do IBGE + 91 RFB)</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:string">
-			<xs:whiteSpace value="preserve"/>
-			<xs:enumeration value="11"/>
-			<xs:enumeration value="12"/>
-			<xs:enumeration value="13"/>
-			<xs:enumeration value="14"/>
-			<xs:enumeration value="15"/>
-			<xs:enumeration value="16"/>
-			<xs:enumeration value="17"/>
-			<xs:enumeration value="21"/>
-			<xs:enumeration value="22"/>
-			<xs:enumeration value="23"/>
-			<xs:enumeration value="24"/>
-			<xs:enumeration value="25"/>
-			<xs:enumeration value="26"/>
-			<xs:enumeration value="27"/>
-			<xs:enumeration value="28"/>
-			<xs:enumeration value="29"/>
-			<xs:enumeration value="31"/>
-			<xs:enumeration value="32"/>
-			<xs:enumeration value="33"/>
-			<xs:enumeration value="35"/>
-			<xs:enumeration value="41"/>
-			<xs:enumeration value="42"/>
-			<xs:enumeration value="43"/>
-			<xs:enumeration value="50"/>
-			<xs:enumeration value="51"/>
-			<xs:enumeration value="52"/>
-			<xs:enumeration value="53"/>
-			<xs:enumeration value="91"/>
-		</xs:restriction>
 	</xs:simpleType>
 </xs:schema>

--- a/NFe.AppTeste/Schemas/leiauteAverb_v1.00.xsd
+++ b/NFe.AppTeste/Schemas/leiauteAverb_v1.00.xsd
@@ -442,41 +442,4 @@
       <xs:pattern value="1.00"/>
     </xs:restriction>
   </xs:simpleType>
-  <xs:simpleType name="TCOrgaoIBGE">
-    <xs:annotation>
-      <xs:documentation>Tipo Código de orgão (UF da tabela do IBGE)</xs:documentation>
-    </xs:annotation>
-    <xs:restriction base="xs:string">
-      <xs:whiteSpace value="preserve"/>
-      <xs:enumeration value="11"/>
-      <xs:enumeration value="12"/>
-      <xs:enumeration value="13"/>
-      <xs:enumeration value="14"/>
-      <xs:enumeration value="15"/>
-      <xs:enumeration value="16"/>
-      <xs:enumeration value="17"/>
-      <xs:enumeration value="21"/>
-      <xs:enumeration value="22"/>
-      <xs:enumeration value="23"/>
-      <xs:enumeration value="24"/>
-      <xs:enumeration value="25"/>
-      <xs:enumeration value="26"/>
-      <xs:enumeration value="27"/>
-      <xs:enumeration value="28"/>
-      <xs:enumeration value="29"/>
-      <xs:enumeration value="31"/>
-      <xs:enumeration value="32"/>
-      <xs:enumeration value="33"/>
-      <xs:enumeration value="35"/>
-      <xs:enumeration value="41"/>
-      <xs:enumeration value="42"/>
-      <xs:enumeration value="43"/>
-      <xs:enumeration value="50"/>
-      <xs:enumeration value="51"/>
-      <xs:enumeration value="52"/>
-      <xs:enumeration value="53"/>
-      <xs:enumeration value="90"/>
-      <xs:enumeration value="91"/>
-    </xs:restriction>
-  </xs:simpleType>
 </xs:schema>

--- a/NFe.AppTeste/Schemas/leiauteConfRecebto_v1.00.xsd
+++ b/NFe.AppTeste/Schemas/leiauteConfRecebto_v1.00.xsd
@@ -366,41 +366,4 @@
 			<xs:pattern value="1\.00"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="TCOrgaoIBGE">
-		<xs:annotation>
-			<xs:documentation>Tipo Código de orgão (UF da tabela do IBGE + 90 SUFRAMA + 91 - RFB)</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:string">
-			<xs:whiteSpace value="preserve"/>
-			<xs:enumeration value="11"/>
-			<xs:enumeration value="12"/>
-			<xs:enumeration value="13"/>
-			<xs:enumeration value="14"/>
-			<xs:enumeration value="15"/>
-			<xs:enumeration value="16"/>
-			<xs:enumeration value="17"/>
-			<xs:enumeration value="21"/>
-			<xs:enumeration value="22"/>
-			<xs:enumeration value="23"/>
-			<xs:enumeration value="24"/>
-			<xs:enumeration value="25"/>
-			<xs:enumeration value="26"/>
-			<xs:enumeration value="27"/>
-			<xs:enumeration value="28"/>
-			<xs:enumeration value="29"/>
-			<xs:enumeration value="31"/>
-			<xs:enumeration value="32"/>
-			<xs:enumeration value="33"/>
-			<xs:enumeration value="35"/>
-			<xs:enumeration value="41"/>
-			<xs:enumeration value="42"/>
-			<xs:enumeration value="43"/>
-			<xs:enumeration value="50"/>
-			<xs:enumeration value="51"/>
-			<xs:enumeration value="52"/>
-			<xs:enumeration value="53"/>
-			<xs:enumeration value="90"/>
-			<xs:enumeration value="91"/>
-		</xs:restriction>
-	</xs:simpleType>
 </xs:schema>

--- a/NFe.AppTeste/Schemas/leiauteConsSitNFe_v2.01.xsd
+++ b/NFe.AppTeste/Schemas/leiauteConsSitNFe_v2.01.xsd
@@ -502,41 +502,4 @@
 			<xs:enumeration value="2.01"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="TCOrgaoIBGE">
-		<xs:annotation>
-			<xs:documentation>Tipo Código de orgão (UF da tabela do IBGE + 91 RFB)</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:string">
-			<xs:whiteSpace value="preserve"/>
-			<xs:enumeration value="11"/>
-			<xs:enumeration value="12"/>
-			<xs:enumeration value="13"/>
-			<xs:enumeration value="14"/>
-			<xs:enumeration value="15"/>
-			<xs:enumeration value="16"/>
-			<xs:enumeration value="17"/>
-			<xs:enumeration value="21"/>
-			<xs:enumeration value="22"/>
-			<xs:enumeration value="23"/>
-			<xs:enumeration value="24"/>
-			<xs:enumeration value="25"/>
-			<xs:enumeration value="26"/>
-			<xs:enumeration value="27"/>
-			<xs:enumeration value="28"/>
-			<xs:enumeration value="29"/>
-			<xs:enumeration value="31"/>
-			<xs:enumeration value="32"/>
-			<xs:enumeration value="33"/>
-			<xs:enumeration value="35"/>
-			<xs:enumeration value="41"/>
-			<xs:enumeration value="42"/>
-			<xs:enumeration value="43"/>
-			<xs:enumeration value="50"/>
-			<xs:enumeration value="51"/>
-			<xs:enumeration value="52"/>
-			<xs:enumeration value="53"/>
-			<xs:enumeration value="90"/>
-			<xs:enumeration value="91"/>
-		</xs:restriction>
-	</xs:simpleType>
 </xs:schema>

--- a/NFe.AppTeste/Schemas/leiauteEPEC_v1.00.xsd
+++ b/NFe.AppTeste/Schemas/leiauteEPEC_v1.00.xsd
@@ -420,40 +420,4 @@
 			<xs:pattern value="1\.00"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="TCOrgaoIBGE">
-		<xs:annotation>
-			<xs:documentation>Tipo Código de orgão (UF da tabela do IBGE + 91 RFB)</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:string">
-			<xs:whiteSpace value="preserve"/>
-			<xs:enumeration value="11"/>
-			<xs:enumeration value="12"/>
-			<xs:enumeration value="13"/>
-			<xs:enumeration value="14"/>
-			<xs:enumeration value="15"/>
-			<xs:enumeration value="16"/>
-			<xs:enumeration value="17"/>
-			<xs:enumeration value="21"/>
-			<xs:enumeration value="22"/>
-			<xs:enumeration value="23"/>
-			<xs:enumeration value="24"/>
-			<xs:enumeration value="25"/>
-			<xs:enumeration value="26"/>
-			<xs:enumeration value="27"/>
-			<xs:enumeration value="28"/>
-			<xs:enumeration value="29"/>
-			<xs:enumeration value="31"/>
-			<xs:enumeration value="32"/>
-			<xs:enumeration value="33"/>
-			<xs:enumeration value="35"/>
-			<xs:enumeration value="41"/>
-			<xs:enumeration value="42"/>
-			<xs:enumeration value="43"/>
-			<xs:enumeration value="50"/>
-			<xs:enumeration value="51"/>
-			<xs:enumeration value="52"/>
-			<xs:enumeration value="53"/>
-			<xs:enumeration value="91"/>
-		</xs:restriction>
-	</xs:simpleType>
 </xs:schema>

--- a/NFe.AppTeste/Schemas/leiauteEvento_v1.00.xsd
+++ b/NFe.AppTeste/Schemas/leiauteEvento_v1.00.xsd
@@ -332,48 +332,4 @@
 			<xs:pattern value="1\.00"/>
 		</xs:restriction>
 	</xs:simpleType>
-
-<!-- Comentado pelo fato da definição já constar no tiposBasico_v1.03.xsd
-
-	<xs:simpleType name="TCOrgaoIBGE">
-		<xs:annotation>
-			<xs:documentation>Tipo Código de orgão (UF da tabela do IBGE + 90 RFB)</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:string">
-			<xs:whiteSpace value="preserve"/>
-			<xs:enumeration value="11"/>
-			<xs:enumeration value="12"/>
-			<xs:enumeration value="13"/>
-			<xs:enumeration value="14"/>
-			<xs:enumeration value="15"/>
-			<xs:enumeration value="16"/>
-			<xs:enumeration value="17"/>
-			<xs:enumeration value="21"/>
-			<xs:enumeration value="22"/>
-			<xs:enumeration value="23"/>
-			<xs:enumeration value="24"/>
-			<xs:enumeration value="25"/>
-			<xs:enumeration value="26"/>
-			<xs:enumeration value="27"/>
-			<xs:enumeration value="28"/>
-			<xs:enumeration value="29"/>
-			<xs:enumeration value="31"/>
-			<xs:enumeration value="32"/>
-			<xs:enumeration value="33"/>
-			<xs:enumeration value="35"/>
-			<xs:enumeration value="41"/>
-			<xs:enumeration value="42"/>
-			<xs:enumeration value="43"/>
-			<xs:enumeration value="50"/>
-			<xs:enumeration value="51"/>
-			<xs:enumeration value="52"/>
-			<xs:enumeration value="53"/>
-			<xs:enumeration value="90"/>
-			<xs:enumeration value="91"/>
-			<xs:enumeration value="92"/>
-		</xs:restriction>
-	</xs:simpleType>
-
--->
-
 </xs:schema>

--- a/NFe.AppTeste/Schemas/leiauteRemIndus_v1.00.xsd
+++ b/NFe.AppTeste/Schemas/leiauteRemIndus_v1.00.xsd
@@ -341,42 +341,4 @@
 			<xs:pattern value="1\.00"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="TCOrgaoIBGE">
-		<xs:annotation>
-			<xs:documentation>Tipo Código de orgão (UF da tabela do IBGE + 90 RFB)</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:string">
-			<xs:whiteSpace value="preserve"/>
-			<xs:enumeration value="11"/>
-			<xs:enumeration value="12"/>
-			<xs:enumeration value="13"/>
-			<xs:enumeration value="14"/>
-			<xs:enumeration value="15"/>
-			<xs:enumeration value="16"/>
-			<xs:enumeration value="17"/>
-			<xs:enumeration value="21"/>
-			<xs:enumeration value="22"/>
-			<xs:enumeration value="23"/>
-			<xs:enumeration value="24"/>
-			<xs:enumeration value="25"/>
-			<xs:enumeration value="26"/>
-			<xs:enumeration value="27"/>
-			<xs:enumeration value="28"/>
-			<xs:enumeration value="29"/>
-			<xs:enumeration value="31"/>
-			<xs:enumeration value="32"/>
-			<xs:enumeration value="33"/>
-			<xs:enumeration value="35"/>
-			<xs:enumeration value="41"/>
-			<xs:enumeration value="42"/>
-			<xs:enumeration value="43"/>
-			<xs:enumeration value="50"/>
-			<xs:enumeration value="51"/>
-			<xs:enumeration value="52"/>
-			<xs:enumeration value="53"/>
-			<xs:enumeration value="90"/>
-			<xs:enumeration value="91"/>
-			<xs:enumeration value="92"/>
-		</xs:restriction>
-	</xs:simpleType>
 </xs:schema>

--- a/NFe.AppTeste/Schemas/leiauteSRE_v1.00.xsd
+++ b/NFe.AppTeste/Schemas/leiauteSRE_v1.00.xsd
@@ -333,40 +333,4 @@
 			<xs:pattern value="1\.00"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="TCOrgaoIBGE">
-		<xs:annotation>
-			<xs:documentation>Tipo Código de orgão (UF da tabela do IBGE + 90 RFB)</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:string">
-			<xs:whiteSpace value="preserve"/>
-			<xs:enumeration value="11"/>
-			<xs:enumeration value="12"/>
-			<xs:enumeration value="13"/>
-			<xs:enumeration value="14"/>
-			<xs:enumeration value="15"/>
-			<xs:enumeration value="16"/>
-			<xs:enumeration value="17"/>
-			<xs:enumeration value="21"/>
-			<xs:enumeration value="22"/>
-			<xs:enumeration value="23"/>
-			<xs:enumeration value="24"/>
-			<xs:enumeration value="25"/>
-			<xs:enumeration value="26"/>
-			<xs:enumeration value="27"/>
-			<xs:enumeration value="28"/>
-			<xs:enumeration value="29"/>
-			<xs:enumeration value="31"/>
-			<xs:enumeration value="32"/>
-			<xs:enumeration value="33"/>
-			<xs:enumeration value="35"/>
-			<xs:enumeration value="41"/>
-			<xs:enumeration value="42"/>
-			<xs:enumeration value="43"/>
-			<xs:enumeration value="50"/>
-			<xs:enumeration value="51"/>
-			<xs:enumeration value="52"/>
-			<xs:enumeration value="53"/>
-			<xs:enumeration value="90"/>
-		</xs:restriction>
-	</xs:simpleType>
 </xs:schema>

--- a/NFe.AppTeste/Schemas/leiauteSuframaInternaliza_v1.00.xsd
+++ b/NFe.AppTeste/Schemas/leiauteSuframaInternaliza_v1.00.xsd
@@ -602,41 +602,4 @@
 		</xs:sequence>
 		<xs:attribute name="versao" type="TVerEvento" use="required"/>
 	</xs:complexType>
-	<xs:simpleType name="TCOrgaoIBGE">
-		<xs:annotation>
-			<xs:documentation>Tipo Código de orgão (UF da tabela do IBGE + 90 RFB)</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:string">
-			<xs:whiteSpace value="preserve"/>
-			<xs:enumeration value="11"/>
-			<xs:enumeration value="12"/>
-			<xs:enumeration value="13"/>
-			<xs:enumeration value="14"/>
-			<xs:enumeration value="15"/>
-			<xs:enumeration value="16"/>
-			<xs:enumeration value="17"/>
-			<xs:enumeration value="21"/>
-			<xs:enumeration value="22"/>
-			<xs:enumeration value="23"/>
-			<xs:enumeration value="24"/>
-			<xs:enumeration value="25"/>
-			<xs:enumeration value="26"/>
-			<xs:enumeration value="27"/>
-			<xs:enumeration value="28"/>
-			<xs:enumeration value="29"/>
-			<xs:enumeration value="31"/>
-			<xs:enumeration value="32"/>
-			<xs:enumeration value="33"/>
-			<xs:enumeration value="35"/>
-			<xs:enumeration value="41"/>
-			<xs:enumeration value="42"/>
-			<xs:enumeration value="43"/>
-			<xs:enumeration value="50"/>
-			<xs:enumeration value="51"/>
-			<xs:enumeration value="52"/>
-			<xs:enumeration value="53"/>
-			<xs:enumeration value="90"/>
-			<xs:enumeration value="91"/>
-		</xs:restriction>
-	</xs:simpleType>
 </xs:schema>

--- a/NFe.AppTeste/Schemas/leiauteSuframaVistoria_v1.00.xsd
+++ b/NFe.AppTeste/Schemas/leiauteSuframaVistoria_v1.00.xsd
@@ -608,41 +608,4 @@
 		</xs:sequence>
 		<xs:attribute name="versao" type="TVerEvento" use="required"/>
 	</xs:complexType>
-	<xs:simpleType name="TCOrgaoIBGE">
-		<xs:annotation>
-			<xs:documentation>Tipo Código de orgão (UF da tabela do IBGE + 90 RFB)</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:string">
-			<xs:whiteSpace value="preserve"/>
-			<xs:enumeration value="11"/>
-			<xs:enumeration value="12"/>
-			<xs:enumeration value="13"/>
-			<xs:enumeration value="14"/>
-			<xs:enumeration value="15"/>
-			<xs:enumeration value="16"/>
-			<xs:enumeration value="17"/>
-			<xs:enumeration value="21"/>
-			<xs:enumeration value="22"/>
-			<xs:enumeration value="23"/>
-			<xs:enumeration value="24"/>
-			<xs:enumeration value="25"/>
-			<xs:enumeration value="26"/>
-			<xs:enumeration value="27"/>
-			<xs:enumeration value="28"/>
-			<xs:enumeration value="29"/>
-			<xs:enumeration value="31"/>
-			<xs:enumeration value="32"/>
-			<xs:enumeration value="33"/>
-			<xs:enumeration value="35"/>
-			<xs:enumeration value="41"/>
-			<xs:enumeration value="42"/>
-			<xs:enumeration value="43"/>
-			<xs:enumeration value="50"/>
-			<xs:enumeration value="51"/>
-			<xs:enumeration value="52"/>
-			<xs:enumeration value="53"/>
-			<xs:enumeration value="90"/>
-			<xs:enumeration value="91"/>
-		</xs:restriction>
-	</xs:simpleType>
 </xs:schema>

--- a/NFe.AppTeste/Schemas/retEnvCancelPProrrogNFe_v1.0.xsd
+++ b/NFe.AppTeste/Schemas/retEnvCancelPProrrogNFe_v1.0.xsd
@@ -56,7 +56,7 @@
 				  </xs:annotation>
 				  <xs:complexType>
 					<xs:sequence>
-					  <xs:element name="tpAmb" type="TAmb"> 
+					  <xs:element name="tpAmb" type="TAmb">
 						<xs:annotation>
 						  <xs:documentation>Identificação do Ambiente: 1  Produção / 2  Homologação</xs:documentation>
 						</xs:annotation>
@@ -93,9 +93,9 @@
 						</xs:annotation>
 						<xs:simpleType>
 							  <xs:restriction base="xs:string">
-								  <xs:whiteSpace value="preserve" /> 
-								  <xs:pattern value="[0-9]{6}" /> 
-								  <xs:enumeration value="111502" /> 
+								  <xs:whiteSpace value="preserve" />
+								  <xs:pattern value="[0-9]{6}" />
+								  <xs:enumeration value="111502" />
 								  <xs:enumeration value="111503" />
 							  </xs:restriction>
 						</xs:simpleType>
@@ -106,7 +106,7 @@
 						</xs:annotation>
 						<xs:simpleType>
 							<xs:restriction base="xs:string">
-								<xs:enumeration value="Cancelamento de Pedido de Prorrogação registrado" />									
+								<xs:enumeration value="Cancelamento de Pedido de Prorrogação registrado" />
 							</xs:restriction>
 						</xs:simpleType>
 					  </xs:element>
@@ -116,8 +116,8 @@
 						</xs:annotation>
 						<xs:simpleType>
 							<xs:restriction base="xs:string">
-							   <xs:whiteSpace value="preserve" /> 
-							   <xs:pattern value="[0-9]{1,2}" /> 
+							   <xs:whiteSpace value="preserve" />
+							   <xs:pattern value="[0-9]{1,2}" />
 							</xs:restriction>
 						</xs:simpleType>
 					  </xs:element>
@@ -160,7 +160,7 @@
 								<xs:pattern value="ID[0-9]{52}"/>
 							</xs:restriction>
 						</xs:simpleType>
-					</xs:attribute>	
+					</xs:attribute>
 				  </xs:complexType>
 				</xs:element>
 				<xs:element ref="ds:Signature"/>
@@ -192,40 +192,4 @@
 		</xs:attribute>
 	  </xs:complexType>
 	</xs:element>
-	<xs:simpleType name="TCOrgaoIBGE">
-		<xs:annotation>
-			<xs:documentation>Tipo Código de orgão (UF da tabela do IBGE + 91 RFB)</xs:documentation> 
-		</xs:annotation>
-		<xs:restriction base="xs:string">
-			<xs:whiteSpace value="preserve" /> 
-			<xs:enumeration value="11" /> 
-			<xs:enumeration value="12" /> 
-			<xs:enumeration value="13" /> 
-			<xs:enumeration value="14" /> 
-			<xs:enumeration value="15" /> 
-			<xs:enumeration value="16" /> 
-			<xs:enumeration value="17" /> 
-			<xs:enumeration value="21" /> 
-			<xs:enumeration value="22" /> 
-			<xs:enumeration value="23" /> 
-			<xs:enumeration value="24" /> 
-			<xs:enumeration value="25" /> 
-			<xs:enumeration value="26" /> 
-			<xs:enumeration value="27" /> 
-			<xs:enumeration value="28" /> 
-			<xs:enumeration value="29" /> 
-			<xs:enumeration value="31" /> 
-			<xs:enumeration value="32" /> 
-			<xs:enumeration value="33" /> 
-			<xs:enumeration value="35" /> 
-			<xs:enumeration value="41" /> 
-			<xs:enumeration value="42" /> 
-			<xs:enumeration value="43" /> 
-			<xs:enumeration value="50" /> 
-			<xs:enumeration value="51" /> 
-			<xs:enumeration value="52" /> 
-			<xs:enumeration value="53" /> 
-			<xs:enumeration value="91" /> 
-		</xs:restriction>
-	</xs:simpleType>
 </xs:schema>

--- a/NFe.AppTeste/Schemas/retEnvFiscoNFe_v1.0.xsd
+++ b/NFe.AppTeste/Schemas/retEnvFiscoNFe_v1.0.xsd
@@ -56,7 +56,7 @@
 				  </xs:annotation>
 				  <xs:complexType>
 					<xs:sequence>
-					  <xs:element name="tpAmb" type="TAmb"> 
+					  <xs:element name="tpAmb" type="TAmb">
 						<xs:annotation>
 						  <xs:documentation>Identificação do Ambiente: 1  Produção / 2  Homologação</xs:documentation>
 						</xs:annotation>
@@ -93,13 +93,13 @@
 						</xs:annotation>
 						<xs:simpleType>
 							<xs:restriction base="xs:string">
-								<xs:whiteSpace value="preserve" /> 
-								<xs:pattern value="[0-9]{6}" /> 
-								<xs:enumeration value="411500" /> 
+								<xs:whiteSpace value="preserve" />
+								<xs:pattern value="[0-9]{6}" />
+								<xs:enumeration value="411500" />
 								<xs:enumeration value="411501" />
-								<xs:enumeration value="411502" /> 
+								<xs:enumeration value="411502" />
 								<xs:enumeration value="411503" />
-							</xs:restriction>  
+							</xs:restriction>
 						</xs:simpleType>
 					  </xs:element>
 					  <xs:element maxOccurs="1" minOccurs="0" name="xEvento">
@@ -108,8 +108,8 @@
 						</xs:annotation>
 						<xs:simpleType>
 							<xs:restriction base="xs:string">
-								<xs:whiteSpace value="preserve" /> 
-								<xs:enumeration value="Evento Fisco Registrado" /> 
+								<xs:whiteSpace value="preserve" />
+								<xs:enumeration value="Evento Fisco Registrado" />
 							</xs:restriction>
 						</xs:simpleType>
 					  </xs:element>
@@ -119,8 +119,8 @@
 						</xs:annotation>
 						<xs:simpleType>
 							<xs:restriction base="xs:string">
-							   <xs:whiteSpace value="preserve" /> 
-							   <xs:pattern value="[0-9]{1,2}" /> 
+							   <xs:whiteSpace value="preserve" />
+							   <xs:pattern value="[0-9]{1,2}" />
 							</xs:restriction>
 						</xs:simpleType>
 					  </xs:element>
@@ -163,7 +163,7 @@
 								<xs:pattern value="ID[0-9]{52}"/>
 							</xs:restriction>
 						</xs:simpleType>
-					</xs:attribute>	
+					</xs:attribute>
 				  </xs:complexType>
 				</xs:element>
 				<xs:element ref="ds:Signature"/>
@@ -195,40 +195,4 @@
 		</xs:attribute>
 	  </xs:complexType>
 	</xs:element>
-    <xs:simpleType name="TCOrgaoIBGE">
-		<xs:annotation>
-			<xs:documentation>Tipo Código de orgão (UF da tabela do IBGE + 91 RFB)</xs:documentation> 
-		</xs:annotation>
-		<xs:restriction base="xs:string">
-			<xs:whiteSpace value="preserve" /> 
-			<xs:enumeration value="11" /> 
-			<xs:enumeration value="12" /> 
-			<xs:enumeration value="13" /> 
-			<xs:enumeration value="14" /> 
-			<xs:enumeration value="15" /> 
-			<xs:enumeration value="16" /> 
-			<xs:enumeration value="17" /> 
-			<xs:enumeration value="21" /> 
-			<xs:enumeration value="22" /> 
-			<xs:enumeration value="23" /> 
-			<xs:enumeration value="24" /> 
-			<xs:enumeration value="25" /> 
-			<xs:enumeration value="26" /> 
-			<xs:enumeration value="27" /> 
-			<xs:enumeration value="28" /> 
-			<xs:enumeration value="29" /> 
-			<xs:enumeration value="31" /> 
-			<xs:enumeration value="32" /> 
-			<xs:enumeration value="33" /> 
-			<xs:enumeration value="35" /> 
-			<xs:enumeration value="41" /> 
-			<xs:enumeration value="42" /> 
-			<xs:enumeration value="43" /> 
-			<xs:enumeration value="50" /> 
-			<xs:enumeration value="51" /> 
-			<xs:enumeration value="52" /> 
-			<xs:enumeration value="53" /> 
-			<xs:enumeration value="91" /> 
-		</xs:restriction>
-	</xs:simpleType>
 </xs:schema>

--- a/NFe.AppTeste/Schemas/retEventoEPEC_v0.01.xsd
+++ b/NFe.AppTeste/Schemas/retEventoEPEC_v0.01.xsd
@@ -147,7 +147,7 @@
 												<xs:length  value="17" />
 											</xs:restriction>
                                         </xs:simpleType>
-                                    </xs:attribute>    
+                                    </xs:attribute>
                                 </xs:complexType>
                             </xs:element>
                             <xs:element ref="ds:Signature" minOccurs="0"/>
@@ -166,42 +166,6 @@
 		<xs:restriction base="xs:string">
 			<xs:whiteSpace value="preserve"/>
 			<xs:pattern value="[0-9]{1,2}\.[0-9]{1,2}"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="TCOrgaoIBGE">
-		<xs:annotation>
-			<xs:documentation>Tipo Código de orgão (UF da tabela do IBGE + 91 RFB)</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:string">
-			<xs:whiteSpace value="preserve"/>
-			<xs:enumeration value="11"/>
-			<xs:enumeration value="12"/>
-			<xs:enumeration value="13"/>
-			<xs:enumeration value="14"/>
-			<xs:enumeration value="15"/>
-			<xs:enumeration value="16"/>
-			<xs:enumeration value="17"/>
-			<xs:enumeration value="21"/>
-			<xs:enumeration value="22"/>
-			<xs:enumeration value="23"/>
-			<xs:enumeration value="24"/>
-			<xs:enumeration value="25"/>
-			<xs:enumeration value="26"/>
-			<xs:enumeration value="27"/>
-			<xs:enumeration value="28"/>
-			<xs:enumeration value="29"/>
-			<xs:enumeration value="31"/>
-			<xs:enumeration value="32"/>
-			<xs:enumeration value="33"/>
-			<xs:enumeration value="35"/>
-			<xs:enumeration value="41"/>
-			<xs:enumeration value="42"/>
-			<xs:enumeration value="43"/>
-			<xs:enumeration value="50"/>
-			<xs:enumeration value="51"/>
-			<xs:enumeration value="52"/>
-			<xs:enumeration value="53"/>
-			<xs:enumeration value="91"/>
 		</xs:restriction>
 	</xs:simpleType>
 </xs:schema>

--- a/NFe.AppTeste/Schemas/retPProrrogNFe_v1.0.xsd
+++ b/NFe.AppTeste/Schemas/retPProrrogNFe_v1.0.xsd
@@ -193,41 +193,4 @@
 		</xs:attribute>
 	  </xs:complexType>
 	</xs:element>
-	
-	<xs:simpleType name="TCOrgaoIBGE">
-		<xs:annotation>
-			<xs:documentation>Tipo Código de orgão (UF da tabela do IBGE + 91 RFB)</xs:documentation> 
-		</xs:annotation>
-		<xs:restriction base="xs:string">
-			<xs:whiteSpace value="preserve" /> 
-			<xs:enumeration value="11" /> 
-			<xs:enumeration value="12" /> 
-			<xs:enumeration value="13" /> 
-			<xs:enumeration value="14" /> 
-			<xs:enumeration value="15" /> 
-			<xs:enumeration value="16" /> 
-			<xs:enumeration value="17" /> 
-			<xs:enumeration value="21" /> 
-			<xs:enumeration value="22" /> 
-			<xs:enumeration value="23" /> 
-			<xs:enumeration value="24" /> 
-			<xs:enumeration value="25" /> 
-			<xs:enumeration value="26" /> 
-			<xs:enumeration value="27" /> 
-			<xs:enumeration value="28" /> 
-			<xs:enumeration value="29" /> 
-			<xs:enumeration value="31" /> 
-			<xs:enumeration value="32" /> 
-			<xs:enumeration value="33" /> 
-			<xs:enumeration value="35" /> 
-			<xs:enumeration value="41" /> 
-			<xs:enumeration value="42" /> 
-			<xs:enumeration value="43" /> 
-			<xs:enumeration value="50" /> 
-			<xs:enumeration value="51" /> 
-			<xs:enumeration value="52" /> 
-			<xs:enumeration value="53" /> 
-			<xs:enumeration value="91" /> 
-		</xs:restriction>
-	</xs:simpleType>
 </xs:schema>

--- a/NFe.AppTeste/Schemas/tiposBasico_v1.00.xsd
+++ b/NFe.AppTeste/Schemas/tiposBasico_v1.00.xsd
@@ -340,42 +340,4 @@
       <xs:pattern value="1\.00"/>
     </xs:restriction>
   </xs:simpleType>
-  <xs:simpleType name="TCOrgaoIBGE">
-    <xs:annotation>
-      <xs:documentation>Tipo Código de orgão (UF da tabela do IBGE + 90 RFB)</xs:documentation>
-    </xs:annotation>
-    <xs:restriction base="xs:string">
-      <xs:whiteSpace value="preserve"/>
-      <xs:enumeration value="11"/>
-      <xs:enumeration value="12"/>
-      <xs:enumeration value="13"/>
-      <xs:enumeration value="14"/>
-      <xs:enumeration value="15"/>
-      <xs:enumeration value="16"/>
-      <xs:enumeration value="17"/>
-      <xs:enumeration value="21"/>
-      <xs:enumeration value="22"/>
-      <xs:enumeration value="23"/>
-      <xs:enumeration value="24"/>
-      <xs:enumeration value="25"/>
-      <xs:enumeration value="26"/>
-      <xs:enumeration value="27"/>
-      <xs:enumeration value="28"/>
-      <xs:enumeration value="29"/>
-      <xs:enumeration value="31"/>
-      <xs:enumeration value="32"/>
-      <xs:enumeration value="33"/>
-      <xs:enumeration value="35"/>
-      <xs:enumeration value="41"/>
-      <xs:enumeration value="42"/>
-      <xs:enumeration value="43"/>
-      <xs:enumeration value="50"/>
-      <xs:enumeration value="51"/>
-      <xs:enumeration value="52"/>
-      <xs:enumeration value="53"/>
-      <xs:enumeration value="90"/>
-      <xs:enumeration value="91"/>
-      <xs:enumeration value="92"/>
-    </xs:restriction>
-  </xs:simpleType>
 </xs:schema>


### PR DESCRIPTION
Verifiquei através do retorno da SEFAZ em algumas manifestações de nota de entrada que retornava a seguinte mensagem

![image](https://github.com/ZeusAutomacao/DFe.NET/assets/79063684/701fa4f1-a9cd-4b85-bdb4-08befafec9ea)
 
Com isso procedi para verificar o problema e percebi que só poderia ter relação com os schemas NFe, alguns arquivos estão importando o tiposBasico_v3.10.xsd, nesse arquivo já tem declarado o simpleType TCOrgaoIBGE, causando duplicidade de declaração caso declare o mesmo simpleType após importá-lo. O erro ocorreu no estado do CE, testei também no RJ e ficou funcionando normalmente após as alterações. Segue exemplo de um schema importando o tiposBasico_v3.10.xsd e os arquivos que foram alterados e removida a declaração desse simpleType.

![image](https://github.com/ZeusAutomacao/DFe.NET/assets/79063684/74fd77f1-c739-422f-a1e0-13f33c4e4cd6)
![image](https://github.com/ZeusAutomacao/DFe.NET/assets/79063684/a5992861-094d-49da-871a-cbdc235d2566)

Acredito que não tenha chances de causar problemas a alteração feita nesse commit, pois apenas está sendo removida uma duplicidade de declaração. Contudo, convém ser analisada. Por aqui foi necessária esta alteração para conseguir manifestar nota no estado do CE.
