### PR TITLE
Corrigido nome do parâmetro de documento cancelado na impressão do DAMDFe

### DIFF
--- a/MDFe.Damdfe.Base/MDFe/MDFeRetrato.frx
+++ b/MDFe.Damdfe.Base/MDFe/MDFeRetrato.frx
@@ -682,7 +682,6 @@ namespace FastReport
         </Column>
       </Column>
     </BusinessObjectDataSource>
-    <Parameter Name="DoocumentoCancelado" DataType="System.Boolean" AsString=""/>
     <Parameter Name="DocumentoEncerrado" DataType="System.Boolean" AsString=""/>
     <Parameter Name="Desenvolvedor" DataType="System.String" AsString=""/>
     <Parameter Name="QuebrarLinhasObservacao" DataType="System.Boolean" AsString=""/>

--- a/MDFe.Damdfe.Fast/DamdfeFrMDFe.cs
+++ b/MDFe.Damdfe.Fast/DamdfeFrMDFe.cs
@@ -78,7 +78,7 @@ namespace MDFe.Damdfe.Fast
         
         public void Configurar(ConfiguracaoDamdfe config)
         {
-            Relatorio.SetParameterValue("DoocumentoCancelado", config.DocumentoCancelado);
+            Relatorio.SetParameterValue("DocumentoCancelado", config.DocumentoCancelado);
             Relatorio.SetParameterValue("DocumentoEncerrado", config.DocumentoEncerrado);
             Relatorio.SetParameterValue("Desenvolvedor", config.Desenvolvedor);
             Relatorio.SetParameterValue("QuebrarLinhasObservacao", config.QuebrarLinhasObservacao);


### PR DESCRIPTION
 - Corrigido nome do parâmetro de documento cancelado na impressão do DAMDFe;
 - Corrigido bug ao gerar DAMDFe usando a aplicação de teste.