### PR TITLE
bugfix: ajuste na impressão dos documentos fiscais do MDFe para evitar sobreposição com observação

### DIFF
--- a/MDFe.Damdfe.Base/MDFe/MDFeRetrato.frx
+++ b/MDFe.Damdfe.Base/MDFe/MDFeRetrato.frx
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Report ScriptLanguage="CSharp" ReferencedAssemblies="System.dll&#13;&#10;System.Drawing.dll&#13;&#10;System.Windows.Forms.dll&#13;&#10;System.Data.dll&#13;&#10;System.Xml.dll&#13;&#10;MDFe.Classes.dll&#13;&#10;DFe.Classes.dll&#13;&#10;MDFe.Utils.dll" ReportInfo.Created="01/12/2017 09:00:32" ReportInfo.Modified="11/25/2024 15:15:33" ReportInfo.CreatorVersion="2023.3.0.0">
+<Report ScriptLanguage="CSharp" ReferencedAssemblies="System.dll&#13;&#10;System.Drawing.dll&#13;&#10;System.Windows.Forms.dll&#13;&#10;System.Data.dll&#13;&#10;System.Xml.dll&#13;&#10;MDFe.Classes.dll&#13;&#10;DFe.Classes.dll&#13;&#10;MDFe.Utils.dll" ReportInfo.Created="01/12/2017 09:00:32" ReportInfo.Modified="04/28/2025 15:07:12" ReportInfo.CreatorVersion="2022.2.9.0">
   <ScriptText>using System;
 using System.IO;
 using System.Collections;
@@ -295,54 +295,54 @@ namespace FastReport
 }
 </ScriptText>
   <Dictionary>
-    <BusinessObjectDataSource Name="MDFeProcMDFe" ReferenceName="MDFeProcMDFe" DataType="System.Int32" Enabled="true">
-      <Column Name="Versao" DataType="System.Int32"/>
-      <Column Name="MDFe" DataType="System.Int32">
-        <Column Name="InfMDFe" DataType="System.Int32">
-          <Column Name="Versao" DataType="System.Int32"/>
+    <BusinessObjectDataSource Name="MDFeProcMDFe" ReferenceName="MDFeProcMDFe" DataType="MDFe.Classes.Retorno.MDFeProcMDFe[], MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" Enabled="true">
+      <Column Name="Versao" DataType="MDFe.Utils.Flags.VersaoServico, MDFe.Utils, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"/>
+      <Column Name="MDFe" DataType="MDFe.Classes.Informacoes.MDFe, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+        <Column Name="InfMDFe" DataType="MDFe.Classes.Informacoes.MDFeInfMDFe, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+          <Column Name="Versao" DataType="MDFe.Utils.Flags.VersaoServico, MDFe.Utils, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"/>
           <Column Name="Id" DataType="System.String"/>
-          <Column Name="Ide" DataType="System.Int32">
-            <Column Name="CUF" DataType="System.Int32"/>
-            <Column Name="TpAmb" DataType="System.Int32"/>
-            <Column Name="TpEmit" DataType="System.Int32"/>
-            <Column Name="TpTransp" DataType="System.Int32"/>
+          <Column Name="Ide" DataType="MDFe.Classes.Informacoes.MDFeIde, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+            <Column Name="CUF" DataType="DFe.Classes.Entidades.Estado, DFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"/>
+            <Column Name="TpAmb" DataType="DFe.Classes.Flags.TipoAmbiente, DFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"/>
+            <Column Name="TpEmit" DataType="MDFe.Classes.Flags.MDFeTipoEmitente, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"/>
+            <Column Name="TpTransp" DataType="System.Nullable`1[[MDFe.Classes.Flags.MDFeTpTransp, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]"/>
             <Column Name="TpTranspSpecified" DataType="System.Boolean" BindableControl="CheckBox"/>
-            <Column Name="Mod" DataType="System.Int32"/>
+            <Column Name="Mod" DataType="DFe.Classes.Flags.ModeloDocumento, DFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"/>
             <Column Name="Serie" DataType="System.Int16"/>
             <Column Name="NMDF" DataType="System.Int64"/>
             <Column Name="CMDF" DataType="System.Int32"/>
             <Column Name="ProxyCMDF" DataType="System.String"/>
             <Column Name="CDV" DataType="System.Byte"/>
-            <Column Name="Modal" DataType="System.Int32"/>
+            <Column Name="Modal" DataType="MDFe.Classes.Flags.MDFeModal, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"/>
             <Column Name="DhEmi" DataType="System.DateTime"/>
             <Column Name="ProxyDhEmi" DataType="System.String"/>
-            <Column Name="TpEmis" DataType="System.Int32"/>
-            <Column Name="ProcEmi" DataType="System.Int32"/>
+            <Column Name="TpEmis" DataType="MDFe.Classes.Flags.MDFeTipoEmissao, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"/>
+            <Column Name="ProcEmi" DataType="MDFe.Classes.Flags.MDFeIdentificacaoProcessoEmissao, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"/>
             <Column Name="VerProc" DataType="System.String"/>
-            <Column Name="UFIni" DataType="System.Int32"/>
+            <Column Name="UFIni" DataType="DFe.Classes.Entidades.Estado, DFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"/>
             <Column Name="ProxyUFIni" DataType="System.String"/>
-            <Column Name="UFFim" DataType="System.Int32"/>
+            <Column Name="UFFim" DataType="DFe.Classes.Entidades.Estado, DFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"/>
             <Column Name="ProxyUFFim" DataType="System.String"/>
-            <BusinessObjectDataSource Name="BusinessObjectDataSource1" Alias="InfMunCarrega" DataType="System.Int32" PropName="InfMunCarrega" Enabled="true">
+            <BusinessObjectDataSource Name="BusinessObjectDataSource1" Alias="InfMunCarrega" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeInfMunCarrega, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]" PropName="InfMunCarrega" Enabled="true">
               <Column Name="CMunCarrega" DataType="System.String"/>
               <Column Name="XMunCarrega" DataType="System.String"/>
             </BusinessObjectDataSource>
-            <BusinessObjectDataSource Name="BusinessObjectDataSource2" Alias="InfPercurso" DataType="System.Int32" PropName="InfPercurso" Enabled="true">
-              <Column Name="UFPer" DataType="System.Int32"/>
+            <BusinessObjectDataSource Name="BusinessObjectDataSource2" Alias="InfPercurso" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeInfPercurso, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]" PropName="InfPercurso" Enabled="true">
+              <Column Name="UFPer" DataType="DFe.Classes.Entidades.Estado, DFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"/>
               <Column Name="ProxyUFPer" DataType="System.String"/>
             </BusinessObjectDataSource>
-            <Column Name="DhIniViagem" DataType="System.Int32"/>
+            <Column Name="DhIniViagem" DataType="System.Nullable`1[[System.DateTime, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
             <Column Name="ProxyDhIniViagem" DataType="System.String"/>
             <Column Name="IndCanalVerde" DataType="System.String"/>
             <Column Name="IndCarregaPosterior" DataType="System.String"/>
           </Column>
-          <Column Name="Emit" DataType="System.Int32">
+          <Column Name="Emit" DataType="MDFe.Classes.Informacoes.MDFeEmit, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
             <Column Name="CNPJ" DataType="System.String"/>
             <Column Name="CPF" DataType="System.String"/>
             <Column Name="IE" DataType="System.String"/>
             <Column Name="XNome" DataType="System.String"/>
             <Column Name="XFant" DataType="System.String"/>
-            <Column Name="EnderEmit" DataType="System.Int32">
+            <Column Name="EnderEmit" DataType="MDFe.Classes.Informacoes.MDFeEnderEmit, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
               <Column Name="XLgr" DataType="System.String"/>
               <Column Name="Nro" DataType="System.String"/>
               <Column Name="XCpl" DataType="System.String"/>
@@ -351,128 +351,128 @@ namespace FastReport
               <Column Name="XMun" DataType="System.String"/>
               <Column Name="CEP" DataType="System.Int64"/>
               <Column Name="ProxyCEP" DataType="System.String"/>
-              <Column Name="UF" DataType="System.Int32"/>
+              <Column Name="UF" DataType="DFe.Classes.Entidades.Estado, DFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"/>
               <Column Name="ProxyUF" DataType="System.String"/>
               <Column Name="Fone" DataType="System.String"/>
               <Column Name="Email" DataType="System.String"/>
             </Column>
           </Column>
-          <Column Name="InfModal" DataType="System.Int32">
-            <Column Name="VersaoModal" DataType="System.Int32"/>
-            <Column Name="Modal" DataType="System.Int32">
-              <Column Name="InfANTT" DataType="System.Int32">
+          <Column Name="InfModal" DataType="MDFe.Classes.Informacoes.MDFeInfModal, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+            <Column Name="VersaoModal" DataType="MDFe.Classes.Flags.MDFeVersaoModal, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"/>
+            <Column Name="Modal" DataType="MDFe.Classes.Contratos.MDFeModalContainer, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+              <Column Name="InfANTT" DataType="MDFe.Classes.Informacoes.MDFeInfANTT, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
                 <Column Name="RNTRC" DataType="System.String"/>
-                <Column Name="ValePed" DataType="System.Int32">
-                  <Column Name="CategCombVeic" DataType="System.Int32"/>
+                <Column Name="ValePed" DataType="MDFe.Classes.Informacoes.MDFeValePed, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+                  <Column Name="CategCombVeic" DataType="System.Nullable`1[[MDFe.Classes.Flags.MDFeCategCombVeic, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]"/>
                   <Column Name="CategCombVeicSpecified" DataType="System.Boolean" BindableControl="CheckBox"/>
-                  <BusinessObjectDataSource Name="BusinessObjectDataSource21" Alias="Disp" Enabled="false" DataType="System.Int32" PropName="Disp"/>
+                  <BusinessObjectDataSource Name="BusinessObjectDataSource21" Alias="Disp" Enabled="false" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeDisp, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]" PropName="Disp"/>
                 </Column>
-                <BusinessObjectDataSource Name="BusinessObjectDataSource20" Alias="InfCIOT" Enabled="false" DataType="System.Int32" PropName="InfCIOT"/>
-                <BusinessObjectDataSource Name="BusinessObjectDataSource22" Alias="InfContratante" Enabled="false" DataType="System.Int32" PropName="InfContratante"/>
-                <BusinessObjectDataSource Name="BusinessObjectDataSource23" Alias="InfPag" Enabled="false" DataType="System.Int32" PropName="InfPag"/>
+                <BusinessObjectDataSource Name="BusinessObjectDataSource20" Alias="InfCIOT" Enabled="false" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.infCIOT, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]" PropName="InfCIOT"/>
+                <BusinessObjectDataSource Name="BusinessObjectDataSource22" Alias="InfContratante" Enabled="false" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeInfContratante, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]" PropName="InfContratante"/>
+                <BusinessObjectDataSource Name="BusinessObjectDataSource23" Alias="InfPag" Enabled="false" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeInfPag, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]" PropName="InfPag"/>
               </Column>
               <Column Name="RNTRC" DataType="System.String"/>
               <Column Name="CIOT" DataType="System.String"/>
-              <Column Name="VeicTracao" DataType="System.Int32">
+              <Column Name="VeicTracao" DataType="MDFe.Classes.Informacoes.MDFeVeicTracao, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
                 <Column Name="CInt" DataType="System.String"/>
                 <Column Name="Placa" DataType="System.String"/>
                 <Column Name="RENAVAM" DataType="System.String"/>
-                <Column Name="Tara" DataType="System.Int32"/>
-                <Column Name="CapKG" DataType="System.Int32"/>
-                <Column Name="CapM3" DataType="System.Int32"/>
-                <Column Name="Prop" DataType="System.Int32">
+                <Column Name="Tara" DataType="System.Nullable`1[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
+                <Column Name="CapKG" DataType="System.Nullable`1[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
+                <Column Name="CapM3" DataType="System.Nullable`1[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
+                <Column Name="Prop" DataType="MDFe.Classes.Informacoes.MDFeProp, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
                   <Column Name="CPF" DataType="System.String"/>
                   <Column Name="CNPJ" DataType="System.String"/>
                   <Column Name="RNTRC" DataType="System.String"/>
                   <Column Name="XNome" DataType="System.String"/>
                   <Column Name="IE" DataType="System.String"/>
-                  <Column Name="UF" DataType="System.Int32"/>
+                  <Column Name="UF" DataType="DFe.Classes.Entidades.Estado, DFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"/>
                   <Column Name="ProxyUF" DataType="System.String"/>
-                  <Column Name="MDFeTpProp" DataType="System.Int32"/>
+                  <Column Name="MDFeTpProp" DataType="MDFe.Classes.Flags.MDFeTpProp, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"/>
                 </Column>
-                <BusinessObjectDataSource Name="BusinessObjectDataSource19" Alias="Condutor" DataType="System.Int32" PropName="Condutor" Enabled="true">
+                <BusinessObjectDataSource Name="BusinessObjectDataSource19" Alias="Condutor" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeCondutor, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]" PropName="Condutor" Enabled="true">
                   <Column Name="XNome" DataType="System.String"/>
                   <Column Name="CPF" DataType="System.String"/>
                 </BusinessObjectDataSource>
-                <Column Name="TpRod" DataType="System.Int32"/>
-                <Column Name="TpCar" DataType="System.Int32"/>
-                <Column Name="UF" DataType="System.Int32"/>
+                <Column Name="TpRod" DataType="MDFe.Classes.Flags.MDFeTpRod, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"/>
+                <Column Name="TpCar" DataType="MDFe.Classes.Flags.MDFeTpCar, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"/>
+                <Column Name="UF" DataType="System.Nullable`1[[DFe.Classes.Entidades.Estado, DFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]"/>
                 <Column Name="ProxyUF" DataType="System.String"/>
                 <Column Name="CapKGSpecified" DataType="System.Boolean" BindableControl="CheckBox"/>
                 <Column Name="CapM3Specified" DataType="System.Boolean" BindableControl="CheckBox"/>
                 <Column Name="TaraSpecified" DataType="System.Boolean" BindableControl="CheckBox"/>
               </Column>
-              <BusinessObjectDataSource Name="BusinessObjectDataSource8" Alias="VeicReboque" DataType="System.Int32" PropName="VeicReboque" Enabled="true">
+              <BusinessObjectDataSource Name="BusinessObjectDataSource8" Alias="VeicReboque" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeVeicReboque, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]" PropName="VeicReboque" Enabled="true">
                 <Column Name="CInt" DataType="System.String"/>
                 <Column Name="Placa" DataType="System.String"/>
                 <Column Name="RENAVAM" DataType="System.String"/>
-                <Column Name="Tara" DataType="System.Int32"/>
-                <Column Name="CapKG" DataType="System.Int32"/>
-                <Column Name="CapM3" DataType="System.Int32"/>
-                <Column Name="Prop" DataType="System.Int32">
+                <Column Name="Tara" DataType="System.Nullable`1[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
+                <Column Name="CapKG" DataType="System.Nullable`1[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
+                <Column Name="CapM3" DataType="System.Nullable`1[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
+                <Column Name="Prop" DataType="MDFe.Classes.Informacoes.MDFeProp, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
                   <Column Name="CPF" DataType="System.String"/>
                   <Column Name="CNPJ" DataType="System.String"/>
                   <Column Name="RNTRC" DataType="System.String"/>
                   <Column Name="XNome" DataType="System.String"/>
                   <Column Name="IE" DataType="System.String"/>
-                  <Column Name="UF" DataType="System.Int32"/>
+                  <Column Name="UF" DataType="DFe.Classes.Entidades.Estado, DFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"/>
                   <Column Name="ProxyUF" DataType="System.String"/>
-                  <Column Name="MDFeTpProp" DataType="System.Int32"/>
+                  <Column Name="MDFeTpProp" DataType="MDFe.Classes.Flags.MDFeTpProp, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"/>
                 </Column>
-                <Column Name="TpCar" DataType="System.Int32"/>
-                <Column Name="UF" DataType="System.Int32"/>
+                <Column Name="TpCar" DataType="MDFe.Classes.Flags.MDFeTpCar, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"/>
+                <Column Name="UF" DataType="System.Nullable`1[[DFe.Classes.Entidades.Estado, DFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]"/>
                 <Column Name="ProxyUF" DataType="System.String"/>
                 <Column Name="TaraSpecified" DataType="System.Boolean" BindableControl="CheckBox"/>
                 <Column Name="CapKGSpecified" DataType="System.Boolean" BindableControl="CheckBox"/>
                 <Column Name="CapM3Specified" DataType="System.Boolean" BindableControl="CheckBox"/>
               </BusinessObjectDataSource>
-              <Column Name="ValePed" DataType="System.Int32">
-                <BusinessObjectDataSource Name="BusinessObjectDataSource9" Alias="Disp" DataType="System.Int32" PropName="Disp" Enabled="true">
+              <Column Name="ValePed" DataType="MDFe.Classes.Informacoes.MDFeValePed, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+                <BusinessObjectDataSource Name="BusinessObjectDataSource9" Alias="Disp" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeDisp, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]" PropName="Disp" Enabled="true">
                   <Column Name="CNPJForn" DataType="System.String"/>
                   <Column Name="CNPJPg" DataType="System.String"/>
                   <Column Name="CPFPg" DataType="System.String"/>
                   <Column Name="NCompra" DataType="System.String"/>
-                  <Column Name="vValePed" DataType="System.Decimal"/>
-                  <Column Name="TpValePed" DataType="System.Int32"/>
+                  <Column Name="TpValePed" DataType="System.Nullable`1[[MDFe.Classes.Informacoes.MDFeTpValePed, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]"/>
                   <Column Name="TpValePedSpecified" DataType="System.Boolean" BindableControl="CheckBox"/>
+                  <Column Name="VValePed" DataType="System.Decimal"/>
                 </BusinessObjectDataSource>
-                <Column Name="CategCombVeic" DataType="System.Int32"/>
+                <Column Name="CategCombVeic" DataType="System.Nullable`1[[MDFe.Classes.Flags.MDFeCategCombVeic, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]"/>
                 <Column Name="CategCombVeicSpecified" DataType="System.Boolean" BindableControl="CheckBox"/>
               </Column>
               <Column Name="CodAgPorto" DataType="System.String"/>
-              <BusinessObjectDataSource Name="BusinessObjectDataSource10" Alias="LacRodo" DataType="System.Int32" PropName="LacRodo" Enabled="true">
+              <BusinessObjectDataSource Name="BusinessObjectDataSource10" Alias="LacRodo" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeLacre, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]" PropName="LacRodo" Enabled="true">
                 <Column Name="NLacre" DataType="System.String"/>
               </BusinessObjectDataSource>
             </Column>
           </Column>
-          <Column Name="InfDoc" DataType="System.Int32">
-            <BusinessObjectDataSource Name="BusinessObjectDataSource11" Alias="InfMunDescarga" DataType="System.Int32" PropName="InfMunDescarga" Enabled="true">
+          <Column Name="InfDoc" DataType="MDFe.Classes.Informacoes.MDFeInfDoc, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+            <BusinessObjectDataSource Name="BusinessObjectDataSource11" Alias="InfMunDescarga" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeInfMunDescarga, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]" PropName="InfMunDescarga" Enabled="true">
               <Column Name="CMunDescarga" DataType="System.String"/>
               <Column Name="XMunDescarga" DataType="System.String"/>
-              <BusinessObjectDataSource Name="InfCTe" DataType="System.Int32" Enabled="true">
+              <BusinessObjectDataSource Name="InfCTe" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeInfCTe, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
                 <Column Name="ChCTe" DataType="System.String"/>
                 <Column Name="SegCodBarra" DataType="System.String"/>
-                <Column Name="IndReentrega" DataType="System.Int32"/>
+                <Column Name="IndReentrega" DataType="System.Nullable`1[[System.Byte, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
                 <Column Name="IndReentregaSpecified" DataType="System.Boolean" BindableControl="CheckBox"/>
-                <BusinessObjectDataSource Name="InfUnidTransps" DataType="System.Int32" Enabled="true">
-                  <Column Name="TpUnidTransp" DataType="System.Int32"/>
+                <BusinessObjectDataSource Name="InfUnidTransps" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeInfUnidTransp, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
+                  <Column Name="TpUnidTransp" DataType="MDFe.Classes.Flags.MDFeTpUnidTransp, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"/>
                   <Column Name="IdUnidTransp" DataType="System.String"/>
-                  <BusinessObjectDataSource Name="LacUnidTransps" DataType="System.Int32" Enabled="true">
+                  <BusinessObjectDataSource Name="LacUnidTransps" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeLacUnidTransp, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
                     <Column Name="NLacre" DataType="System.String"/>
                   </BusinessObjectDataSource>
-                  <BusinessObjectDataSource Name="InfUnidCargas" DataType="System.Int32" Enabled="true">
-                    <Column Name="TpUnidCarga" DataType="System.Int32"/>
+                  <BusinessObjectDataSource Name="InfUnidCargas" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeInfUnidCarga, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
+                    <Column Name="TpUnidCarga" DataType="MDFe.Classes.Flags.MDFeTpUnidCarga, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"/>
                     <Column Name="IdUnidCarga" DataType="System.String"/>
-                    <BusinessObjectDataSource Name="LacUnidCargas" DataType="System.Int32" Enabled="true">
+                    <BusinessObjectDataSource Name="LacUnidCargas" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeLacUnidCarga, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
                       <Column Name="NLacre" DataType="System.String"/>
                     </BusinessObjectDataSource>
-                    <Column Name="QtdRat" DataType="System.Int32"/>
+                    <Column Name="QtdRat" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
                     <Column Name="QtdRatSpecified" DataType="System.Boolean" BindableControl="CheckBox"/>
                   </BusinessObjectDataSource>
-                  <Column Name="QtdRat" DataType="System.Int32"/>
+                  <Column Name="QtdRat" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
                   <Column Name="QtdRatSpecified" DataType="System.Boolean" BindableControl="CheckBox"/>
                 </BusinessObjectDataSource>
-                <BusinessObjectDataSource Name="Peri" DataType="System.Int32" Enabled="true">
+                <BusinessObjectDataSource Name="Peri" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFePeri, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
                   <Column Name="NONU" DataType="System.String"/>
                   <Column Name="XNomeAE" DataType="System.String"/>
                   <Column Name="XClaRisco" DataType="System.String"/>
@@ -480,35 +480,35 @@ namespace FastReport
                   <Column Name="QTotProd" DataType="System.String"/>
                   <Column Name="QVolTipo" DataType="System.String"/>
                 </BusinessObjectDataSource>
-                <Column Name="InfEntregaParcial" DataType="System.Int32">
+                <Column Name="InfEntregaParcial" DataType="MDFe.Classes.Informacoes.MDFeInfEntregaParcial, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
                   <Column Name="QtdTotal" DataType="System.Decimal"/>
                   <Column Name="QtdParcial" DataType="System.Decimal"/>
                 </Column>
               </BusinessObjectDataSource>
-              <BusinessObjectDataSource Name="InfNFe" DataType="System.Int32" Enabled="true">
+              <BusinessObjectDataSource Name="InfNFe" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeInfNFe, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
                 <Column Name="ChNFe" DataType="System.String"/>
                 <Column Name="SegCodBarra" DataType="System.String"/>
-                <Column Name="IndReentrega" DataType="System.Int32"/>
+                <Column Name="IndReentrega" DataType="System.Nullable`1[[System.Byte, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
                 <Column Name="IndReentregaSpecified" DataType="System.Boolean" BindableControl="CheckBox"/>
-                <BusinessObjectDataSource Name="InfUnidTransps1" Alias="InfUnidTransps" DataType="System.Int32" PropName="InfUnidTransps" Enabled="true">
-                  <Column Name="TpUnidTransp" DataType="System.Int32"/>
+                <BusinessObjectDataSource Name="InfUnidTransps1" Alias="InfUnidTransps" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeInfUnidTransp, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]" PropName="InfUnidTransps" Enabled="true">
+                  <Column Name="TpUnidTransp" DataType="MDFe.Classes.Flags.MDFeTpUnidTransp, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"/>
                   <Column Name="IdUnidTransp" DataType="System.String"/>
-                  <BusinessObjectDataSource Name="LacUnidTransps1" Alias="LacUnidTransps" DataType="System.Int32" PropName="LacUnidTransps" Enabled="true">
+                  <BusinessObjectDataSource Name="LacUnidTransps1" Alias="LacUnidTransps" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeLacUnidTransp, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]" PropName="LacUnidTransps" Enabled="true">
                     <Column Name="NLacre" DataType="System.String"/>
                   </BusinessObjectDataSource>
-                  <BusinessObjectDataSource Name="InfUnidCargas1" Alias="InfUnidCargas" DataType="System.Int32" PropName="InfUnidCargas" Enabled="true">
-                    <Column Name="TpUnidCarga" DataType="System.Int32"/>
+                  <BusinessObjectDataSource Name="InfUnidCargas1" Alias="InfUnidCargas" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeInfUnidCarga, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]" PropName="InfUnidCargas" Enabled="true">
+                    <Column Name="TpUnidCarga" DataType="MDFe.Classes.Flags.MDFeTpUnidCarga, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"/>
                     <Column Name="IdUnidCarga" DataType="System.String"/>
-                    <BusinessObjectDataSource Name="LacUnidCargas1" Alias="LacUnidCargas" DataType="System.Int32" PropName="LacUnidCargas" Enabled="true">
+                    <BusinessObjectDataSource Name="LacUnidCargas1" Alias="LacUnidCargas" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeLacUnidCarga, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]" PropName="LacUnidCargas" Enabled="true">
                       <Column Name="NLacre" DataType="System.String"/>
                     </BusinessObjectDataSource>
-                    <Column Name="QtdRat" DataType="System.Int32"/>
+                    <Column Name="QtdRat" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
                     <Column Name="QtdRatSpecified" DataType="System.Boolean" BindableControl="CheckBox"/>
                   </BusinessObjectDataSource>
-                  <Column Name="QtdRat" DataType="System.Int32"/>
+                  <Column Name="QtdRat" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
                   <Column Name="QtdRatSpecified" DataType="System.Boolean" BindableControl="CheckBox"/>
                 </BusinessObjectDataSource>
-                <BusinessObjectDataSource Name="Peri1" Alias="Peri" DataType="System.Int32" PropName="Peri" Enabled="true">
+                <BusinessObjectDataSource Name="Peri1" Alias="Peri" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFePeri, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]" PropName="Peri" Enabled="true">
                   <Column Name="NONU" DataType="System.String"/>
                   <Column Name="XNomeAE" DataType="System.String"/>
                   <Column Name="XClaRisco" DataType="System.String"/>
@@ -517,29 +517,29 @@ namespace FastReport
                   <Column Name="QVolTipo" DataType="System.String"/>
                 </BusinessObjectDataSource>
               </BusinessObjectDataSource>
-              <BusinessObjectDataSource Name="InfMdFeTransps" DataType="System.Int32" Enabled="true">
+              <BusinessObjectDataSource Name="InfMdFeTransps" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeInfMDFeTransp, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
                 <Column Name="ChMDFe" DataType="System.String"/>
-                <Column Name="IndReentrega" DataType="System.Int32"/>
+                <Column Name="IndReentrega" DataType="System.Nullable`1[[System.Byte, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
                 <Column Name="IndReentregaSpecified" DataType="System.Boolean" BindableControl="CheckBox"/>
-                <BusinessObjectDataSource Name="InfUnidTransp" DataType="System.Int32" Enabled="true">
-                  <Column Name="TpUnidTransp" DataType="System.Int32"/>
+                <BusinessObjectDataSource Name="InfUnidTransp" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeInfUnidTransp, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]" Enabled="true">
+                  <Column Name="TpUnidTransp" DataType="MDFe.Classes.Flags.MDFeTpUnidTransp, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"/>
                   <Column Name="IdUnidTransp" DataType="System.String"/>
-                  <BusinessObjectDataSource Name="LacUnidTransps2" Alias="LacUnidTransps" DataType="System.Int32" PropName="LacUnidTransps" Enabled="true">
+                  <BusinessObjectDataSource Name="LacUnidTransps2" Alias="LacUnidTransps" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeLacUnidTransp, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]" PropName="LacUnidTransps" Enabled="true">
                     <Column Name="NLacre" DataType="System.String"/>
                   </BusinessObjectDataSource>
-                  <BusinessObjectDataSource Name="InfUnidCargas2" Alias="InfUnidCargas" DataType="System.Int32" PropName="InfUnidCargas" Enabled="true">
-                    <Column Name="TpUnidCarga" DataType="System.Int32"/>
+                  <BusinessObjectDataSource Name="InfUnidCargas2" Alias="InfUnidCargas" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeInfUnidCarga, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]" PropName="InfUnidCargas" Enabled="true">
+                    <Column Name="TpUnidCarga" DataType="MDFe.Classes.Flags.MDFeTpUnidCarga, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"/>
                     <Column Name="IdUnidCarga" DataType="System.String"/>
-                    <BusinessObjectDataSource Name="LacUnidCargas2" Alias="LacUnidCargas" DataType="System.Int32" PropName="LacUnidCargas" Enabled="true">
+                    <BusinessObjectDataSource Name="LacUnidCargas2" Alias="LacUnidCargas" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeLacUnidCarga, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]" PropName="LacUnidCargas" Enabled="true">
                       <Column Name="NLacre" DataType="System.String"/>
                     </BusinessObjectDataSource>
-                    <Column Name="QtdRat" DataType="System.Int32"/>
+                    <Column Name="QtdRat" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
                     <Column Name="QtdRatSpecified" DataType="System.Boolean" BindableControl="CheckBox"/>
                   </BusinessObjectDataSource>
-                  <Column Name="QtdRat" DataType="System.Int32"/>
+                  <Column Name="QtdRat" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
                   <Column Name="QtdRatSpecified" DataType="System.Boolean" BindableControl="CheckBox"/>
                 </BusinessObjectDataSource>
-                <BusinessObjectDataSource Name="Peri2" Alias="Peri" DataType="System.Int32" PropName="Peri" Enabled="true">
+                <BusinessObjectDataSource Name="Peri2" Alias="Peri" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFePeri, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]" PropName="Peri" Enabled="true">
                   <Column Name="NONU" DataType="System.String"/>
                   <Column Name="XNomeAE" DataType="System.String"/>
                   <Column Name="XClaRisco" DataType="System.String"/>
@@ -550,104 +550,104 @@ namespace FastReport
               </BusinessObjectDataSource>
             </BusinessObjectDataSource>
           </Column>
-          <BusinessObjectDataSource Name="BusinessObjectDataSource12" Alias="Seg" DataType="System.Int32" PropName="Seg" Enabled="true">
-            <Column Name="InfResp" DataType="System.Int32">
-              <Column Name="RespSeg" DataType="System.Int32"/>
+          <BusinessObjectDataSource Name="BusinessObjectDataSource12" Alias="Seg" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeSeg, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]" PropName="Seg" Enabled="true">
+            <Column Name="InfResp" DataType="MDFe.Classes.Informacoes.MDFeInfResp, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+              <Column Name="RespSeg" DataType="MDFe.Classes.Flags.MDFeRespSeg, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"/>
               <Column Name="CNPJ" DataType="System.String"/>
               <Column Name="CPF" DataType="System.String"/>
             </Column>
-            <Column Name="InfSeg" DataType="System.Int32">
+            <Column Name="InfSeg" DataType="MDFe.Classes.Informacoes.MDFeInfSeg, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
               <Column Name="XSeg" DataType="System.String"/>
               <Column Name="CNPJ" DataType="System.String"/>
             </Column>
             <Column Name="NApol" DataType="System.String"/>
-            <BusinessObjectDataSource Name="NAver" DataType="System.Int32" Enabled="true">
+            <BusinessObjectDataSource Name="NAver" DataType="System.Collections.Generic.List`1[[System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]" Enabled="true">
               <Column Name="Length" DataType="System.Int32"/>
             </BusinessObjectDataSource>
           </BusinessObjectDataSource>
-          <Column Name="ProdPred" DataType="System.Int32">
-            <Column Name="TpCarga" DataType="System.Int32"/>
+          <Column Name="ProdPred" DataType="MDFe.Classes.Informacoes.MDFeProdPred, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+            <Column Name="TpCarga" DataType="MDFe.Classes.Flags.MDFeTpCarga, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"/>
             <Column Name="XProd" DataType="System.String"/>
             <Column Name="CEan" DataType="System.String"/>
             <Column Name="Ncm" DataType="System.String"/>
-            <Column Name="InfLotacao" DataType="System.Int32">
-              <Column Name="InfLocalCarrega" DataType="System.Int32">
+            <Column Name="InfLotacao" DataType="MDFe.Classes.Informacoes.MDFeInfLotacao, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+              <Column Name="InfLocalCarrega" DataType="MDFe.Classes.Informacoes.MDFeInfLocalCarrega, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
                 <Column Name="CEP" DataType="System.String"/>
                 <Column Name="LatitudeProxy" DataType="System.String"/>
                 <Column Name="LongitudeProxy" DataType="System.String"/>
               </Column>
-              <Column Name="InfLocalDescarrega" DataType="System.Int32">
+              <Column Name="InfLocalDescarrega" DataType="MDFe.Classes.Informacoes.MDFeInfLocalDescarrega, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
                 <Column Name="CEP" DataType="System.String"/>
                 <Column Name="LatitudeProxy" DataType="System.String"/>
                 <Column Name="LongitudeProxy" DataType="System.String"/>
               </Column>
             </Column>
           </Column>
-          <Column Name="Tot" DataType="System.Int32">
-            <Column Name="QCTe" DataType="System.Int32"/>
-            <Column Name="QNFe" DataType="System.Int32"/>
-            <Column Name="QMDFe" DataType="System.Int32"/>
+          <Column Name="Tot" DataType="MDFe.Classes.Informacoes.MDFeTot, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+            <Column Name="QCTe" DataType="System.Nullable`1[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
+            <Column Name="QNFe" DataType="System.Nullable`1[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
+            <Column Name="QMDFe" DataType="System.Nullable`1[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
             <Column Name="vCarga" DataType="System.Decimal"/>
-            <Column Name="CUnid" DataType="System.Int32"/>
+            <Column Name="CUnid" DataType="MDFe.Classes.Flags.MDFeCUnid, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"/>
             <Column Name="QCarga" DataType="System.Decimal"/>
             <Column Name="QCTeSpecified" DataType="System.Boolean" BindableControl="CheckBox"/>
             <Column Name="QNFeSpecified" DataType="System.Boolean" BindableControl="CheckBox"/>
             <Column Name="QMDFeSpecified" DataType="System.Boolean" BindableControl="CheckBox"/>
           </Column>
-          <BusinessObjectDataSource Name="BusinessObjectDataSource13" Alias="Lacres" DataType="System.Int32" PropName="Lacres" Enabled="true">
+          <BusinessObjectDataSource Name="BusinessObjectDataSource13" Alias="Lacres" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeLacre, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]" PropName="Lacres" Enabled="true">
             <Column Name="NLacre" DataType="System.String"/>
           </BusinessObjectDataSource>
-          <BusinessObjectDataSource Name="BusinessObjectDataSource14" Alias="AutXml" DataType="System.Int32" PropName="AutXml" Enabled="true">
+          <BusinessObjectDataSource Name="BusinessObjectDataSource14" Alias="AutXml" DataType="System.Collections.Generic.List`1[[MDFe.Classes.Informacoes.MDFeAutXML, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]" PropName="AutXml" Enabled="true">
             <Column Name="CNPJ" DataType="System.String"/>
             <Column Name="CPF" DataType="System.String"/>
           </BusinessObjectDataSource>
-          <Column Name="InfAdic" DataType="System.Int32">
+          <Column Name="InfAdic" DataType="MDFe.Classes.Informacoes.MDFeInfAdic, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
             <Column Name="InfAdFisco" DataType="System.String"/>
             <Column Name="InfCpl" DataType="System.String"/>
           </Column>
-          <Column Name="InfRespTec" DataType="System.Int32">
+          <Column Name="InfRespTec" DataType="MDFe.Classes.Informacoes.MDFeInfRespTec, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
             <Column Name="CNPJ" DataType="System.String"/>
             <Column Name="XContato" DataType="System.String"/>
             <Column Name="Email" DataType="System.String"/>
             <Column Name="Fone" DataType="System.String"/>
-            <Column Name="idCSRTSpecified" DataType="System.Boolean" BindableControl="CheckBox"/>
             <Column Name="ProxyIdCSRT" DataType="System.String"/>
             <Column Name="HashCSRT" DataType="System.String"/>
+            <Column Name="IdCSRTSpecified" DataType="System.Boolean" BindableControl="CheckBox"/>
           </Column>
         </Column>
-        <Column Name="InfMDFeSupl" DataType="System.Int32">
+        <Column Name="InfMDFeSupl" DataType="MDFe.Classes.Informacoes.MdfeInfMDFeSupl, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
           <Column Name="QrCodMDFe" DataType="System.String"/>
         </Column>
-        <Column Name="Signature" DataType="System.Int32">
-          <Column Name="SignedInfo" DataType="System.Int32">
-            <Column Name="CanonicalizationMethod" DataType="System.Int32">
+        <Column Name="Signature" DataType="DFe.Classes.Assinatura.Signature, DFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+          <Column Name="SignedInfo" DataType="DFe.Classes.Assinatura.SignedInfo, DFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+            <Column Name="CanonicalizationMethod" DataType="DFe.Classes.Assinatura.CanonicalizationMethod, DFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
               <Column Name="Algorithm" DataType="System.String"/>
             </Column>
-            <Column Name="SignatureMethod" DataType="System.Int32">
+            <Column Name="SignatureMethod" DataType="DFe.Classes.Assinatura.SignatureMethod, DFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
               <Column Name="Algorithm" DataType="System.String"/>
             </Column>
-            <Column Name="Reference" DataType="System.Int32">
+            <Column Name="Reference" DataType="DFe.Classes.Assinatura.Reference, DFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
               <Column Name="URI" DataType="System.String"/>
-              <Column Name="DigestMethod" DataType="System.Int32">
+              <Column Name="DigestMethod" DataType="DFe.Classes.Assinatura.DigestMethod, DFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
                 <Column Name="Algorithm" DataType="System.String"/>
               </Column>
               <Column Name="DigestValue" DataType="System.String"/>
-              <BusinessObjectDataSource Name="BusinessObjectDataSource24" Alias="Transforms" Enabled="false" DataType="System.Int32" PropName="Transforms"/>
+              <BusinessObjectDataSource Name="BusinessObjectDataSource24" Alias="Transforms" Enabled="false" DataType="System.Collections.Generic.List`1[[DFe.Classes.Assinatura.Transform, DFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]" PropName="Transforms"/>
             </Column>
           </Column>
           <Column Name="SignatureValue" DataType="System.String"/>
-          <Column Name="KeyInfo" DataType="System.Int32">
-            <Column Name="X509Data" DataType="System.Int32">
+          <Column Name="KeyInfo" DataType="DFe.Classes.Assinatura.KeyInfo, DFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+            <Column Name="X509Data" DataType="DFe.Classes.Assinatura.X509Data, DFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
               <Column Name="X509Certificate" DataType="System.String"/>
             </Column>
           </Column>
         </Column>
       </Column>
-      <Column Name="ProtMDFe" DataType="System.Int32">
+      <Column Name="ProtMDFe" DataType="MDFe.Classes.Retorno.MDFeRetRecepcao.MDFeProtMDFe, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
         <Column Name="Versao" DataType="System.String"/>
-        <Column Name="InfProt" DataType="System.Int32">
+        <Column Name="InfProt" DataType="MDFe.Classes.Retorno.MDFeRetRecepcao.MDFeInfProtMDFe, MDFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
           <Column Name="Id" DataType="System.String"/>
-          <Column Name="TpAmb" DataType="System.Int32"/>
+          <Column Name="TpAmb" DataType="DFe.Classes.Flags.TipoAmbiente, DFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"/>
           <Column Name="VerAplic" DataType="System.String"/>
           <Column Name="ChMDFe" DataType="System.String"/>
           <Column Name="DhRecbto" DataType="System.DateTime"/>
@@ -655,26 +655,26 @@ namespace FastReport
           <Column Name="DigVal" DataType="System.String"/>
           <Column Name="CStat" DataType="System.Int16"/>
           <Column Name="XMotivo" DataType="System.String"/>
-          <Column Name="Signature" DataType="System.Int32">
-            <Column Name="SignedInfo" DataType="System.Int32">
-              <Column Name="CanonicalizationMethod" DataType="System.Int32">
+          <Column Name="Signature" DataType="DFe.Classes.Assinatura.Signature, DFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+            <Column Name="SignedInfo" DataType="DFe.Classes.Assinatura.SignedInfo, DFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+              <Column Name="CanonicalizationMethod" DataType="DFe.Classes.Assinatura.CanonicalizationMethod, DFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
                 <Column Name="Algorithm" DataType="System.String"/>
               </Column>
-              <Column Name="SignatureMethod" DataType="System.Int32">
+              <Column Name="SignatureMethod" DataType="DFe.Classes.Assinatura.SignatureMethod, DFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
                 <Column Name="Algorithm" DataType="System.String"/>
               </Column>
-              <Column Name="Reference" DataType="System.Int32">
+              <Column Name="Reference" DataType="DFe.Classes.Assinatura.Reference, DFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
                 <Column Name="URI" DataType="System.String"/>
-                <Column Name="DigestMethod" DataType="System.Int32">
+                <Column Name="DigestMethod" DataType="DFe.Classes.Assinatura.DigestMethod, DFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
                   <Column Name="Algorithm" DataType="System.String"/>
                 </Column>
                 <Column Name="DigestValue" DataType="System.String"/>
-                <BusinessObjectDataSource Name="BusinessObjectDataSource25" Alias="Transforms" Enabled="false" DataType="System.Int32" PropName="Transforms"/>
+                <BusinessObjectDataSource Name="BusinessObjectDataSource25" Alias="Transforms" Enabled="false" DataType="System.Collections.Generic.List`1[[DFe.Classes.Assinatura.Transform, DFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]" PropName="Transforms"/>
               </Column>
             </Column>
             <Column Name="SignatureValue" DataType="System.String"/>
-            <Column Name="KeyInfo" DataType="System.Int32">
-              <Column Name="X509Data" DataType="System.Int32">
+            <Column Name="KeyInfo" DataType="DFe.Classes.Assinatura.KeyInfo, DFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+              <Column Name="X509Data" DataType="DFe.Classes.Assinatura.X509Data, DFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
                 <Column Name="X509Certificate" DataType="System.String"/>
               </Column>
             </Column>
@@ -774,7 +774,7 @@ namespace FastReport
       <TextObject Name="Text62" Left="407.8" Top="3.67" Width="335.85" Height="11.9" Text="Seguro" Font="Arial, 8.25pt, style=Bold"/>
       <TextObject Name="Text66" Left="314.85" Top="3.67" Width="88.7" Height="11.9" Text="Contratante(s)" Font="Arial, 8.25pt, style=Bold"/>
     </DataBand>
-    <DataBand Name="Data3" Top="475.92" Width="748.44" Height="47.25">
+    <DataBand Name="Data3" Top="475.92" Width="748.44" Height="47.25" CanGrow="true" CanBreak="true">
       <TextObject Name="txtDocumentosFiscais" Top="19.28" Width="378" Height="18.9" CanGrow="true" Font="Arial, 7.5pt"/>
       <TextObject Name="Text181" Top="3.78" Width="122.85" Height="11.9" Text="Documentos Fiscais" Padding="0, 0, 2, 0" VertAlign="Center" Font="Times New Roman, 9.75pt, style=Bold"/>
     </DataBand>

--- a/MDFe.Damdfe.Base/MDFe/MDFeRetrato.frx
+++ b/MDFe.Damdfe.Base/MDFe/MDFeRetrato.frx
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Report ScriptLanguage="CSharp" ReferencedAssemblies="System.dll&#13;&#10;System.Drawing.dll&#13;&#10;System.Windows.Forms.dll&#13;&#10;System.Data.dll&#13;&#10;System.Xml.dll&#13;&#10;MDFe.Classes.dll&#13;&#10;DFe.Classes.dll&#13;&#10;MDFe.Utils.dll" ReportInfo.Created="01/12/2017 09:00:32" ReportInfo.Modified="04/28/2025 16:02:23" ReportInfo.CreatorVersion="2022.2.9.0">
+<Report ScriptLanguage="CSharp" ReferencedAssemblies="System.dll&#13;&#10;System.Drawing.dll&#13;&#10;System.Windows.Forms.dll&#13;&#10;System.Data.dll&#13;&#10;System.Xml.dll&#13;&#10;MDFe.Classes.dll&#13;&#10;DFe.Classes.dll&#13;&#10;MDFe.Utils.dll" ReportInfo.Created="01/12/2017 09:00:32" ReportInfo.Modified="04/29/2025 15:20:33" ReportInfo.CreatorVersion="2022.2.9.0">
   <ScriptText>using System;
 using System.IO;
 using System.Collections;
@@ -29,6 +29,11 @@ namespace FastReport
 {
   public class ReportScript
   {
+    private void Page1_StartPage(object sender, EventArgs e)
+    {
+      Overlay1.Visible = ((TipoAmbiente)Report.GetColumnValue(&quot;MDFeProcMDFe.MDFe.InfMDFe.Ide.TpAmb&quot;)) == TipoAmbiente.Homologacao;
+    }
+    
     private string ObterSiglaDeUF(string codigoUF)
     { 
       Estado estado = (Estado)System.Enum.Parse(typeof(Estado), codigoUF);
@@ -81,7 +86,7 @@ namespace FastReport
     private int? qtdeMDFe = 0;
 
     private void PageHeader1_BeforePrint(object sender, EventArgs e)
-    { 
+    {                                    
       var chave = Substring((String)Report.GetColumnValue(&quot;MDFeProcMDFe.MDFe.InfMDFe.Id&quot;), 4);
       if (!string.IsNullOrEmpty(chave) &amp; chave.Length == 44)
       {
@@ -234,8 +239,7 @@ namespace FastReport
       Text40.Text = qtdeMDFe.ToString();
       
       DataDocumentoCancelado.Visible = ((Boolean)Report.GetParameterValue(&quot;DocumentoCancelado&quot;)) || ((Boolean)Report.GetParameterValue(&quot;DocumentoEncerrado&quot;)); 
-      Text60.Text = ((Boolean)Report.GetParameterValue(&quot;DocumentoEncerrado&quot;)) ? &quot;DOCUMENTO ENCERRADO&quot; : &quot;DOCUMENTO CANCELADO&quot;;
-      Text61.Visible = ((TipoAmbiente)Report.GetColumnValue(&quot;MDFeProcMDFe.MDFe.InfMDFe.Ide.TpAmb&quot;)) == TipoAmbiente.Homologacao;
+      Text60.Text = ((Boolean)Report.GetParameterValue(&quot;DocumentoEncerrado&quot;)) ? &quot;DOCUMENTO ENCERRADO&quot; : &quot;DOCUMENTO CANCELADO&quot;; 
       
       if ((Boolean)Report.GetParameterValue(&quot;QuebrarLinhasObservacao&quot;))
         Text57.Text = ((String)Report.GetColumnValue(&quot;MDFeProcMDFe.MDFe.InfMDFe.InfAdic.InfCpl&quot;)).Replace(&quot;;&quot;,((String)Report.GetParameterValue(&quot;NewLine&quot;)));     
@@ -689,7 +693,7 @@ namespace FastReport
     <Parameter Name="Tabulation" DataType="System.String" AsString=""/>
     <Parameter Name="DocumentoCancelado" DataType="System.Boolean" AsString=""/>
   </Dictionary>
-  <ReportPage Name="Page1" RawPaperSize="9" LeftMargin="6" TopMargin="8" RightMargin="6" BottomMargin="8" Watermark.Font="Arial, 60pt" FirstPageSource="261">
+  <ReportPage Name="Page1" RawPaperSize="9" LeftMargin="6" TopMargin="8" RightMargin="6" BottomMargin="8" FirstPageSource="261" Watermark.Font="Arial, 60pt" StartPageEvent="Page1_StartPage">
     <PageHeaderBand Name="PageHeader1" Width="748.44" Height="280.61" BeforePrintEvent="PageHeader1_BeforePrint">
       <TextObject Name="txtChaveMDFe" Left="387.7" Top="248.35" Width="349.1" Height="15.12" Padding="2, 0, 2, 4" VertAlign="Bottom" Font="Arial, 6pt"/>
       <TextObject Name="Text68" Left="2.78" Top="248.39" Width="256.38" Height="15.12" Text="[MDFeProcMDFe.ProtMDFe.InfProt.NProt] - [FormatDateTime([MDFeProcMDFe.ProtMDFe.InfProt.DhRecbto],&quot;dd/MM/yyyy HH:mm:ss&quot;)]" Padding="2, 0, 2, 4" VertAlign="Bottom" WordWrap="false" Font="Arial, 6pt"/>
@@ -778,14 +782,18 @@ namespace FastReport
       <TextObject Name="txtDocumentosFiscais" Top="19.28" Width="378" Height="18.9" CanGrow="true" Font="Arial, 7.5pt"/>
       <TextObject Name="Text181" Top="3.78" Width="122.85" Height="11.9" Text="Documentos Fiscais" Padding="0, 0, 2, 0" VertAlign="Center" Font="Times New Roman, 9.75pt, style=Bold"/>
     </DataBand>
-    <DataBand Name="DataInformacaoComplementar" Top="532.5" Width="748.44" Height="96.77" CanGrow="true" CanBreak="true" PrintOnBottom="true">
-      <TextObject Name="Text56" Top="3.45" Width="745.04" Height="14.45" Border.Lines="Bottom" Text="Observações" Padding="4, 0, 2, 0" Font="Arial, 8.25pt, style=Bold"/>
-      <TextObject Name="Text57" Left="1" Top="20.9" Width="745.75" Height="73.7" CanGrow="true" Text="&#13;&#10;" Padding="2, 4, 2, 2" Font="Arial, 8.25pt"/>
-      <TextObject Name="Text61" Left="4.45" Top="3.95" Width="738.55" Height="88.5" Text="MDF-e EMITIDO EM  AMIENTE DE HOMOLOGAÇÃO&#13;&#10;SEM VALOR FISCAL" HorzAlign="Center" VertAlign="Center" Font="Arial Black, 12pt, style=Bold" TextFill.Color="DarkGray"/>
+    <DataBand Name="DataInformacaoComplementar" Top="559.18" Width="748.44" Height="77.87" CanGrow="true" CanBreak="true">
+      <TextObject Name="Text57" Left="1" Top="2" Width="745.75" Height="73.7" CanGrow="true" Text="&#13;&#10;" Padding="2, 4, 2, 2" Font="Arial, 8.25pt"/>
+      <DataHeaderBand Name="DataHeader1" Top="532.5" Width="748.44" Height="22.68" RepeatOnEveryPage="true">
+        <TextObject Name="Text56" Top="7.45" Width="745.04" Height="14.45" Border.Lines="Bottom" Text="Observações" Padding="4, 0, 2, 0" Font="Arial, 8.25pt, style=Bold"/>
+      </DataHeaderBand>
     </DataBand>
-    <PageFooterBand Name="PageFooter1" Top="633.27" Width="748.44" Height="12.47" CanGrow="true">
+    <PageFooterBand Name="PageFooter1" Top="641.05" Width="748.44" Height="11" CanGrow="true">
       <TextObject Name="Text58" Left="1" Top="2" Width="299.75" Height="9" Text="Data e Hora da impressão: [FormatDateTime([Date],&quot;dd/MM/yyyy HH:mm:ss&quot;)]" Font="Arial, 5.25pt"/>
       <TextObject Name="Text59" Left="437.05" Top="2" Width="309.2" Height="9" Text="Desenvolvido por: [Desenvolvedor]" HorzAlign="Right" Font="Arial, 5.25pt"/>
     </PageFooterBand>
+    <OverlayBand Name="Overlay1" Top="656.05" Width="748.44" Height="945">
+      <TextObject Name="Text61" Left="4.45" Top="873.35" Width="738.55" Height="69.6" Anchor="Bottom, Left, Right" Text="MDF-e EMITIDO EM AMBIENTE DE HOMOLOGAÇÃO&#13;&#10;SEM VALOR FISCAL" HorzAlign="Center" VertAlign="Bottom" Font="Arial Black, 20pt, style=Bold" TextFill.Color="DarkGray"/>
+    </OverlayBand>
   </ReportPage>
 </Report>

--- a/MDFe.Damdfe.Base/MDFe/MDFeRetrato.frx
+++ b/MDFe.Damdfe.Base/MDFe/MDFeRetrato.frx
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Report ScriptLanguage="CSharp" ReferencedAssemblies="System.dll&#13;&#10;System.Drawing.dll&#13;&#10;System.Windows.Forms.dll&#13;&#10;System.Data.dll&#13;&#10;System.Xml.dll&#13;&#10;MDFe.Classes.dll&#13;&#10;DFe.Classes.dll&#13;&#10;MDFe.Utils.dll" ReportInfo.Created="01/12/2017 09:00:32" ReportInfo.Modified="04/28/2025 15:07:12" ReportInfo.CreatorVersion="2022.2.9.0">
+<Report ScriptLanguage="CSharp" ReferencedAssemblies="System.dll&#13;&#10;System.Drawing.dll&#13;&#10;System.Windows.Forms.dll&#13;&#10;System.Data.dll&#13;&#10;System.Xml.dll&#13;&#10;MDFe.Classes.dll&#13;&#10;DFe.Classes.dll&#13;&#10;MDFe.Utils.dll" ReportInfo.Created="01/12/2017 09:00:32" ReportInfo.Modified="04/28/2025 16:02:23" ReportInfo.CreatorVersion="2022.2.9.0">
   <ScriptText>using System;
 using System.IO;
 using System.Collections;
@@ -778,14 +778,14 @@ namespace FastReport
       <TextObject Name="txtDocumentosFiscais" Top="19.28" Width="378" Height="18.9" CanGrow="true" Font="Arial, 7.5pt"/>
       <TextObject Name="Text181" Top="3.78" Width="122.85" Height="11.9" Text="Documentos Fiscais" Padding="0, 0, 2, 0" VertAlign="Center" Font="Times New Roman, 9.75pt, style=Bold"/>
     </DataBand>
-    <PageFooterBand Name="PageFooter1" Top="525.83" Width="748.44" Height="96.6" CanGrow="true">
-      <TextObject Name="Text61" Left="4.45" Top="3.45" Width="738.55" Height="88.5" Text="MDF-e EMITIDO EM  AMIENTE DE HOMOLOGAÇÃO&#13;&#10;SEM VALOR FISCAL" HorzAlign="Center" VertAlign="Center" Font="Arial Black, 12pt, style=Bold" TextFill.Color="DarkGray"/>
-      <TextObject Name="Text57" Left="1" Top="22.9" Width="745.75" Height="73.7" CanGrow="true" Text="&#13;&#10;" Padding="2, 4, 2, 2" Font="Arial, 8.25pt"/>
+    <DataBand Name="DataInformacaoComplementar" Top="532.5" Width="748.44" Height="96.77" CanGrow="true" CanBreak="true" PrintOnBottom="true">
       <TextObject Name="Text56" Top="3.45" Width="745.04" Height="14.45" Border.Lines="Bottom" Text="Observações" Padding="4, 0, 2, 0" Font="Arial, 8.25pt, style=Bold"/>
-      <ChildBand Name="Child1" Top="625.1" Width="748.44" Height="12.45">
-        <TextObject Name="Text58" Left="1" Top="3" Width="299.75" Height="9" Text="Data e Hora da impressão: [FormatDateTime([Date],&quot;dd/MM/yyyy HH:mm:ss&quot;)]" Font="Arial, 5.25pt"/>
-        <TextObject Name="Text59" Left="437.05" Top="3" Width="309.2" Height="9" Text="Desenvolvido por: [Desenvolvedor]" HorzAlign="Right" Font="Arial, 5.25pt"/>
-      </ChildBand>
+      <TextObject Name="Text57" Left="1" Top="20.9" Width="745.75" Height="73.7" CanGrow="true" Text="&#13;&#10;" Padding="2, 4, 2, 2" Font="Arial, 8.25pt"/>
+      <TextObject Name="Text61" Left="4.45" Top="3.95" Width="738.55" Height="88.5" Text="MDF-e EMITIDO EM  AMIENTE DE HOMOLOGAÇÃO&#13;&#10;SEM VALOR FISCAL" HorzAlign="Center" VertAlign="Center" Font="Arial Black, 12pt, style=Bold" TextFill.Color="DarkGray"/>
+    </DataBand>
+    <PageFooterBand Name="PageFooter1" Top="633.27" Width="748.44" Height="12.47" CanGrow="true">
+      <TextObject Name="Text58" Left="1" Top="2" Width="299.75" Height="9" Text="Data e Hora da impressão: [FormatDateTime([Date],&quot;dd/MM/yyyy HH:mm:ss&quot;)]" Font="Arial, 5.25pt"/>
+      <TextObject Name="Text59" Left="437.05" Top="2" Width="309.2" Height="9" Text="Desenvolvido por: [Desenvolvedor]" HorzAlign="Right" Font="Arial, 5.25pt"/>
     </PageFooterBand>
   </ReportPage>
 </Report>

--- a/MDFe.Damdfe.Base/MDFe/MDFeRetrato.frx
+++ b/MDFe.Damdfe.Base/MDFe/MDFeRetrato.frx
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Report ScriptLanguage="CSharp" ReferencedAssemblies="System.dll&#13;&#10;System.Drawing.dll&#13;&#10;System.Windows.Forms.dll&#13;&#10;System.Data.dll&#13;&#10;System.Xml.dll&#13;&#10;MDFe.Classes.dll&#13;&#10;DFe.Classes.dll&#13;&#10;MDFe.Utils.dll" ReportInfo.Created="01/12/2017 09:00:32" ReportInfo.Modified="04/29/2025 15:20:33" ReportInfo.CreatorVersion="2022.2.9.0">
+<Report ScriptLanguage="CSharp" ReferencedAssemblies="System.dll&#13;&#10;System.Drawing.dll&#13;&#10;System.Windows.Forms.dll&#13;&#10;System.Data.dll&#13;&#10;System.Xml.dll&#13;&#10;MDFe.Classes.dll&#13;&#10;DFe.Classes.dll&#13;&#10;MDFe.Utils.dll" ReportInfo.Created="01/12/2017 09:00:32" ReportInfo.Modified="04/29/2025 16:20:33" ReportInfo.CreatorVersion="2022.2.9.0">
   <ScriptText>using System;
 using System.IO;
 using System.Collections;
@@ -31,6 +31,8 @@ namespace FastReport
   {
     private void Page1_StartPage(object sender, EventArgs e)
     {
+      Overlay1.Height = 945f;                                                               
+      
       Overlay1.Visible = ((TipoAmbiente)Report.GetColumnValue(&quot;MDFeProcMDFe.MDFe.InfMDFe.Ide.TpAmb&quot;)) == TipoAmbiente.Homologacao;
     }
     
@@ -792,8 +794,8 @@ namespace FastReport
       <TextObject Name="Text58" Left="1" Top="2" Width="299.75" Height="9" Text="Data e Hora da impressão: [FormatDateTime([Date],&quot;dd/MM/yyyy HH:mm:ss&quot;)]" Font="Arial, 5.25pt"/>
       <TextObject Name="Text59" Left="437.05" Top="2" Width="309.2" Height="9" Text="Desenvolvido por: [Desenvolvedor]" HorzAlign="Right" Font="Arial, 5.25pt"/>
     </PageFooterBand>
-    <OverlayBand Name="Overlay1" Top="656.05" Width="748.44" Height="945">
-      <TextObject Name="Text61" Left="4.45" Top="873.35" Width="738.55" Height="69.6" Anchor="Bottom, Left, Right" Text="MDF-e EMITIDO EM AMBIENTE DE HOMOLOGAÇÃO&#13;&#10;SEM VALOR FISCAL" HorzAlign="Center" VertAlign="Bottom" Font="Arial Black, 20pt, style=Bold" TextFill.Color="DarkGray"/>
+    <OverlayBand Name="Overlay1" Top="656.05" Width="748.44" Height="75.6">
+      <TextObject Name="txtEmitidoEmHomologacao" Top="6" Width="748.44" Height="69.6" Dock="Bottom" Anchor="None" Text="MDF-e EMITIDO EM AMBIENTE DE HOMOLOGAÇÃO&#13;&#10;SEM VALOR FISCAL" HorzAlign="Center" VertAlign="Bottom" Font="Arial Black, 20pt, style=Bold" TextFill.Color="DarkGray"/>
     </OverlayBand>
   </ReportPage>
 </Report>


### PR DESCRIPTION
Correção no layout de impressão dos documentos fiscais vinculados ao MDF-e.

- Ajustado o layout para evitar sobreposição entre os documentos fiscais e o campo de observação.
- Implementado controle para que a observação `infCpl` seja impressa apenas uma vez, ao final da lista de documentos fiscais, mesmo quando a lista se estende por múltiplas páginas.
- Ajustado modo de exibição do texto “EMITIDO EM AMBIENTE DE HOMOLOGAÇÃO – SEM VALOR FISCAL" para ser exibido através de um Overlay.

Esse ajuste garante conformidade com o layout esperado e melhora a legibilidade da impressão.