### PR TITLE
ci: substituido comando set-output obsoleto no pipeline

### DIFF
--- a/.github/workflows/DFe.NET_build.yml
+++ b/.github/workflows/DFe.NET_build.yml
@@ -32,7 +32,7 @@ jobs:
     
     - name: Setando Versao
       id: date
-      run: echo "::set-output name=date::$(date +'%Y.%m.%d.%H%M')"
+      run: echo "date=$(date +'%Y.%m.%d.%H%M')" >> $GITHUB_OUTPUT
       
     - name: Versao
       run: echo ${{ steps.date.outputs.date }}

--- a/.github/workflows/DFe.NET_build.yml
+++ b/.github/workflows/DFe.NET_build.yml
@@ -32,7 +32,7 @@ jobs:
     
     - name: Setando Versao
       id: date
-      run: echo "date=$(date +'%Y.%m.%d.%H%M')" >> $GITHUB_OUTPUT
+      run: echo "date=$(date +'%Y.%m.%d.%H%M')" >> "$GITHUB_OUTPUT"
       
     - name: Versao
       run: echo "${{ steps.date.outputs.date }}"

--- a/.github/workflows/DFe.NET_build.yml
+++ b/.github/workflows/DFe.NET_build.yml
@@ -35,7 +35,7 @@ jobs:
       run: echo "date=$(date +'%Y.%m.%d.%H%M')" >> $GITHUB_OUTPUT
       
     - name: Versao
-      run: echo ${{ steps.date.outputs.date }}
+      run: echo "${{ steps.date.outputs.date }}"
       
     - name: Setup .NET 6.0.x
       uses: actions/setup-dotnet@v2


### PR DESCRIPTION
Atualizado comando do GitHub Actions de `set-output` para `GITHUB_OUTPUT` no pipeline de build.

Documentação de referência: [GitHub Actions: Deprecating save-state and set-output commands](https://github.blog/changelog/2022-10-10-github-actions-deprecating-save-state-and-set-output-commands/)