### PR TITLE
Adiciona criação de tag e release automática no pipeline do GitHub Actions

### DIFF
--- a/.github/workflows/DFe.NET_build.yml
+++ b/.github/workflows/DFe.NET_build.yml
@@ -71,6 +71,11 @@ jobs:
         
     #- name: Test
     #  run: dotnet test --no-build --verbosity normal
+
+    - name: Listar arquivos para debug
+      run: |
+        echo "Arquivos e pastas no workspace:"
+        dir ${{ github.workspace }} -Recurse
     
     - name: Pack
       run: | 

--- a/.github/workflows/DFe.NET_build.yml
+++ b/.github/workflows/DFe.NET_build.yml
@@ -77,12 +77,22 @@ jobs:
         dotnet pack -o ${{ github.workspace }} -v minimal -c Release -p:NuspecProperties=version=${{ steps.date.outputs.date }} -p:PackageVersion=${{ steps.date.outputs.date }} NuGet\Zeus.Net.NFe.NFCe\Zeus.Net.NFe.NFCe.csproj
         dotnet pack -o ${{ github.workspace }} -v minimal -c Release -p:NuspecProperties=version=${{ steps.date.outputs.date }} -p:PackageVersion=${{ steps.date.outputs.date }} NuGet\Zeus.Net.MDFe\Zeus.Net.MDFe.csproj
         dotnet pack -o ${{ github.workspace }} -v minimal -c Release -p:NuspecProperties=version=${{ steps.date.outputs.date }} -p:PackageVersion=${{ steps.date.outputs.date }} NuGet\Zeus.Net.CTe\Zeus.Net.CTe.csproj
+        
+        zip -r ${{ github.workspace }}/CteArtefato.zip .\path\to\CTeArtefato
+        zip -r ${{ github.workspace }}/MdfeArtefato.zip .\path\to\MdfeArtefato
+        zip -r ${{ github.workspace }}/NfeArtefato.zip .\path\to\NfeArtefato
 
     - name: Upload Artifacts
       uses: actions/upload-artifact@v4
       with:
         name: nupkg
         path: ${{ github.workspace }}/*.nupkg
+
+    - name: Upload ZIP Files as Assets
+      uses: actions/upload-artifact@v4
+      with:
+        name: zip-artefatos
+        path: ${{ github.workspace }}/*.zip
         
   deploy:
     needs: build
@@ -136,6 +146,16 @@ jobs:
                 "prerelease": false
               }' \
           https://api.github.com/repos/${{ github.repository }}/releases
+  
+      - name: Attach ZIP Files as Assets to Release
+        run: |
+          curl -X POST \
+          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          -F "file=@${{ github.workspace }}/CteArtefato.zip" \
+          -F "file=@${{ github.workspace }}/MdfeArtefato.zip" \
+          -F "file=@${{ github.workspace }}/NfeArtefato.zip" \
+          -F "file=@${{ github.workspace }}/*.nupkg" \
+          https://uploads.github.com/repos/${{ github.repository }}/releases/${{ steps.create_release.outputs.id }}/assets?name=CteArtefato.zip
 
       - name: Discord notification
         continue-on-error: true

--- a/.github/workflows/DFe.NET_build.yml
+++ b/.github/workflows/DFe.NET_build.yml
@@ -71,21 +71,52 @@ jobs:
         
     #- name: Test
     #  run: dotnet test --no-build --verbosity normal
-
-    - name: Listar arquivos para debug
-      run: |
-        echo "Arquivos e pastas no workspace:"
-        dir ${{ github.workspace }} -Recurse
     
-    - name: Pack
+    - name: Organizar arquivos de artefatos
+      run: |
+        mkdir -p CTeArtefato
+        mkdir -p MdfeArtefato
+        mkdir -p NfeArtefato
+
+        # Organizar arquivos para NFeArtefato
+        cp NuGet/Zeus.Net.NFe.NFCe/Zeus.Net.NFe.NFCe.nuspec NfeArtefato/
+        cp ${{ github.workspace }}/*.nupkg NfeArtefato/
+        mkdir -p NfeArtefato/lib/net40
+        cp NFe.Wsdl/bin/Release/net40/NFe.Wsdl.dll NfeArtefato/lib/net40/
+        cp NFe.Utils/bin/Release/net40/NFe.Utils.dll NfeArtefato/lib/net40/
+        cp NFe.Servicos/bin/Release/net40/NFe.Servicos.dll NfeArtefato/lib/net40/
+        cp NFe.Classes/bin/Release/net40/NFe.Classes.dll NfeArtefato/lib/net40/
+        cp DFe.Classes/bin/Release/net40/DFe.Classes.dll NfeArtefato/lib/net40/
+
+        # Organizar arquivos para MDFeArtefato
+        cp NuGet/Zeus.Net.MDFe/Zeus.Net.MDFe.nuspec MdfeArtefato/
+        cp ${{ github.workspace }}/*.nupkg MdfeArtefato/
+        mkdir -p MdfeArtefato/lib/net40
+        cp MDFe.Wsdl/bin/Release/net40/MDFe.Wsdl.dll MdfeArtefato/lib/net40/
+        cp MDFe.Utils/bin/Release/net40/MDFe.Utils.dll MdfeArtefato/lib/net40/
+        cp MDFe.Servicos/bin/Release/net40/MDFe.Servicos.dll MdfeArtefato/lib/net40/
+        cp MDFe.Classes/bin/Release/net40/MDFe.Classes.dll MdfeArtefato/lib/net40/
+        cp DFe.Classes/bin/Release/net40/DFe.Classes.dll MdfeArtefato/lib/net40/
+
+        # Organizar arquivos para CTeArtefato
+        cp NuGet/Zeus.Net.CTe/Zeus.Net.CTe.nuspec CTeArtefato/
+        cp ${{ github.workspace }}/*.nupkg CTeArtefato/
+        mkdir -p CTeArtefato/lib/net40
+        cp CTe.Wsdl/bin/Release/net40/CTe.Wsdl.dll CTeArtefato/lib/net40/
+        cp CTe.Utils/bin/Release/net40/CTe.Utils.dll CTeArtefato/lib/net40/
+        cp CTe.Servicos/bin/Release/net40/CTe.Servicos.dll CTeArtefato/lib/net40/
+        cp CTe.Classes/bin/Release/net40/CTe.Classes.dll CTeArtefato/lib/net40/
+        cp DFe.Classes/bin/Release/net40/DFe.Classes.dll CTeArtefato/lib/net40/
+
+    - name: Packe e compactar artefatos
       run: | 
         dotnet pack -o ${{ github.workspace }} -v minimal -c Release -p:NuspecProperties=version=${{ steps.date.outputs.date }} -p:PackageVersion=${{ steps.date.outputs.date }} NuGet\Zeus.Net.NFe.NFCe\Zeus.Net.NFe.NFCe.csproj
         dotnet pack -o ${{ github.workspace }} -v minimal -c Release -p:NuspecProperties=version=${{ steps.date.outputs.date }} -p:PackageVersion=${{ steps.date.outputs.date }} NuGet\Zeus.Net.MDFe\Zeus.Net.MDFe.csproj
         dotnet pack -o ${{ github.workspace }} -v minimal -c Release -p:NuspecProperties=version=${{ steps.date.outputs.date }} -p:PackageVersion=${{ steps.date.outputs.date }} NuGet\Zeus.Net.CTe\Zeus.Net.CTe.csproj
         
-        Compress-Archive -Path .\path\to\CTeArtefato -DestinationPath ${{ github.workspace }}\CteArtefato.zip
-        Compress-Archive -Path .\path\to\MdfeArtefato -DestinationPath ${{ github.workspace }}\MdfeArtefato.zip
-        Compress-Archive -Path .\path\to\NfeArtefato -DestinationPath ${{ github.workspace }}\NfeArtefato.zip
+        Compress-Archive -Path ./CTeArtefato -DestinationPath ${{ github.workspace }}/CTeArtefato.zip
+        Compress-Archive -Path ./MdfeArtefato -DestinationPath ${{ github.workspace }}/MdfeArtefato.zip
+        Compress-Archive -Path ./NfeArtefato -DestinationPath ${{ github.workspace }}/NfeArtefato.zip
 
     - name: Upload Artifacts
       uses: actions/upload-artifact@v4

--- a/.github/workflows/DFe.NET_build.yml
+++ b/.github/workflows/DFe.NET_build.yml
@@ -131,7 +131,7 @@ jobs:
           -d '{
                 "tag_name": "${{ needs.build.outputs.version }}",
                 "name": "${{ needs.build.outputs.version }}",
-                "body": "Esta é a release da versão ${{ needs.build.outputs.version }} do Zeus DFe.NET.\n\n### Links dos pacotes no NuGet:\n- [Zeus.NFe.NFCe](https://www.nuget.org/packages/Zeus.Net.NFe.NFCe/)\n- [Zeus.MDFe](https://www.nuget.org/packages/Zeus.Net.MDFe/)\n- [Zeus.CTe](https://www.nuget.org/packages/Zeus.Net.CTe/)",
+                "body": "Esta é a release da versão ${{ needs.build.outputs.version }} do Zeus DFe.NET.\n\n### Links dos pacotes no NuGet:\n- [Zeus.NFe.NFCe](https://www.nuget.org/packages/Zeus.Net.NFe.NFCe/${{ needs.build.outputs.version }})\n- [Zeus.MDFe](https://www.nuget.org/packages/Zeus.Net.MDFe/${{ needs.build.outputs.version }})\n- [Zeus.CTe](https://www.nuget.org/packages/Zeus.Net.CTe/${{ needs.build.outputs.version }})",
                 "draft": false,
                 "prerelease": false
               }' \

--- a/.github/workflows/DFe.NET_build.yml
+++ b/.github/workflows/DFe.NET_build.yml
@@ -113,22 +113,12 @@ jobs:
         dotnet pack -o ${{ github.workspace }} -v minimal -c Release -p:NuspecProperties=version=${{ steps.date.outputs.date }} -p:PackageVersion=${{ steps.date.outputs.date }} NuGet\Zeus.Net.NFe.NFCe\Zeus.Net.NFe.NFCe.csproj
         dotnet pack -o ${{ github.workspace }} -v minimal -c Release -p:NuspecProperties=version=${{ steps.date.outputs.date }} -p:PackageVersion=${{ steps.date.outputs.date }} NuGet\Zeus.Net.MDFe\Zeus.Net.MDFe.csproj
         dotnet pack -o ${{ github.workspace }} -v minimal -c Release -p:NuspecProperties=version=${{ steps.date.outputs.date }} -p:PackageVersion=${{ steps.date.outputs.date }} NuGet\Zeus.Net.CTe\Zeus.Net.CTe.csproj
-        
-        Compress-Archive -Path ./CTeArtefato -DestinationPath ${{ github.workspace }}/CTeArtefato.zip
-        Compress-Archive -Path ./MdfeArtefato -DestinationPath ${{ github.workspace }}/MdfeArtefato.zip
-        Compress-Archive -Path ./NfeArtefato -DestinationPath ${{ github.workspace }}/NfeArtefato.zip
 
     - name: Upload Artifacts
       uses: actions/upload-artifact@v4
       with:
         name: nupkg
         path: ${{ github.workspace }}/*.nupkg
-
-    - name: Upload ZIP Files as Assets
-      uses: actions/upload-artifact@v4
-      with:
-        name: zip-artefatos
-        path: ${{ github.workspace }}/*.zip
         
   deploy:
     needs: build
@@ -182,16 +172,6 @@ jobs:
                 "prerelease": false
               }' \
           https://api.github.com/repos/${{ github.repository }}/releases
-  
-      - name: Attach ZIP Files as Assets to Release
-        run: |
-          curl -X POST \
-          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-          -F "file=@${{ github.workspace }}/CteArtefato.zip" \
-          -F "file=@${{ github.workspace }}/MdfeArtefato.zip" \
-          -F "file=@${{ github.workspace }}/NfeArtefato.zip" \
-          -F "file=@${{ github.workspace }}/*.nupkg" \
-          https://uploads.github.com/repos/${{ github.repository }}/releases/${{ steps.create_release.outputs.id }}/assets?name=CteArtefato.zip
 
       - name: Discord notification
         continue-on-error: true

--- a/.github/workflows/DFe.NET_build.yml
+++ b/.github/workflows/DFe.NET_build.yml
@@ -89,6 +89,20 @@ jobs:
     if: github.event_name == 'push' || github.event.inputs.nugetdeploy == 'true'
     runs-on: ${{ 'ubuntu-latest' }}
     steps:
+      - name: Criar Deployment
+        id: create_deployment
+        run: |
+          curl -X POST \
+          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          -d '{
+                "ref": "${{ github.ref }}",
+                "environment": "NuGet",
+                "description": "Deploy de pacotes para o NuGet",
+                "required_contexts": []
+              }' \
+          https://api.github.com/repos/${{ github.repository }}/deployments
+
       - name: Download Artifacts
         uses: actions/download-artifact@v4
         with:
@@ -145,3 +159,17 @@ jobs:
         uses: Ilshidur/action-discord@master
         with:
           args: 'Lançado Zeus DFe.NET versão {{ DISCORD_MENSAGEM }} no Nuget! Acesse: https://www.nuget.org/profiles/ZeusAutomacao'
+
+      - name: Atualizar Status do Deployment
+        if: success()
+        run: |
+          curl -X POST \
+          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          -d '{
+                "state": "success",
+                "environment": "NuGet",
+                "description": "Deploy concluído com sucesso.",
+                "log_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              }' \
+          https://api.github.com/repos/${{ github.repository }}/deployments/${{ steps.create_deployment.outputs.id }}/statuses

--- a/.github/workflows/DFe.NET_build.yml
+++ b/.github/workflows/DFe.NET_build.yml
@@ -71,44 +71,8 @@ jobs:
         
     #- name: Test
     #  run: dotnet test --no-build --verbosity normal
-    
-    - name: Organizar arquivos de artefatos
-      run: |
-        mkdir -p CTeArtefato
-        mkdir -p MdfeArtefato
-        mkdir -p NfeArtefato
 
-        # Organizar arquivos para NFeArtefato
-        cp NuGet/Zeus.Net.NFe.NFCe/Zeus.Net.NFe.NFCe.nuspec NfeArtefato/
-        cp ${{ github.workspace }}/*.nupkg NfeArtefato/
-        mkdir -p NfeArtefato/lib/net40
-        cp NFe.Wsdl/bin/Release/net40/NFe.Wsdl.dll NfeArtefato/lib/net40/
-        cp NFe.Utils/bin/Release/net40/NFe.Utils.dll NfeArtefato/lib/net40/
-        cp NFe.Servicos/bin/Release/net40/NFe.Servicos.dll NfeArtefato/lib/net40/
-        cp NFe.Classes/bin/Release/net40/NFe.Classes.dll NfeArtefato/lib/net40/
-        cp DFe.Classes/bin/Release/net40/DFe.Classes.dll NfeArtefato/lib/net40/
-
-        # Organizar arquivos para MDFeArtefato
-        cp NuGet/Zeus.Net.MDFe/Zeus.Net.MDFe.nuspec MdfeArtefato/
-        cp ${{ github.workspace }}/*.nupkg MdfeArtefato/
-        mkdir -p MdfeArtefato/lib/net40
-        cp MDFe.Wsdl/bin/Release/net40/MDFe.Wsdl.dll MdfeArtefato/lib/net40/
-        cp MDFe.Utils/bin/Release/net40/MDFe.Utils.dll MdfeArtefato/lib/net40/
-        cp MDFe.Servicos/bin/Release/net40/MDFe.Servicos.dll MdfeArtefato/lib/net40/
-        cp MDFe.Classes/bin/Release/net40/MDFe.Classes.dll MdfeArtefato/lib/net40/
-        cp DFe.Classes/bin/Release/net40/DFe.Classes.dll MdfeArtefato/lib/net40/
-
-        # Organizar arquivos para CTeArtefato
-        cp NuGet/Zeus.Net.CTe/Zeus.Net.CTe.nuspec CTeArtefato/
-        cp ${{ github.workspace }}/*.nupkg CTeArtefato/
-        mkdir -p CTeArtefato/lib/net40
-        cp CTe.Wsdl/bin/Release/net40/CTe.Wsdl.dll CTeArtefato/lib/net40/
-        cp CTe.Utils/bin/Release/net40/CTe.Utils.dll CTeArtefato/lib/net40/
-        cp CTe.Servicos/bin/Release/net40/CTe.Servicos.dll CTeArtefato/lib/net40/
-        cp CTe.Classes/bin/Release/net40/CTe.Classes.dll CTeArtefato/lib/net40/
-        cp DFe.Classes/bin/Release/net40/DFe.Classes.dll CTeArtefato/lib/net40/
-
-    - name: Packe e compactar artefatos
+    - name: Packe
       run: | 
         dotnet pack -o ${{ github.workspace }} -v minimal -c Release -p:NuspecProperties=version=${{ steps.date.outputs.date }} -p:PackageVersion=${{ steps.date.outputs.date }} NuGet\Zeus.Net.NFe.NFCe\Zeus.Net.NFe.NFCe.csproj
         dotnet pack -o ${{ github.workspace }} -v minimal -c Release -p:NuspecProperties=version=${{ steps.date.outputs.date }} -p:PackageVersion=${{ steps.date.outputs.date }} NuGet\Zeus.Net.MDFe\Zeus.Net.MDFe.csproj

--- a/.github/workflows/DFe.NET_build.yml
+++ b/.github/workflows/DFe.NET_build.yml
@@ -89,20 +89,6 @@ jobs:
     if: github.event_name == 'push' || github.event.inputs.nugetdeploy == 'true'
     runs-on: ${{ 'ubuntu-latest' }}
     steps:
-      - name: Criar Deployment
-        id: create_deployment
-        run: |
-          curl -X POST \
-          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-          -H "Accept: application/vnd.github.v3+json" \
-          -d '{
-                "ref": "${{ github.ref }}",
-                "environment": "NuGet",
-                "description": "Deploy de pacotes para o NuGet",
-                "required_contexts": []
-              }' \
-          https://api.github.com/repos/${{ github.repository }}/deployments
-
       - name: Download Artifacts
         uses: actions/download-artifact@v4
         with:
@@ -159,17 +145,3 @@ jobs:
         uses: Ilshidur/action-discord@master
         with:
           args: 'Lançado Zeus DFe.NET versão {{ DISCORD_MENSAGEM }} no Nuget! Acesse: https://www.nuget.org/profiles/ZeusAutomacao'
-
-      - name: Atualizar Status do Deployment
-        if: success()
-        run: |
-          curl -X POST \
-          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-          -H "Accept: application/vnd.github.v3+json" \
-          -d '{
-                "state": "success",
-                "environment": "NuGet",
-                "description": "Deploy concluído com sucesso.",
-                "log_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-              }' \
-          https://api.github.com/repos/${{ github.repository }}/deployments/${{ steps.create_deployment.outputs.id }}/statuses

--- a/.github/workflows/DFe.NET_build.yml
+++ b/.github/workflows/DFe.NET_build.yml
@@ -107,7 +107,36 @@ jobs:
         run: dotnet nuget push *.nupkg -k $NUGET_AUTH_TOKEN -s https://api.nuget.org/v3/index.json
         env:
           NUGET_AUTH_TOKEN: ${{secrets.NUGET_SECRET_DEPLOY}}
-          
+
+      - name: Criar Tag
+        id: create_tag
+        run: |
+          curl -X POST \
+          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          -H "Content-Type: application/json" \
+          -d '{
+                "tag": "${{ needs.build.outputs.version }}",
+                "message": "Release versão ${{ needs.build.outputs.version }}",
+                "object": "${{ github.sha }}",
+                "type": "commit"
+              }' \
+          https://api.github.com/repos/${{ github.repository }}/git/tags
+
+      - name: Criar Release
+        id: create_release
+        run: |
+          curl -X POST \
+          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          -H "Content-Type: application/json" \
+          -d '{
+                "tag_name": "${{ needs.build.outputs.version }}",
+                "name": "${{ needs.build.outputs.version }}",
+                "body": "Esta é a release da versão ${{ needs.build.outputs.version }} do Zeus DFe.NET.",
+                "draft": false,
+                "prerelease": false
+              }' \
+          https://api.github.com/repos/${{ github.repository }}/releases
+
       - name: Discord notification
         continue-on-error: true
         env:

--- a/.github/workflows/DFe.NET_build.yml
+++ b/.github/workflows/DFe.NET_build.yml
@@ -78,9 +78,9 @@ jobs:
         dotnet pack -o ${{ github.workspace }} -v minimal -c Release -p:NuspecProperties=version=${{ steps.date.outputs.date }} -p:PackageVersion=${{ steps.date.outputs.date }} NuGet\Zeus.Net.MDFe\Zeus.Net.MDFe.csproj
         dotnet pack -o ${{ github.workspace }} -v minimal -c Release -p:NuspecProperties=version=${{ steps.date.outputs.date }} -p:PackageVersion=${{ steps.date.outputs.date }} NuGet\Zeus.Net.CTe\Zeus.Net.CTe.csproj
         
-        zip -r ${{ github.workspace }}/CteArtefato.zip .\path\to\CTeArtefato
-        zip -r ${{ github.workspace }}/MdfeArtefato.zip .\path\to\MdfeArtefato
-        zip -r ${{ github.workspace }}/NfeArtefato.zip .\path\to\NfeArtefato
+        Compress-Archive -Path .\path\to\CTeArtefato -DestinationPath ${{ github.workspace }}\CteArtefato.zip
+        Compress-Archive -Path .\path\to\MdfeArtefato -DestinationPath ${{ github.workspace }}\MdfeArtefato.zip
+        Compress-Archive -Path .\path\to\NfeArtefato -DestinationPath ${{ github.workspace }}\NfeArtefato.zip
 
     - name: Upload Artifacts
       uses: actions/upload-artifact@v4

--- a/.github/workflows/DFe.NET_build.yml
+++ b/.github/workflows/DFe.NET_build.yml
@@ -72,7 +72,7 @@ jobs:
     #- name: Test
     #  run: dotnet test --no-build --verbosity normal
 
-    - name: Packe
+    - name: Pack
       run: | 
         dotnet pack -o ${{ github.workspace }} -v minimal -c Release -p:NuspecProperties=version=${{ steps.date.outputs.date }} -p:PackageVersion=${{ steps.date.outputs.date }} NuGet\Zeus.Net.NFe.NFCe\Zeus.Net.NFe.NFCe.csproj
         dotnet pack -o ${{ github.workspace }} -v minimal -c Release -p:NuspecProperties=version=${{ steps.date.outputs.date }} -p:PackageVersion=${{ steps.date.outputs.date }} NuGet\Zeus.Net.MDFe\Zeus.Net.MDFe.csproj

--- a/.github/workflows/DFe.NET_build.yml
+++ b/.github/workflows/DFe.NET_build.yml
@@ -131,7 +131,7 @@ jobs:
           -d '{
                 "tag_name": "${{ needs.build.outputs.version }}",
                 "name": "${{ needs.build.outputs.version }}",
-                "body": "Esta é a release da versão ${{ needs.build.outputs.version }} do Zeus DFe.NET.",
+                "body": "Esta é a release da versão ${{ needs.build.outputs.version }} do Zeus DFe.NET.\n\n### Links dos pacotes no NuGet:\n- [Zeus.NFe.NFCe](https://www.nuget.org/packages/Zeus.Net.NFe.NFCe/)\n- [Zeus.MDFe](https://www.nuget.org/packages/Zeus.Net.MDFe/)\n- [Zeus.CTe](https://www.nuget.org/packages/Zeus.Net.CTe/)",
                 "draft": false,
                 "prerelease": false
               }' \


### PR DESCRIPTION
Implementa a criação automática de tags e releases durante a execução do pipeline no GitHub Actions.

O que foi feito:
- Adicionada etapa no job de deploy para:
  1. Criar uma tag no repositório com a versão gerada pelo pipeline.
  2. Criar uma release associada à tag, contendo:
      - Título e descrição formatados.
      - Links para os pacotes NuGet correspondentes às versões publicadas.