### PR TITLE
cleanup: refatoração de código que gera avisos no pipeline

### DIFF
--- a/CTe.Classes/CTeOutrosServicos/Extensoes/extretCteOS.cs
+++ b/CTe.Classes/CTeOutrosServicos/Extensoes/extretCteOS.cs
@@ -35,23 +35,10 @@ namespace CTe.CTeOSDocumento.CTe.CTeOS.Extensoes
         {
             if (config.NaoSalvarXml()) return;
 
-            var dataEnvio = DateTimeOffset.Now;
-
-            if (retEnviCte != null && retEnviCte.protCTe != null 
-                && retEnviCte.protCTe.infProt != null
-                && retEnviCte.protCTe.infProt.dhRecbto != null)
-            {
-                dataEnvio = retEnviCte.protCTe.infProt.dhRecbto;
-            }
-
             var caminhoXml = config.DiretorioSalvarXml;
-
             var protocolo = "000000";
-
-
-            if (retEnviCte != null && retEnviCte.protCTe != null
-                                   && retEnviCte.protCTe.infProt != null
-                                   && retEnviCte.protCTe.infProt.nProt != null)
+            
+            if (retEnviCte?.protCTe?.infProt?.nProt != null)
             {
                 protocolo = retEnviCte.protCTe.infProt.nProt;
             }

--- a/CTe.Servicos/DistribuicaoDFe/RetornoCteDistDFeInt.cs
+++ b/CTe.Servicos/DistribuicaoDFe/RetornoCteDistDFeInt.cs
@@ -31,8 +31,6 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 
-
-
 using CTe.Classes.Servicos.DistribuicaoDFe;
 
 namespace CTe.Servicos.DistribuicaoDFe
@@ -46,12 +44,11 @@ namespace CTe.Servicos.DistribuicaoDFe
             RetornoCompletoStr = retornoCompletaStr;
             Retorno = retorno;
         }
-
-
+        
         public string EnvioStr { get; protected set; }
         public string RetornoStr { get; protected set; }
         public string RetornoCompletoStr { get; protected set; }
 
-        public new retDistDFeInt Retorno { get; set; }
+        public retDistDFeInt Retorno { get; set; }
     }
 }

--- a/DFe.Utils/FrxFileHelper.cs
+++ b/DFe.Utils/FrxFileHelper.cs
@@ -19,7 +19,7 @@ namespace DFe.Utils
                 var bytes = File.ReadAllBytes(path);
                 return bytes.Length == 0 ? null : bytes;
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 return null;
             }

--- a/NFe.Classes/Informacoes/Agropecuario/agropecuario.cs
+++ b/NFe.Classes/Informacoes/Agropecuario/agropecuario.cs
@@ -4,6 +4,8 @@
     {
 #if NET5_0_OR_GREATER//o uso de tipos de referência anuláveis não é permitido até o C# 8.0.
 
+        #nullable enable
+
         /// <summary>
         /// ZF02 - serieGuia
         /// </summary>
@@ -13,6 +15,8 @@
         /// ZF04 - Guia de Trânsito
         /// </summary>
         public guiaTransito? guiaTransito { get; set; }
+        
+        #nullable disable
 
         public bool ShouldSerializedefensivo()
         {

--- a/NFe.Classes/Informacoes/Agropecuario/guiaTransito.cs
+++ b/NFe.Classes/Informacoes/Agropecuario/guiaTransito.cs
@@ -8,6 +8,8 @@
         /// </summary>
         public TipoGuia tpGuia { get; set; }
 
+        #nullable enable
+
         /// <summary>
         /// ZF06 - UF de emissão
         /// </summary>
@@ -17,6 +19,8 @@
         /// ZF07 - Série da Guia
         /// </summary>
         public string? serieGuia { get; set; }
+
+        #nullable disable
 
         /// <summary>
         /// ZF08 - Número da Guia

--- a/NFe.Classes/Servicos/Status/retConsStatServ.cs
+++ b/NFe.Classes/Servicos/Status/retConsStatServ.cs
@@ -108,7 +108,12 @@ namespace NFe.Classes.Servicos.Status
         ///     FR11 - Informações adicionais para o Contribuinte
         /// </summary>
 #if NET5_0_OR_GREATER//o uso de tipos de referência anuláveis não é permitido até o C# 8.0.
+
+        #nullable enable
+
         public string? xObs { get; set; }
+        
+        #nullable disable
 #else
         public string xObs { get; set; }
 #endif


### PR DESCRIPTION
- Removido new redundante desnecessário em retDistDFeInt;
- Refatorado metodo SalvarXmlEmDisco na classe extretCteOS;
- Envolvido blocos anulaveis em nullable nas classes agropecuario, guiaTransito e retConsStatServ;
- Removido variáveis sem uso.

Ajustes realizados a fim de corrigir avisos disparados no pipeline.