### PR TITLE
ci: substituido comando set-output obsoleto no pipeline

### DIFF
--- a/.github/workflows/DFe.NET_build.yml
+++ b/.github/workflows/DFe.NET_build.yml
@@ -32,7 +32,9 @@ jobs:
     
     - name: Setando Versao
       id: date
-      run: echo "::set-output name=date::$(date +'%Y.%m.%d.%H%M')"
+      run: |
+        $date = Get-Date -Format "yyyy.MM.dd.HHmm"
+        echo "date=$date" >> $env:GITHUB_OUTPUT
       
     - name: Versao
       run: echo ${{ steps.date.outputs.date }}


### PR DESCRIPTION
Substituido comando do GitHub Actions de `set-output` para `GITHUB_OUTPUT` no pipeline de build;
Ajustado modo de obtenção da data de versão para usar PowerShell ao invés de Bash;

Documentação de referência: [GitHub Actions: Deprecating save-state and set-output commands](https://github.blog/changelog/2022-10-10-github-actions-deprecating-save-state-and-set-output-commands/)