### PR TITLE
Refatorada lógica de limpeza de certificado em MDFeConfiguracao para checar existência de certificado e configuração de cache

### DIFF
--- a/MDFe.Utils/Configuracoes/MDFeConfiguracao.cs
+++ b/MDFe.Utils/Configuracoes/MDFeConfiguracao.cs
@@ -117,9 +117,9 @@ namespace MDFe.Utils.Configuracoes
         {
             get
             {
-                if (_certificado != null)
-                    if (!ConfiguracaoCertificado.ManterDadosEmCache)
-                        _certificado.Reset();
+                if (_certificado != null && !DeveManterCertificadoEmCache())
+                    _certificado.Reset();
+
                 _certificado = ObterCertificado();
                 return _certificado;
             }
@@ -190,15 +190,20 @@ namespace MDFe.Utils.Configuracoes
 
         private void LimparCertificado()
         {
-            var deveManterCertificadoEmCache = _certificado == null ||
-                                               ConfiguracaoCertificado == null ||
-                                               ConfiguracaoCertificado.ManterDadosEmCache;
-
-            if (deveManterCertificadoEmCache)
+            if (DeveManterCertificadoEmCache())
                 return;
 
             _certificado.Reset();
             _certificado = null;
+        }
+
+        private bool DeveManterCertificadoEmCache()
+        {
+            var deveManterCertificadoEmCache = _certificado == null ||
+                                               ConfiguracaoCertificado == null ||
+                                               ConfiguracaoCertificado.ManterDadosEmCache;
+
+            return deveManterCertificadoEmCache;
         }
     }
 }

--- a/MDFe.Utils/Configuracoes/MDFeConfiguracao.cs
+++ b/MDFe.Utils/Configuracoes/MDFeConfiguracao.cs
@@ -190,14 +190,15 @@ namespace MDFe.Utils.Configuracoes
 
         private void LimparCertificado()
         {
-            var naoDeveManterCertificadoEmCache =
-                !ConfiguracaoCertificado.ManterDadosEmCache && _certificado != null;
+            var deveManterCertificadoEmCache = _certificado == null ||
+                                               ConfiguracaoCertificado == null ||
+                                               ConfiguracaoCertificado.ManterDadosEmCache;
 
-            if (naoDeveManterCertificadoEmCache)
-            {
-                _certificado.Reset();
-                _certificado = null;
-            }
+            if (deveManterCertificadoEmCache)
+                return;
+
+            _certificado.Reset();
+            _certificado = null;
         }
     }
 }


### PR DESCRIPTION
Em cenários onde a configuração de certificado não esteja preenchida, o método LimparCertificado poderia disparar NullReferenceException ao ser acionado pelo Dispose.