### PR TITLE
fix(CT-e): Corrigido erro de nulo ao executar o evento de CT-e com configuração do serviço nula

### DIFF
--- a/CTe.Servicos/Eventos/ServicoController.cs
+++ b/CTe.Servicos/Eventos/ServicoController.cs
@@ -72,7 +72,7 @@ namespace CTe.Servicos.Eventos
             var evento = FactoryEvento.CriaEvento(cTeTipoEvento, sequenciaEvento, chave, cnpj, container, configServico);
             evento.Assina(configServico);
 
-            if (configuracaoServico.IsValidaSchemas)
+            if (configServico.IsValidaSchemas)
                 evento.ValidarSchema(configServico);
 
             evento.SalvarXmlEmDisco(configServico);


### PR DESCRIPTION
Ajustada a expressão de execução das validações dos schemas para utilizar a instância de configuração previamente inicializada, evitando exceção de referência nula (NullReferenceException).