### PR TITLE
Criação do atributo personalizado "[TString]" o qual deve ser utiliza…

### DIFF
--- a/DFe.Utils/Attributes/TStringAttribute.cs
+++ b/DFe.Utils/Attributes/TStringAttribute.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Text.RegularExpressions;
+
+namespace DFe.Utils.Attributes
+{
+    /// <summary>
+    /// Indica que esta propriedade, corresponde ao tipo 'TString' (Tipo string genérico), do schema da NF-e ([!-ÿ]{1}[ -ÿ]{0,}[!-ÿ]{1}|[!-ÿ]{1})
+    /// <para></para>
+    /// 
+    /// Utilize este atributo, para forçar a correção dos dados enviados nesta propriedade
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+    public class TStringAttribute : Attribute
+    {
+        /// <summary>
+        /// Remove caracteres inválidos, de acordo com o tipo: TString (Tipo string genérico) do arquivo 'tiposBasico_v4.00.xsd'
+        /// </summary>
+        /// <param name="valor"></param>
+        /// <returns></returns>
+        public static string CorrigirValor(string valor)
+        {
+            // Qualquer string que comece e termine com um ou mais caracteres no intervalo de ! (33) a ÿ (255) ou espaços em branco.
+            var regex = new Regex(@"[^!-ÿ\s]+");
+
+            // Substitui todos os caracteres que não correspondem ao padrão por uma string vazia,
+            // removendo todos os caracteres inválidos
+            valor = regex.Replace(valor, "");
+
+            // Remove espaços no início e no final da string
+            valor = valor.Trim();
+
+            return valor;
+        }
+    }
+}

--- a/NFe.AppTeste.NetCore/Program.cs
+++ b/NFe.AppTeste.NetCore/Program.cs
@@ -537,6 +537,8 @@ namespace NFe.AppTeste.NetCore
                 infNFe.infAdic = new infAdic() { infCpl = "Troco: 10,00" }; //Susgestão para impressão do troco em NFCe
             }
 
+            infNFe.ExecutarCorrecaoDeDados(infNFe);
+
             return infNFe;
         }
 
@@ -545,7 +547,7 @@ namespace NFe.AppTeste.NetCore
             ide ide = new ide
             {
                 cUF = _configuracoes.EnderecoEmitente.UF,
-                natOp = "VENDA",
+                natOp = " VENDA ",
                 mod = modelo,
                 serie = 1,
                 nNF = numero,
@@ -556,7 +558,7 @@ namespace NFe.AppTeste.NetCore
                 cNF = "1234",
                 tpAmb = _configuracoes.CfgServico.tpAmb,
                 finNFe = FinalidadeNFe.fnNormal,
-                verProc = "3.000"
+                verProc = " 3.000 "
             };
 
             if (ide.tpEmis != TipoEmissao.teNormal)
@@ -649,7 +651,7 @@ namespace NFe.AppTeste.NetCore
                 CNPJ = "99999999000191",
                 //CPF = "99999999999",
             };
-            dest.xNome = "NF-E EMITIDA EM AMBIENTE DE HOMOLOGACAO - SEM VALOR FISCAL"; //Obrigatório para NFe e opcional para NFCe
+            dest.xNome = " NF-E EMITIDA EM AMBIENTE DE HOMOLOGACAO - SEM VALOR FISCAL "; //Obrigatório para NFe e opcional para NFCe
             dest.enderDest = GetEnderecoDestinatario(); //Obrigatório para NFe e opcional para NFCe
 
             //if (versao == VersaoServico.Versao200)
@@ -668,15 +670,15 @@ namespace NFe.AppTeste.NetCore
         {
             enderDest enderDest = new enderDest
             {
-                xLgr = "RUA ...",
+                xLgr = " RUA ...",
                 nro = "S/N",
-                xBairro = "CENTRO",
+                xBairro = " CENTRO ",
                 cMun = 2802908,
-                xMun = "ITABAIANA",
+                xMun = " ITABAIANA ",
                 UF = "SE",
                 CEP = "49500000",
                 cPais = 1058,
-                xPais = "BRASIL"
+                xPais = " BRASIL "
             };
             return enderDest;
         }

--- a/NFe.Classes/Informacoes/Destinatario/dest.cs
+++ b/NFe.Classes/Informacoes/Destinatario/dest.cs
@@ -33,6 +33,7 @@
 using System;
 using System.Xml.Serialization;
 using DFe.Classes.Flags;
+using DFe.Utils.Attributes;
 using NFe.Classes.Servicos.Tipos;
 
 namespace NFe.Classes.Informacoes.Destinatario
@@ -102,6 +103,7 @@ namespace NFe.Classes.Informacoes.Destinatario
         /// <summary>
         ///     E04 - Razão Social ou nome do destinatário
         /// </summary>
+        [TString]
         public string xNome { get; set; }
 
         /// <summary>

--- a/NFe.Classes/Informacoes/Destinatario/enderDest.cs
+++ b/NFe.Classes/Informacoes/Destinatario/enderDest.cs
@@ -31,6 +31,7 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 
+using DFe.Utils.Attributes;
 using System;
 using System.Linq;
 
@@ -43,21 +44,25 @@ namespace NFe.Classes.Informacoes.Destinatario
         /// <summary>
         ///     E06 - Logradouro
         /// </summary>
+        [TString]
         public string xLgr { get; set; }
 
         /// <summary>
         ///     E07 - Número
         /// </summary>
+        [TString]
         public string nro { get; set; }
 
         /// <summary>
         ///     E08 - Complemento
         /// </summary>
+        [TString]
         public string xCpl { get; set; }
 
         /// <summary>
         ///     E09 - Bairro
         /// </summary>
+        [TString]
         public string xBairro { get; set; }
 
         /// <summary>
@@ -69,6 +74,7 @@ namespace NFe.Classes.Informacoes.Destinatario
         /// <summary>
         ///     E11 - Nome do município, informar EXTERIOR para operações com o exterior.
         /// </summary>
+        [TString]
         public string xMun { get; set; }
 
         /// <summary>
@@ -107,6 +113,7 @@ namespace NFe.Classes.Informacoes.Destinatario
         ///     E15 - Nome do País
         ///     <para>Brasil ou BRASIL</para>
         /// </summary>
+        [TString]
         public string xPais { get; set; }
 
         /// <summary>

--- a/NFe.Classes/Informacoes/Identificacao/ide.cs
+++ b/NFe.Classes/Informacoes/Identificacao/ide.cs
@@ -37,6 +37,7 @@ using System.Xml.Serialization;
 using DFe.Classes.Entidades;
 using DFe.Classes.Flags;
 using DFe.Utils;
+using DFe.Utils.Attributes;
 using NFe.Classes.Informacoes.Identificacao.Tipos;
 
 namespace NFe.Classes.Informacoes.Identificacao
@@ -56,6 +57,7 @@ namespace NFe.Classes.Informacoes.Identificacao
         /// <summary>
         ///     B04 - Descrição da Natureza da Operação
         /// </summary>
+        [TString]
         public string natOp { get; set; }
 
         /// <summary>
@@ -220,6 +222,7 @@ namespace NFe.Classes.Informacoes.Identificacao
         /// <summary>
         ///     B27 - versão do aplicativo utilizado no processo de emissão
         /// </summary>
+        [TString]
         public string verProc { get; set; }
 
         /// <summary>
@@ -244,6 +247,7 @@ namespace NFe.Classes.Informacoes.Identificacao
         /// <summary>
         ///     B29 - Informar a Justificativa da entrada
         /// </summary>
+        [TString]
         public string xJust { get; set; }
 
         /// <summary>

--- a/NFe.Classes/Informacoes/_baseNFe.cs
+++ b/NFe.Classes/Informacoes/_baseNFe.cs
@@ -1,0 +1,98 @@
+﻿/********************************************************************************/
+/* Projeto: Biblioteca ZeusNFe                                                  */
+/* Biblioteca C# para emissão de Nota Fiscal Eletrônica - NFe e Nota Fiscal de  */
+/* Consumidor Eletrônica - NFC-e (http://www.nfe.fazenda.gov.br)                */
+/*                                                                              */
+/* Direitos Autorais Reservados (c) 2014 Adenilton Batista da Silva             */
+/*                                       Zeusdev Tecnologia LTDA ME             */
+/*                                                                              */
+/*  Você pode obter a última versão desse arquivo no GitHub                     */
+/* localizado em https://github.com/adeniltonbs/Zeus.Net.NFe.NFCe               */
+/*                                                                              */
+/*                                                                              */
+/*  Esta biblioteca é software livre; você pode redistribuí-la e/ou modificá-la */
+/* sob os termos da Licença Pública Geral Menor do GNU conforme publicada pela  */
+/* Free Software Foundation; tanto a versão 2.1 da Licença, ou (a seu critério) */
+/* qualquer versão posterior.                                                   */
+/*                                                                              */
+/*  Esta biblioteca é distribuída na expectativa de que seja útil, porém, SEM   */
+/* NENHUMA GARANTIA; nem mesmo a garantia implícita de COMERCIABILIDADE OU      */
+/* ADEQUAÇÃO A UMA FINALIDADE ESPECÍFICA. Consulte a Licença Pública Geral Menor*/
+/* do GNU para mais detalhes. (Arquivo LICENÇA.TXT ou LICENSE.TXT)              */
+/*                                                                              */
+/*  Você deve ter recebido uma cópia da Licença Pública Geral Menor do GNU junto*/
+/* com esta biblioteca; se não, escreva para a Free Software Foundation, Inc.,  */
+/* no endereço 59 Temple Street, Suite 330, Boston, MA 02111-1307 USA.          */
+/* Você também pode obter uma copia da licença em:                              */
+/* http://www.opensource.org/licenses/lgpl-license.php                          */
+/*                                                                              */
+/* Zeusdev Tecnologia LTDA ME - adenilton@zeusautomacao.com.br                  */
+/* http://www.zeusautomacao.com.br/                                             */
+/* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
+/********************************************************************************/
+
+using DFe.Utils.Attributes;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace NFe.Classes.Informacoes
+{
+    public class _baseNFe
+    {
+        public void ExecutarCorrecaoDeDados(object obj)
+        {
+            var tipo = obj.GetType();
+
+            // Corrige as propriedades
+            var propriedades = tipo.GetProperties();
+            foreach (var propriedade in propriedades)
+            {
+                if (!propriedade.CanRead || !propriedade.CanWrite)
+                {
+                    continue;
+                }
+
+                // Ignora propriedades indexadas
+                if (propriedade.GetIndexParameters().Length > 0)
+                {
+                    continue;
+                }
+
+                var atributosTString = propriedade.GetCustomAttributes(typeof(TStringAttribute), true);
+                if (atributosTString.Length > 0)
+                {
+                    if (propriedade.GetValue(obj) is string valor)
+                    {
+                        var valorCorrigido = TStringAttribute.CorrigirValor(valor);
+                        propriedade.SetValue(obj, valorCorrigido);
+                    }
+                }
+
+                // Se a propriedade é uma lista, itera sobre os itens na lista
+                if (propriedade.PropertyType.IsGenericType && propriedade.PropertyType.GetGenericTypeDefinition() == typeof(List<>))
+                {
+                    var lista = propriedade.GetValue(obj) as IList;
+                    if (lista != null)
+                    {
+                        foreach (var item in lista)
+                        {
+                            ExecutarCorrecaoDeDados(item);
+                        }
+                    }
+                }
+                else
+                {
+                    // Verifica se a propriedade é do tipo de uma classe
+                    if (propriedade.PropertyType.IsClass && propriedade.PropertyType != typeof(string))
+                    {
+                        var propValor = propriedade.GetValue(obj);
+                        if (propValor != null)
+                        {
+                            ExecutarCorrecaoDeDados(propValor);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/NFe.Classes/Informacoes/infNFe.cs
+++ b/NFe.Classes/Informacoes/infNFe.cs
@@ -47,7 +47,7 @@ using Shared.NFe.Classes.Informacoes.Intermediador;
 
 namespace NFe.Classes.Informacoes
 {
-    public class infNFe
+    public class infNFe: _baseNFe
     {
         public infNFe()
         {


### PR DESCRIPTION
Criação do atributo personalizado "[TString]" o qual pode ser utilizado para decorar todas as proriedades referentes às tags do xml do tipo "TString".
Com o objetivo de corrigir automaticamente os dados destas propriedades, evitando a falha de schema:

```O elemento '<nome_elemento>' é inválido - O valor 'exemplo de valor inválido' é inválido de acordo com o seu tipo de dados 'String'```

Já inclui a anotação em alguns atributos, mas será necessário incluir nos demais. São centenas.