### PR TITLE
feat: ajuste nos campos criados pela Reforma Tributária e adição dos da nova Nota Técnica

### DIFF
--- a/NFe.Classes/Informacoes/Detalhe/DFeReferenciado.cs
+++ b/NFe.Classes/Informacoes/Detalhe/DFeReferenciado.cs
@@ -44,5 +44,7 @@ namespace NFe.Classes.Informacoes.Detalhe
         ///     VC03 - Número do item do documento referenciado.
         /// </summary>
         public int? nItem { get; set; }
+        
+        public bool ShouldSerializenItem() => nItem.HasValue;
     }
 }

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Compartilhado/IBSCBS.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Compartilhado/IBSCBS.cs
@@ -50,7 +50,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Compartilhado
         ///     UB14 - Código de Classificação Tributária do IBS e CBS
         /// </summary>
         [XmlElement(Order = 2)]
-        public int cClassTrib { get; set; }
+        public string cClassTrib { get; set; }
         
         /// <summary>
         ///     UB15 - Grupo de Informações do IBS e da CBS

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Compartilhado/InformacoesIbsCbs/InformacoesIbs/gCredPresIBSZFM.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Compartilhado/InformacoesIbsCbs/InformacoesIbs/gCredPresIBSZFM.cs
@@ -52,5 +52,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Compartilhado.InformacoesIb
             get => _vCredPresIbsZfm.Arredondar(2);
             set => _vCredPresIbsZfm = value.Arredondar(2);
         }
+        
+        public bool ShouldSerializevCredPresIBSZFM() => vCredPresIBSZFM.HasValue;
     }
 }

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Compartilhado/InformacoesIbsCbs/gIBSCBS.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Compartilhado/InformacoesIbsCbs/gIBSCBS.cs
@@ -31,6 +31,7 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 
+using System.Xml.Serialization;
 using NFe.Classes.Informacoes.Detalhe.Tributacao.Compartilhado.InformacoesIbsCbs.InformacoesCbs;
 using NFe.Classes.Informacoes.Detalhe.Tributacao.Compartilhado.InformacoesIbsCbs.InformacoesIbs;
 
@@ -44,6 +45,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Compartilhado.InformacoesIb
         /// <summary>
         ///     UB16 - Base de cálculo do IBS e CBS
         /// </summary>
+        [XmlElement(Order = 1)]
         public decimal vBC
         {
             get => _vBc.Arredondar(2);
@@ -53,45 +55,53 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Compartilhado.InformacoesIb
         /// <summary>
         ///     UB17 - Grupo de Informações do IBS para a UF
         /// </summary>
+        [XmlElement(Order = 2)]
         public gIBSUF gIBSUF { get; set; }
         
         /// <summary>
         ///     UB36 - Grupo de Informações do IBS para o município
         /// </summary>
+        [XmlElement(Order = 3)]
         public gIBSMun gIBSMun { get; set; }
         
         /// <summary>
-        ///     UB55 - Grupo de Informações da CBS
-        /// </summary>
-        public gCBS gCBS { get; set; }
-        
-        /// <summary>
-        ///     UB68 - Grupo de informações da Tributação Regular
-        /// </summary>
-        public gTribRegular gTribRegular { get; set; }
-        
-        /// <summary>
-        ///     UB73 - Grupo de Informações do Crédito Presumido referente ao IBS
-        /// </summary>
-        public gIBSCredPres gIBSCredPres { get; set; }
-        
-        /// <summary>
-        ///     UB78 - Grupo de Informações do Crédito Presumido referente a CBS
-        /// </summary>
-        public gCBSCredPres gCBSCredPres { get; set; }
-        
-        /// <summary>
-        ///     UB82a - Grupo de informações da composição do valor do IBS e da CBS em compras governamentais
-        /// </summary>
-        public gTribCompraGov gTribCompraGov { get; set; }
-
-        /// <summary>
         ///     UB54a - Valor do IBS
         /// </summary>
+        [XmlElement(Order = 4)]
         public decimal vIBS
         {
             get => _vIbs.Arredondar(2);
             set => _vIbs = value.Arredondar(2);
         }
+        
+        /// <summary>
+        ///     UB55 - Grupo de Informações da CBS
+        /// </summary>
+        [XmlElement(Order = 5)]
+        public gCBS gCBS { get; set; }
+        
+        /// <summary>
+        ///     UB68 - Grupo de informações da Tributação Regular
+        /// </summary>
+        [XmlElement(Order = 6)]
+        public gTribRegular gTribRegular { get; set; }
+        
+        /// <summary>
+        ///     UB73 - Grupo de Informações do Crédito Presumido referente ao IBS
+        /// </summary>
+        [XmlElement(Order = 7)]
+        public gIBSCredPres gIBSCredPres { get; set; }
+        
+        /// <summary>
+        ///     UB78 - Grupo de Informações do Crédito Presumido referente a CBS
+        /// </summary>
+        [XmlElement(Order = 8)]
+        public gCBSCredPres gCBSCredPres { get; set; }
+        
+        /// <summary>
+        ///     UB82a - Grupo de informações da composição do valor do IBS e da CBS em compras governamentais
+        /// </summary>
+        [XmlElement(Order = 9)]
+        public gTribCompraGov gTribCompraGov { get; set; }
     }
 }

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Compartilhado/InformacoesIbsCbs/gIBSCBS.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Compartilhado/InformacoesIbsCbs/gIBSCBS.cs
@@ -39,6 +39,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Compartilhado.InformacoesIb
     public class gIBSCBS
     {
         private decimal _vBc;
+        private decimal _vIbs;
         
         /// <summary>
         ///     UB16 - Base de cálculo do IBS e CBS
@@ -83,5 +84,14 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Compartilhado.InformacoesIb
         ///     UB82a - Grupo de informações da composição do valor do IBS e da CBS em compras governamentais
         /// </summary>
         public gTribCompraGov gTribCompraGov { get; set; }
+
+        /// <summary>
+        ///     UB54a - Valor do IBS
+        /// </summary>
+        public decimal vIBS
+        {
+            get => _vIbs.Arredondar(2);
+            set => _vIbs = value.Arredondar(2);
+        }
     }
 }

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Compartilhado/InformacoesIbsCbs/gIBSCBSMono.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Compartilhado/InformacoesIbsCbs/gIBSCBSMono.cs
@@ -31,173 +31,36 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 
-using System.Xml.Serialization;
-
 namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Compartilhado.InformacoesIbsCbs
 {
     public class gIBSCBSMono
     {
-        private decimal _qBcMonoReten;
-        private decimal _adRemIbsReten;
-        private decimal _vIbsMonoReten;
-        private decimal _adRemCbsReten;
-        private decimal _vCbsMonoReten;
-        private decimal _qBcMonoRet;
-        private decimal _adRemIbsRet;
-        private decimal _vIbsMonoRet;
-        private decimal _adRemCbsRet;
-        private decimal _vCbsMonoRet;
-        private decimal _pDifIbs;
-        private decimal _vIbsMonoDif;
-        private decimal _pDifCbs;
-        private decimal _vCbsMonoDif;
         private decimal _vTotIbsMonoItem;
         private decimal _vTotCbsMonoItem;
         
         /// <summary>
-        ///     UB91 - Quantidade tributada sujeita à retenção na monofasia
+        ///     UB84a - Grupo de informações da Tributação Monofásica Padrão
         /// </summary>
-        [XmlElement(Order = 6)]
-        public decimal qBCMonoReten
-        {
-            get => _qBcMonoReten.Arredondar(4);
-            set => _qBcMonoReten = value.Arredondar(4);
-        }
+        public gMonoPadrao gMonoPadrao { get; set; }
         
         /// <summary>
-        ///     UB92 - Alíquota ad rem do IBS sujeito a retenção
+        ///     UB90 - Grupo de informações da Tributação Monofásica Sujeita à Retenção
         /// </summary>
-        [XmlElement(Order = 7)]
-        public decimal adRemIBSReten
-        {
-            get => _adRemIbsReten.Arredondar(4);
-            set => _adRemIbsReten = value.Arredondar(4);
-        }
+        public gMonoReten gMonoReten { get; set; }
         
         /// <summary>
-        ///     UB93 - Valor do IBS monofásico sujeito a retenção
+        ///     UB94 - Grupo de informações da Tributação Monofásica Retida Anteriormente
         /// </summary>
-        [XmlElement(Order = 8)]
-        public decimal vIBSMonoReten
-        {
-            get => _vIbsMonoReten.Arredondar(2);
-            set => _vIbsMonoReten = value.Arredondar(2);
-        }
+        public gMonoRet gMonoRet { get; set; }
         
         /// <summary>
-        ///     UB93a - Alíquota ad rem da CBS sujeito a retenção
+        ///     UB99 - Grupo de informações do Diferimento da Tributação Monofásica
         /// </summary>
-        [XmlElement(Order = 9)]
-        public decimal adRemCBSReten
-        {
-            get => _adRemCbsReten.Arredondar(4);
-            set => _adRemCbsReten = value.Arredondar(4);
-        }
-        
-        /// <summary>
-        ///     UB93b - Valor da CBS monofásica sujeita a retenção
-        /// </summary>
-        [XmlElement(Order = 10)]
-        public decimal vCBSMonoReten
-        {
-            get => _vCbsMonoReten.Arredondar(2);
-            set => _vCbsMonoReten = value.Arredondar(2);
-        }
-        
-        /// <summary>
-        ///     UB95 - Quantidade tributada retida anteriormente
-        /// </summary>
-        [XmlElement(Order = 11)]
-        public decimal qBCMonoRet
-        {
-            get => _qBcMonoRet.Arredondar(4);
-            set => _qBcMonoRet = value.Arredondar(4);
-        }
-        
-        /// <summary>
-        ///     UB96 - Alíquota ad rem do IBS retido anteriormente
-        /// </summary>
-        [XmlElement(Order = 12)]
-        public decimal adRemIBSRet
-        {
-            get => _adRemIbsRet.Arredondar(4);
-            set => _adRemIbsRet = value.Arredondar(4);
-        }
-        
-        /// <summary>
-        ///     UB97 - Valor do IBS retido anteriormente
-        /// </summary>
-        [XmlElement(Order = 13)]
-        public decimal vIBSMonoRet
-        {
-            get => _vIbsMonoRet.Arredondar(2);
-            set => _vIbsMonoRet = value.Arredondar(2);
-        }
-        
-        /// <summary>
-        ///     UB98 - Alíquota ad rem da CBS retida anteriormente
-        /// </summary>
-        [XmlElement(Order = 14)]
-        public decimal adRemCBSRet
-        {
-            get => _adRemCbsRet.Arredondar(4);
-            set => _adRemCbsRet = value.Arredondar(4);
-        }
-        
-        /// <summary>
-        ///     UB98a - Valor da CBS retida anteriormente
-        /// </summary>
-        [XmlElement(Order = 15)]
-        public decimal vCBSMonoRet
-        {
-            get => _vCbsMonoRet.Arredondar(2);
-            set => _vCbsMonoRet = value.Arredondar(2);
-        }
-        
-        /// <summary>
-        ///     UB100 - Percentual do diferimento do imposto monofásico
-        /// </summary>
-        [XmlElement(Order = 16)]
-        public decimal pDifIBS
-        {
-            get => _pDifIbs.Arredondar(4);
-            set => _pDifIbs = value.Arredondar(4);
-        }
-        
-        /// <summary>
-        ///     UB101 - Valor do IBS monofásico diferido
-        /// </summary>
-        [XmlElement(Order = 17)]
-        public decimal vIBSMonoDif
-        {
-            get => _vIbsMonoDif.Arredondar(2);
-            set => _vIbsMonoDif = value.Arredondar(2);
-        }
-        
-        /// <summary>
-        ///     UB102 - Percentual do diferimento do imposto monofásico
-        /// </summary>
-        [XmlElement(Order = 18)]
-        public decimal pDifCBS
-        {
-            get => _pDifCbs.Arredondar(4);
-            set => _pDifCbs = value.Arredondar(4);
-        }
-        
-        /// <summary>
-        ///     UB103 - Valor da CBS Monofásica diferida
-        /// </summary>
-        [XmlElement(Order = 19)]
-        public decimal vCBSMonoDif
-        {
-            get => _vCbsMonoDif.Arredondar(2);
-            set => _vCbsMonoDif = value.Arredondar(2);
-        }
+        public gMonoDif gMonoDif { get; set; }
         
         /// <summary>
         ///     UB104 - Total de IBS Monofásico
         /// </summary>
-        [XmlElement(Order = 20)]
         public decimal vTotIBSMonoItem
         {
             get => _vTotIbsMonoItem.Arredondar(2);
@@ -207,7 +70,6 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Compartilhado.InformacoesIb
         /// <summary>
         ///     UB105 - Total da CBS Monofásica
         /// </summary>
-        [XmlElement(Order = 21)]
         public decimal vTotCBSMonoItem
         {
             get => _vTotCbsMonoItem.Arredondar(2);

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Compartilhado/InformacoesIbsCbs/gIBSCBSMono.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Compartilhado/InformacoesIbsCbs/gIBSCBSMono.cs
@@ -37,11 +37,6 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Compartilhado.InformacoesIb
 {
     public class gIBSCBSMono
     {
-        private decimal _qBcMono;
-        private decimal _adRemIbs;
-        private decimal _adRemCbs;
-        private decimal _vIbsMono;
-        private decimal _vCbsMono;
         private decimal _qBcMonoReten;
         private decimal _adRemIbsReten;
         private decimal _vIbsMonoReten;
@@ -58,56 +53,6 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Compartilhado.InformacoesIb
         private decimal _vCbsMonoDif;
         private decimal _vTotIbsMonoItem;
         private decimal _vTotCbsMonoItem;
-
-        /// <summary>
-        ///     UB85 - Quantidade tributada na monofasia
-        /// </summary>
-        [XmlElement(Order = 1)]
-        public decimal qBCMono
-        {
-            get => _qBcMono.Arredondar(4);
-            set => _qBcMono = value.Arredondar(4);
-        }
-        
-        /// <summary>
-        ///     UB86 - Alíquota ad rem do IBS
-        /// </summary>
-        [XmlElement(Order = 2)]
-        public decimal adRemIBS
-        {
-            get => _adRemIbs.Arredondar(4);
-            set => _adRemIbs = value.Arredondar(4);
-        }
-        
-        /// <summary>
-        ///     UB87 - Alíquota ad rem da CBS
-        /// </summary>
-        [XmlElement(Order = 3)]
-        public decimal adRemCBS
-        {
-            get => _adRemCbs.Arredondar(4);
-            set => _adRemCbs = value.Arredondar(4);
-        }
-        
-        /// <summary>
-        ///     UB88 - Valor do IBS monofásico
-        /// </summary>
-        [XmlElement(Order = 4)]
-        public decimal vIBSMono
-        {
-            get => _vIbsMono.Arredondar(2);
-            set => _vIbsMono = value.Arredondar(2);
-        }
-        
-        /// <summary>
-        ///     UB89 - Valor da CBS monofásica
-        /// </summary>
-        [XmlElement(Order = 5)]
-        public decimal vCBSMono
-        {
-            get => _vCbsMono.Arredondar(2);
-            set => _vCbsMono = value.Arredondar(2);
-        }
         
         /// <summary>
         ///     UB91 - Quantidade tributada sujeita à retenção na monofasia

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Compartilhado/InformacoesIbsCbs/gMonoDif.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Compartilhado/InformacoesIbsCbs/gMonoDif.cs
@@ -1,0 +1,79 @@
+﻿/********************************************************************************/
+/* Projeto: Biblioteca ZeusNFe                                                  */
+/* Biblioteca C# para emissão de Nota Fiscal Eletrônica - NFe e Nota Fiscal de  */
+/* Consumidor Eletrônica - NFC-e (http://www.nfe.fazenda.gov.br)                */
+/*                                                                              */
+/* Direitos Autorais Reservados (c) 2014 Adenilton Batista da Silva             */
+/*                                       Zeusdev Tecnologia LTDA ME             */
+/*                                                                              */
+/*  Você pode obter a última versão desse arquivo no GitHub                     */
+/* localizado em https://github.com/adeniltonbs/Zeus.Net.NFe.NFCe               */
+/*                                                                              */
+/*                                                                              */
+/*  Esta biblioteca é software livre; você pode redistribuí-la e/ou modificá-la */
+/* sob os termos da Licença Pública Geral Menor do GNU conforme publicada pela  */
+/* Free Software Foundation; tanto a versão 2.1 da Licença, ou (a seu critério) */
+/* qualquer versão posterior.                                                   */
+/*                                                                              */
+/*  Esta biblioteca é distribuída na expectativa de que seja útil, porém, SEM   */
+/* NENHUMA GARANTIA; nem mesmo a garantia implícita de COMERCIABILIDADE OU      */
+/* ADEQUAÇÃO A UMA FINALIDADE ESPECÍFICA. Consulte a Licença Pública Geral Menor*/
+/* do GNU para mais detalhes. (Arquivo LICENÇA.TXT ou LICENSE.TXT)              */
+/*                                                                              */
+/*  Você deve ter recebido uma cópia da Licença Pública Geral Menor do GNU junto*/
+/* com esta biblioteca; se não, escreva para a Free Software Foundation, Inc.,  */
+/* no endereço 59 Temple Street, Suite 330, Boston, MA 02111-1307 USA.          */
+/* Você também pode obter uma copia da licença em:                              */
+/* http://www.opensource.org/licenses/lgpl-license.php                          */
+/*                                                                              */
+/* Zeusdev Tecnologia LTDA ME - adenilton@zeusautomacao.com.br                  */
+/* http://www.zeusautomacao.com.br/                                             */
+/* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
+/********************************************************************************/
+
+namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Compartilhado.InformacoesIbsCbs
+{
+    public class gMonoDif
+    {
+        private decimal _pDifIbs;
+        private decimal _vIbsMonoDif;
+        private decimal _pDifCbs;
+        private decimal _vCbsMonoDif;
+        
+        /// <summary>
+        ///     UB100 - Percentual do diferimento do imposto monofásico
+        /// </summary>
+        public decimal pDifIBS
+        {
+            get => _pDifIbs.Arredondar(4);
+            set => _pDifIbs = value.Arredondar(4);
+        }
+        
+        /// <summary>
+        ///     UB101 - Valor do IBS monofásico diferido
+        /// </summary>
+        public decimal vIBSMonoDif
+        {
+            get => _vIbsMonoDif.Arredondar(2);
+            set => _vIbsMonoDif = value.Arredondar(2);
+        }
+        
+        /// <summary>
+        ///     UB102 - Percentual do diferimento do imposto monofásico
+        /// </summary>
+        public decimal pDifCBS
+        {
+            get => _pDifCbs.Arredondar(4);
+            set => _pDifCbs = value.Arredondar(4);
+        }
+        
+        /// <summary>
+        ///     UB103 - Valor da CBS Monofásica diferida
+        /// </summary>
+        public decimal vCBSMonoDif
+        {
+            get => _vCbsMonoDif.Arredondar(2);
+            set => _vCbsMonoDif = value.Arredondar(2);
+        }
+    }
+}

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Compartilhado/InformacoesIbsCbs/gMonoPadrao.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Compartilhado/InformacoesIbsCbs/gMonoPadrao.cs
@@ -31,8 +31,6 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 
-using System.Xml.Serialization;
-
 namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Compartilhado.InformacoesIbsCbs
 {
     public class gMonoPadrao
@@ -46,7 +44,6 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Compartilhado.InformacoesIb
         /// <summary>
         ///     UB85 - Quantidade tributada na monofasia
         /// </summary>
-        [XmlElement(Order = 1)]
         public decimal qBCMono
         {
             get => _qBcMono.Arredondar(4);
@@ -56,7 +53,6 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Compartilhado.InformacoesIb
         /// <summary>
         ///     UB86 - Alíquota ad rem do IBS
         /// </summary>
-        [XmlElement(Order = 2)]
         public decimal adRemIBS
         {
             get => _adRemIbs.Arredondar(4);
@@ -66,7 +62,6 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Compartilhado.InformacoesIb
         /// <summary>
         ///     UB87 - Alíquota ad rem da CBS
         /// </summary>
-        [XmlElement(Order = 3)]
         public decimal adRemCBS
         {
             get => _adRemCbs.Arredondar(4);
@@ -76,7 +71,6 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Compartilhado.InformacoesIb
         /// <summary>
         ///     UB88 - Valor do IBS monofásico
         /// </summary>
-        [XmlElement(Order = 4)]
         public decimal vIBSMono
         {
             get => _vIbsMono.Arredondar(2);
@@ -86,7 +80,6 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Compartilhado.InformacoesIb
         /// <summary>
         ///     UB89 - Valor da CBS monofásica
         /// </summary>
-        [XmlElement(Order = 5)]
         public decimal vCBSMono
         {
             get => _vCbsMono.Arredondar(2);

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Compartilhado/InformacoesIbsCbs/gMonoPadrao.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Compartilhado/InformacoesIbsCbs/gMonoPadrao.cs
@@ -1,0 +1,96 @@
+﻿/********************************************************************************/
+/* Projeto: Biblioteca ZeusNFe                                                  */
+/* Biblioteca C# para emissão de Nota Fiscal Eletrônica - NFe e Nota Fiscal de  */
+/* Consumidor Eletrônica - NFC-e (http://www.nfe.fazenda.gov.br)                */
+/*                                                                              */
+/* Direitos Autorais Reservados (c) 2014 Adenilton Batista da Silva             */
+/*                                       Zeusdev Tecnologia LTDA ME             */
+/*                                                                              */
+/*  Você pode obter a última versão desse arquivo no GitHub                     */
+/* localizado em https://github.com/adeniltonbs/Zeus.Net.NFe.NFCe               */
+/*                                                                              */
+/*                                                                              */
+/*  Esta biblioteca é software livre; você pode redistribuí-la e/ou modificá-la */
+/* sob os termos da Licença Pública Geral Menor do GNU conforme publicada pela  */
+/* Free Software Foundation; tanto a versão 2.1 da Licença, ou (a seu critério) */
+/* qualquer versão posterior.                                                   */
+/*                                                                              */
+/*  Esta biblioteca é distribuída na expectativa de que seja útil, porém, SEM   */
+/* NENHUMA GARANTIA; nem mesmo a garantia implícita de COMERCIABILIDADE OU      */
+/* ADEQUAÇÃO A UMA FINALIDADE ESPECÍFICA. Consulte a Licença Pública Geral Menor*/
+/* do GNU para mais detalhes. (Arquivo LICENÇA.TXT ou LICENSE.TXT)              */
+/*                                                                              */
+/*  Você deve ter recebido uma cópia da Licença Pública Geral Menor do GNU junto*/
+/* com esta biblioteca; se não, escreva para a Free Software Foundation, Inc.,  */
+/* no endereço 59 Temple Street, Suite 330, Boston, MA 02111-1307 USA.          */
+/* Você também pode obter uma copia da licença em:                              */
+/* http://www.opensource.org/licenses/lgpl-license.php                          */
+/*                                                                              */
+/* Zeusdev Tecnologia LTDA ME - adenilton@zeusautomacao.com.br                  */
+/* http://www.zeusautomacao.com.br/                                             */
+/* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
+/********************************************************************************/
+
+using System.Xml.Serialization;
+
+namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Compartilhado.InformacoesIbsCbs
+{
+    public class gMonoPadrao
+    {
+        private decimal _qBcMono;
+        private decimal _adRemIbs;
+        private decimal _adRemCbs;
+        private decimal _vIbsMono;
+        private decimal _vCbsMono;
+        
+        /// <summary>
+        ///     UB85 - Quantidade tributada na monofasia
+        /// </summary>
+        [XmlElement(Order = 1)]
+        public decimal qBCMono
+        {
+            get => _qBcMono.Arredondar(4);
+            set => _qBcMono = value.Arredondar(4);
+        }
+        
+        /// <summary>
+        ///     UB86 - Alíquota ad rem do IBS
+        /// </summary>
+        [XmlElement(Order = 2)]
+        public decimal adRemIBS
+        {
+            get => _adRemIbs.Arredondar(4);
+            set => _adRemIbs = value.Arredondar(4);
+        }
+        
+        /// <summary>
+        ///     UB87 - Alíquota ad rem da CBS
+        /// </summary>
+        [XmlElement(Order = 3)]
+        public decimal adRemCBS
+        {
+            get => _adRemCbs.Arredondar(4);
+            set => _adRemCbs = value.Arredondar(4);
+        }
+
+        /// <summary>
+        ///     UB88 - Valor do IBS monofásico
+        /// </summary>
+        [XmlElement(Order = 4)]
+        public decimal vIBSMono
+        {
+            get => _vIbsMono.Arredondar(2);
+            set => _vIbsMono = value.Arredondar(2);
+        }
+        
+        /// <summary>
+        ///     UB89 - Valor da CBS monofásica
+        /// </summary>
+        [XmlElement(Order = 5)]
+        public decimal vCBSMono
+        {
+            get => _vCbsMono.Arredondar(2);
+            set => _vCbsMono = value.Arredondar(2);
+        }
+    }
+}

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Compartilhado/InformacoesIbsCbs/gMonoRet.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Compartilhado/InformacoesIbsCbs/gMonoRet.cs
@@ -1,0 +1,89 @@
+﻿/********************************************************************************/
+/* Projeto: Biblioteca ZeusNFe                                                  */
+/* Biblioteca C# para emissão de Nota Fiscal Eletrônica - NFe e Nota Fiscal de  */
+/* Consumidor Eletrônica - NFC-e (http://www.nfe.fazenda.gov.br)                */
+/*                                                                              */
+/* Direitos Autorais Reservados (c) 2014 Adenilton Batista da Silva             */
+/*                                       Zeusdev Tecnologia LTDA ME             */
+/*                                                                              */
+/*  Você pode obter a última versão desse arquivo no GitHub                     */
+/* localizado em https://github.com/adeniltonbs/Zeus.Net.NFe.NFCe               */
+/*                                                                              */
+/*                                                                              */
+/*  Esta biblioteca é software livre; você pode redistribuí-la e/ou modificá-la */
+/* sob os termos da Licença Pública Geral Menor do GNU conforme publicada pela  */
+/* Free Software Foundation; tanto a versão 2.1 da Licença, ou (a seu critério) */
+/* qualquer versão posterior.                                                   */
+/*                                                                              */
+/*  Esta biblioteca é distribuída na expectativa de que seja útil, porém, SEM   */
+/* NENHUMA GARANTIA; nem mesmo a garantia implícita de COMERCIABILIDADE OU      */
+/* ADEQUAÇÃO A UMA FINALIDADE ESPECÍFICA. Consulte a Licença Pública Geral Menor*/
+/* do GNU para mais detalhes. (Arquivo LICENÇA.TXT ou LICENSE.TXT)              */
+/*                                                                              */
+/*  Você deve ter recebido uma cópia da Licença Pública Geral Menor do GNU junto*/
+/* com esta biblioteca; se não, escreva para a Free Software Foundation, Inc.,  */
+/* no endereço 59 Temple Street, Suite 330, Boston, MA 02111-1307 USA.          */
+/* Você também pode obter uma copia da licença em:                              */
+/* http://www.opensource.org/licenses/lgpl-license.php                          */
+/*                                                                              */
+/* Zeusdev Tecnologia LTDA ME - adenilton@zeusautomacao.com.br                  */
+/* http://www.zeusautomacao.com.br/                                             */
+/* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
+/********************************************************************************/
+
+namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Compartilhado.InformacoesIbsCbs
+{
+    public class gMonoRet
+    {
+        private decimal _qBcMonoRet;
+        private decimal _adRemIbsRet;
+        private decimal _vIbsMonoRet;
+        private decimal _adRemCbsRet;
+        private decimal _vCbsMonoRet;
+        
+        /// <summary>
+        ///     UB95 - Quantidade tributada retida anteriormente
+        /// </summary>
+        public decimal qBCMonoRet
+        {
+            get => _qBcMonoRet.Arredondar(4);
+            set => _qBcMonoRet = value.Arredondar(4);
+        }
+        
+        /// <summary>
+        ///     UB96 - Alíquota ad rem do IBS retido anteriormente
+        /// </summary>
+        public decimal adRemIBSRet
+        {
+            get => _adRemIbsRet.Arredondar(4);
+            set => _adRemIbsRet = value.Arredondar(4);
+        }
+        
+        /// <summary>
+        ///     UB97 - Valor do IBS retido anteriormente
+        /// </summary>
+        public decimal vIBSMonoRet
+        {
+            get => _vIbsMonoRet.Arredondar(2);
+            set => _vIbsMonoRet = value.Arredondar(2);
+        }
+        
+        /// <summary>
+        ///     UB98 - Alíquota ad rem da CBS retida anteriormente
+        /// </summary>
+        public decimal adRemCBSRet
+        {
+            get => _adRemCbsRet.Arredondar(4);
+            set => _adRemCbsRet = value.Arredondar(4);
+        }
+        
+        /// <summary>
+        ///     UB98a - Valor da CBS retida anteriormente
+        /// </summary>
+        public decimal vCBSMonoRet
+        {
+            get => _vCbsMonoRet.Arredondar(2);
+            set => _vCbsMonoRet = value.Arredondar(2);
+        }
+    }
+}

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Compartilhado/InformacoesIbsCbs/gMonoReten.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Compartilhado/InformacoesIbsCbs/gMonoReten.cs
@@ -1,0 +1,89 @@
+﻿/********************************************************************************/
+/* Projeto: Biblioteca ZeusNFe                                                  */
+/* Biblioteca C# para emissão de Nota Fiscal Eletrônica - NFe e Nota Fiscal de  */
+/* Consumidor Eletrônica - NFC-e (http://www.nfe.fazenda.gov.br)                */
+/*                                                                              */
+/* Direitos Autorais Reservados (c) 2014 Adenilton Batista da Silva             */
+/*                                       Zeusdev Tecnologia LTDA ME             */
+/*                                                                              */
+/*  Você pode obter a última versão desse arquivo no GitHub                     */
+/* localizado em https://github.com/adeniltonbs/Zeus.Net.NFe.NFCe               */
+/*                                                                              */
+/*                                                                              */
+/*  Esta biblioteca é software livre; você pode redistribuí-la e/ou modificá-la */
+/* sob os termos da Licença Pública Geral Menor do GNU conforme publicada pela  */
+/* Free Software Foundation; tanto a versão 2.1 da Licença, ou (a seu critério) */
+/* qualquer versão posterior.                                                   */
+/*                                                                              */
+/*  Esta biblioteca é distribuída na expectativa de que seja útil, porém, SEM   */
+/* NENHUMA GARANTIA; nem mesmo a garantia implícita de COMERCIABILIDADE OU      */
+/* ADEQUAÇÃO A UMA FINALIDADE ESPECÍFICA. Consulte a Licença Pública Geral Menor*/
+/* do GNU para mais detalhes. (Arquivo LICENÇA.TXT ou LICENSE.TXT)              */
+/*                                                                              */
+/*  Você deve ter recebido uma cópia da Licença Pública Geral Menor do GNU junto*/
+/* com esta biblioteca; se não, escreva para a Free Software Foundation, Inc.,  */
+/* no endereço 59 Temple Street, Suite 330, Boston, MA 02111-1307 USA.          */
+/* Você também pode obter uma copia da licença em:                              */
+/* http://www.opensource.org/licenses/lgpl-license.php                          */
+/*                                                                              */
+/* Zeusdev Tecnologia LTDA ME - adenilton@zeusautomacao.com.br                  */
+/* http://www.zeusautomacao.com.br/                                             */
+/* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
+/********************************************************************************/
+
+namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Compartilhado.InformacoesIbsCbs
+{
+    public class gMonoReten
+    {
+        private decimal _qBcMonoReten;
+        private decimal _adRemIbsReten;
+        private decimal _vIbsMonoReten;
+        private decimal _adRemCbsReten;
+        private decimal _vCbsMonoReten;
+        
+        /// <summary>
+        ///     UB91 - Quantidade tributada sujeita à retenção na monofasia
+        /// </summary>
+        public decimal qBCMonoReten
+        {
+            get => _qBcMonoReten.Arredondar(4);
+            set => _qBcMonoReten = value.Arredondar(4);
+        }
+        
+        /// <summary>
+        ///     UB92 - Alíquota ad rem do IBS sujeito a retenção
+        /// </summary>
+        public decimal adRemIBSReten
+        {
+            get => _adRemIbsReten.Arredondar(4);
+            set => _adRemIbsReten = value.Arredondar(4);
+        }
+        
+        /// <summary>
+        ///     UB93 - Valor do IBS monofásico sujeito a retenção
+        /// </summary>
+        public decimal vIBSMonoReten
+        {
+            get => _vIbsMonoReten.Arredondar(2);
+            set => _vIbsMonoReten = value.Arredondar(2);
+        }
+        
+        /// <summary>
+        ///     UB93a - Alíquota ad rem da CBS sujeito a retenção
+        /// </summary>
+        public decimal adRemCBSReten
+        {
+            get => _adRemCbsReten.Arredondar(4);
+            set => _adRemCbsReten = value.Arredondar(4);
+        }
+        
+        /// <summary>
+        ///     UB93b - Valor da CBS monofásica sujeita a retenção
+        /// </summary>
+        public decimal vCBSMonoReten
+        {
+            get => _vCbsMonoReten.Arredondar(2);
+            set => _vCbsMonoReten = value.Arredondar(2);
+        }
+    }
+}

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Compartilhado/InformacoesIbsCbs/gTribCompraGov.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Compartilhado/InformacoesIbsCbs/gTribCompraGov.cs
@@ -35,65 +35,65 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Compartilhado.InformacoesIb
 {
     public class gTribCompraGov
     {
-        private decimal _pIbsUf;
-        private decimal _vIbsUf;
-        private decimal _pIbsMun;
-        private decimal _vIbsMun;
-        private decimal _pCbs;
-        private decimal _vCbs;
+        private decimal _pAliqIbsUf;
+        private decimal _vTribIbsUf;
+        private decimal _pAliqIbsMun;
+        private decimal _vTribIbsMun;
+        private decimal _pAliqCbs;
+        private decimal _vTribCbs;
         
         /// <summary>
         ///     UB82b - Alíquota do IBS de competência do Estado
         /// </summary>
-        public decimal pIBSUF
+        public decimal pAliqIBSUF
         {
-            get => _pIbsUf.Arredondar(4);
-            set => _pIbsUf = value.Arredondar(4);
+            get => _pAliqIbsUf.Arredondar(4);
+            set => _pAliqIbsUf = value.Arredondar(4);
         }
 
         /// <summary>
         ///     UB82c - Valor do Tributo do IBS da UF calculado
         /// </summary>
-        public decimal vIBSUF
+        public decimal vTribIBSUF
         {
-            get => _vIbsUf.Arredondar(2);
-            set => _vIbsUf = value.Arredondar(2);
+            get => _vTribIbsUf.Arredondar(2);
+            set => _vTribIbsUf = value.Arredondar(2);
         }
         
         /// <summary>
         ///     UB82d - Alíquota do IBS de competência do Município
         /// </summary>
-        public decimal pIBSMun
+        public decimal pAliqIBSMun
         {
-            get => _pIbsMun.Arredondar(4);
-            set => _pIbsMun = value.Arredondar(4);
+            get => _pAliqIbsMun.Arredondar(4);
+            set => _pAliqIbsMun = value.Arredondar(4);
         }
         
         /// <summary>
         ///     UB82e - Valor do Tributo do IBS do Município calculado
         /// </summary>
-        public decimal vIBSMun
+        public decimal vTribIBSMun
         {
-            get => _vIbsMun.Arredondar(2);
-            set => _vIbsMun = value.Arredondar(2);
+            get => _vTribIbsMun.Arredondar(2);
+            set => _vTribIbsMun = value.Arredondar(2);
         }
         
         /// <summary>
         ///     UB82f - Alíquota da CBS
         /// </summary>
-        public decimal pCBS
+        public decimal pAliqCBS
         {
-            get => _pCbs.Arredondar(4);
-            set => _pCbs = value.Arredondar(4);
+            get => _pAliqCbs.Arredondar(4);
+            set => _pAliqCbs = value.Arredondar(4);
         }
         
         /// <summary>
         ///     UB82g - Valor do Tributo da CBS calculado
         /// </summary>
-        public decimal vCBS
+        public decimal vTribCBS
         {
-            get => _vCbs.Arredondar(2);
-            set => _vCbs = value.Arredondar(2);
+            get => _vTribCbs.Arredondar(2);
+            set => _vTribCbs = value.Arredondar(2);
         }
     }
 }

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Compartilhado/InformacoesIbsCbs/gTribRegular.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Compartilhado/InformacoesIbsCbs/gTribRegular.cs
@@ -52,7 +52,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Compartilhado.InformacoesIb
         /// <summary>
         ///     UB70 - Código de Classificação Tributária do IBS e CBS
         /// </summary>
-        public int cClassTribReg { get; set; }
+        public string cClassTribReg { get; set; }
 
         /// <summary>
         ///     UB71 - Valor da alíquota do IBS da UF

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Federal/IS.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Federal/IS.cs
@@ -54,7 +54,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
         ///     UB03 - Código de Classificação Tributária do Imposto Seletivo
         /// </summary>
         [XmlElement(Order = 2)]
-        public int cClassTribIS { get; set; }
+        public string cClassTribIS { get; set; }
 
         /// <summary>
         ///     UB05 - Valor da Base de Cálculo do Imposto Seletivo 

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Federal/IS.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Federal/IS.cs
@@ -111,5 +111,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Federal
             get => _vIs.Arredondar(2);
             set => _vIs = value.Arredondar(2);
         }
+        
+        public bool ShouldSerializepISEspec() => pISEspec.HasValue;
     }
 }

--- a/NFe.Classes/Informacoes/Detalhe/det.cs
+++ b/NFe.Classes/Informacoes/Detalhe/det.cs
@@ -85,5 +85,7 @@ namespace NFe.Classes.Informacoes.Detalhe
         ///     VC01 - Documento Fiscal Eletrônico Referenciado
         /// </summary>
         public DFeReferenciado DFeReferenciado { get; set; }
+
+        public bool ShouldSerializevItem() => vItem.HasValue;
     }
 }

--- a/NFe.Classes/Informacoes/Detalhe/prod.cs
+++ b/NFe.Classes/Informacoes/Detalhe/prod.cs
@@ -353,5 +353,6 @@ namespace NFe.Classes.Informacoes.Detalhe
             return vOutro.HasValue && vOutro > 0;
         }
         
+        public bool ShouldSerializeindBemMovelUsado() => indBemMovelUsado.HasValue;
     }
 }

--- a/NFe.Classes/Informacoes/Identificacao/Tipos/ideTipos.cs
+++ b/NFe.Classes/Informacoes/Identificacao/Tipos/ideTipos.cs
@@ -590,7 +590,11 @@ namespace NFe.Classes.Informacoes.Identificacao.Tipos
         
         [Description("Apropriação de crédito presumido de IBS sobre o saldo devedor na ZFM (art. 450, § 1º, LC 214/25)")]
         [XmlEnum("2")]
-        ApropriacaoDeCredito
+        ApropriacaoDeCredito,
+        
+        [Description("Retorno")]
+        [XmlEnum("3")]
+        Retorno
     }
 
     /// <summary>

--- a/NFe.Classes/Informacoes/Identificacao/gPagAntecipado.cs
+++ b/NFe.Classes/Informacoes/Identificacao/gPagAntecipado.cs
@@ -32,6 +32,7 @@
 /********************************************************************************/
 
 using System.Collections.Generic;
+using System.Xml.Serialization;
 
 namespace NFe.Classes.Informacoes.Identificacao
 {
@@ -43,6 +44,7 @@ namespace NFe.Classes.Informacoes.Identificacao
         /// <summary>
         ///     BB02 - Chave de acesso da NF-e de antecipação de pagamento
         /// </summary>
-        private List<string> refNFe { get; set; }
+        [XmlElement("refNFe")]
+        public List<string> refNFe { get; set; }
     }
 }

--- a/NFe.Classes/Informacoes/Identificacao/ide.cs
+++ b/NFe.Classes/Informacoes/Identificacao/ide.cs
@@ -270,7 +270,7 @@ namespace NFe.Classes.Informacoes.Identificacao
         /// <summary>
         ///     B31 - Grupo de Compra Governamental
         /// </summary>
-        public gCompraGov GCompraGov { get; set; }
+        public gCompraGov gCompraGov { get; set; }
         
         /// <summary>
         ///     BB01 - Grupo de notas de antecipação de pagamento

--- a/NFe.Classes/Informacoes/Identificacao/ide.cs
+++ b/NFe.Classes/Informacoes/Identificacao/ide.cs
@@ -291,5 +291,11 @@ namespace NFe.Classes.Informacoes.Identificacao
         {
             return indPres.HasValue;
         }
+        
+        public bool ShouldSerializetpNFDebito() => tpNFDebito.HasValue;
+        
+        public bool ShouldSerializetpNFCredito() => tpNFCredito.HasValue;
+        
+        public bool ShouldSerializecMunFGIBS() => cMunFGIBS.HasValue;
     }
 }

--- a/NFe.Classes/Informacoes/Total/IbsCbs/Cbs/gCBSTotal.cs
+++ b/NFe.Classes/Informacoes/Total/IbsCbs/Cbs/gCBSTotal.cs
@@ -31,39 +31,59 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 
-namespace NFe.Classes.Informacoes.Total.IbsCbs.Ibs
+namespace NFe.Classes.Informacoes.Total.IbsCbs.Cbs
 {
-    public class gIBSMun
+    public class gCBSTotal
     {
         private decimal _vDif;
         private decimal _vDevTrib;
-        private decimal _vIBSMun;
-
+        private decimal _vCBS;
+        private decimal _vCredPres;
+        private decimal _vCredPresCondSus;
+        
         /// <summary>
-        ///     W43 - Valor total do diferimento
+        ///     W53 - Valor total do diferimento
         /// </summary>
         public decimal vDif
         {
             get => _vDif;
             set => _vDif = value.Arredondar(2);
         }
-
+        
         /// <summary>
-        ///     W44 - Valor total de devolução de tributos
+        ///     W54 - Valor total de devolução de tributos
         /// </summary>
         public decimal vDevTrib
         {
             get => _vDevTrib;
             set => _vDevTrib = value.Arredondar(2);
         }
+        
+        /// <summary>
+        ///     W56 - Valor total do CBS
+        /// </summary>
+        public decimal vCBS
+        {
+            get => _vCBS;
+            set => _vCBS = value.Arredondar(2);
+        }
 
         /// <summary>
-        ///     W46 - Valor total do IBS do Município
+        ///     W56a - Valor total do crédito presumido
         /// </summary>
-        public decimal vIBSMun
+        public decimal vCredPres
         {
-            get => _vIBSMun;
-            set => _vIBSMun = value.Arredondar(2);
+            get => _vCredPres;
+            set => _vCredPres = value.Arredondar(2);
+        }
+
+        /// <summary>
+        ///     W56b - Valor total do crédito presumido em condição suspensiva
+        /// </summary>
+        public decimal vCredPresCondSus
+        {
+            get => _vCredPresCondSus;
+            set => _vCredPresCondSus = value.Arredondar(2);
         }
     }
 }

--- a/NFe.Classes/Informacoes/Total/IbsCbs/IBSCBSTot.cs
+++ b/NFe.Classes/Informacoes/Total/IbsCbs/IBSCBSTot.cs
@@ -31,6 +31,7 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 
+using System.Xml.Serialization;
 using NFe.Classes.Informacoes.Total.IbsCbs.Cbs;
 using NFe.Classes.Informacoes.Total.IbsCbs.Ibs;
 using NFe.Classes.Informacoes.Total.IbsCbs.Monofasica;
@@ -58,7 +59,8 @@ namespace NFe.Classes.Informacoes.Total.IbsCbs
         /// <summary>
         ///     W50 - Grupo total do CBS
         /// </summary>
-        public gCBS gCBS { get; set; }
+        [XmlElement("gCBS")]
+        public gCBSTotal gCBS { get; set; }
         
         /// <summary>
         ///     W57 - Grupo total da Monofasia

--- a/NFe.Classes/Informacoes/Total/IbsCbs/Ibs/gIBS.cs
+++ b/NFe.Classes/Informacoes/Total/IbsCbs/Ibs/gIBS.cs
@@ -31,6 +31,8 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 
+using System.Xml.Serialization;
+
 namespace NFe.Classes.Informacoes.Total.IbsCbs.Ibs
 {
     public class gIBS
@@ -42,12 +44,14 @@ namespace NFe.Classes.Informacoes.Total.IbsCbs.Ibs
         /// <summary>
         ///     W37 - Grupo total do IBS da UF
         /// </summary>
-        public gIBSUF gIBSUF  { get; set; }
+        [XmlElement("gIBSUF")]
+        public gIBSUFTotal gIBSUF  { get; set; }
         
         /// <summary>
         ///     W42 - Grupo total do IBS do Município
         /// </summary>
-        public gIBSMun gIBSMun  { get; set; }
+        [XmlElement("gIBSMun")]
+        public gIBSMunTotal gIBSMun  { get; set; }
         
         /// <summary>
         ///     W47 - Valor total do IBS

--- a/NFe.Classes/Informacoes/Total/IbsCbs/Ibs/gIBSMunTotal.cs
+++ b/NFe.Classes/Informacoes/Total/IbsCbs/Ibs/gIBSMunTotal.cs
@@ -31,59 +31,39 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 
-namespace NFe.Classes.Informacoes.Total.IbsCbs.Cbs
+namespace NFe.Classes.Informacoes.Total.IbsCbs.Ibs
 {
-    public class gCBS
+    public class gIBSMunTotal
     {
         private decimal _vDif;
         private decimal _vDevTrib;
-        private decimal _vCBS;
-        private decimal _vCredPres;
-        private decimal _vCredPresCondSus;
-        
+        private decimal _vIBSMun;
+
         /// <summary>
-        ///     W53 - Valor total do diferimento
+        ///     W43 - Valor total do diferimento
         /// </summary>
         public decimal vDif
         {
             get => _vDif;
             set => _vDif = value.Arredondar(2);
         }
-        
+
         /// <summary>
-        ///     W54 - Valor total de devolução de tributos
+        ///     W44 - Valor total de devolução de tributos
         /// </summary>
         public decimal vDevTrib
         {
             get => _vDevTrib;
             set => _vDevTrib = value.Arredondar(2);
         }
-        
-        /// <summary>
-        ///     W56 - Valor total do CBS
-        /// </summary>
-        public decimal vCBS
-        {
-            get => _vCBS;
-            set => _vCBS = value.Arredondar(2);
-        }
 
         /// <summary>
-        ///     W56a - Valor total do crédito presumido
+        ///     W46 - Valor total do IBS do Município
         /// </summary>
-        public decimal vCredPres
+        public decimal vIBSMun
         {
-            get => _vCredPres;
-            set => _vCredPres = value.Arredondar(2);
-        }
-
-        /// <summary>
-        ///     W56b - Valor total do crédito presumido em condição suspensiva
-        /// </summary>
-        public decimal vCredPresCondSus
-        {
-            get => _vCredPresCondSus;
-            set => _vCredPresCondSus = value.Arredondar(2);
+            get => _vIBSMun;
+            set => _vIBSMun = value.Arredondar(2);
         }
     }
 }

--- a/NFe.Classes/Informacoes/Total/IbsCbs/Ibs/gIBSUFTotal.cs
+++ b/NFe.Classes/Informacoes/Total/IbsCbs/Ibs/gIBSUFTotal.cs
@@ -33,7 +33,7 @@
 
 namespace NFe.Classes.Informacoes.Total.IbsCbs.Ibs
 {
-    public class gIBSUF
+    public class gIBSUFTotal
     {
         private decimal _vDif;
         private decimal _vDevTrib;

--- a/NFe.Classes/Informacoes/Total/total.cs
+++ b/NFe.Classes/Informacoes/Total/total.cs
@@ -37,7 +37,7 @@ namespace NFe.Classes.Informacoes.Total
 {
     public class total
     {
-        private decimal _vNFTot;
+        private decimal? _vNFTot;
 
         /// <summary>
         ///     W02 - Grupo Totais referentes ao ICMS
@@ -66,11 +66,14 @@ namespace NFe.Classes.Informacoes.Total
 
         /// <summary>
         ///     W60 - Valor total da NF-e com IBS / CBS / IS
+        ///     Campo obrigatório quando for informado valores do IBS, CBS e IS.
         /// </summary>
-        public decimal vNFTot
+        public decimal? vNFTot
         {
             get => _vNFTot;
             set => _vNFTot = value.Arredondar(2);
         }
+        
+        public bool ShouldSerializevNFTot() => vNFTot.HasValue;
     }
 }

--- a/NFe.Classes/Informacoes/Total/total.cs
+++ b/NFe.Classes/Informacoes/Total/total.cs
@@ -66,7 +66,6 @@ namespace NFe.Classes.Informacoes.Total
 
         /// <summary>
         ///     W60 - Valor total da NF-e com IBS / CBS / IS
-        ///     Campo obrigatório quando for informado valores do IBS, CBS e IS.
         /// </summary>
         public decimal? vNFTot
         {


### PR DESCRIPTION
- Ajustado classes para correção do erro: **_Erro ao refletir propriedade (Ocorrido na serialização)_**:
  - NFe.Classes.Informacoes.Total.IbsCbs.Ibs.gIBSUF;
  - NFe.Classes.Informacoes.Detalhe.Tributacao.Compartilhado.InformacoesIbsCbs.InformacoesIbs.gIBSUF;
  - NFe.Classes.Informacoes.Total.IbsCbs.Ibs.gIBSMun;
  - NFe.Classes.Informacoes.Detalhe.Tributacao.Compartilhado.InformacoesIbsCbs.InformacoesIbs.gIBSMun;
  - NFe.Classes.Informacoes.Total.IbsCbs.Cbs.gCBS;
  - NFe.Classes.Informacoes.Detalhe.Tributacao.Compartilhado.InformacoesIbsCbs.InformacoesCbs.gCBS;

- Alterado de int para string alguns campos para correção do erro: **_Erro de valor inválido para código da classificação tributária (Ocorrido na validação dos schemas)_**:
  - NFe.Classes.Informacoes.Detalhe.Tributacao.Compartilhado.cClassTrib;
  - NFe.Classes.Informacoes.Detalhe.Tributacao.Compartilhado.InformacoesIbsCbs.cClassTribReg;
  - NFe.Classes.Informacoes.Detalhe.Tributacao.Federal.cClassTribIS;

- Implementado ShouldSerialize em campos anuláveis para correção do erro: _**Campos vazios sendo serializado (Ocorrido na validação dos schemas)**_;
- Implementado novos campos da nova nota técnica: Nota Técnica 2025.002-RTC - Versão 1.20 Julho de 2025;
- Ajustado campos alterado pela nova nota técnica: Nota Técnica 2025.002-RTC - Versão 1.20 Julho de 2025;
- Adicionado anotação de sequência de campos com sequência obrigatória;
- Outras correções de nomes de elemento.