### PR TITLE
Suporte ao netstandard 2.0 nos pacotes Zeus.Net.NFe.Danfe.PdfClown e Zeus.Net.NFe.Danfe.QuestPdf

### DIFF
--- a/NFe.Danfe.PdfClown/NFe.Danfe.PdfClown.csproj
+++ b/NFe.Danfe.PdfClown/NFe.Danfe.PdfClown.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>netstandard2.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<LangVersion>latest</LangVersion>

--- a/NFe.Danfe.PdfClown/NFe.Danfe.PdfClown.csproj
+++ b/NFe.Danfe.PdfClown/NFe.Danfe.PdfClown.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
+		<TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<LangVersion>latest</LangVersion>

--- a/NFe.Danfe.QuestPdf/ImpressaoEventoNfe/EventoNfeDocument.cs
+++ b/NFe.Danfe.QuestPdf/ImpressaoEventoNfe/EventoNfeDocument.cs
@@ -1,12 +1,12 @@
-﻿using System.Text;
-using System.Text.RegularExpressions;
-using BarcodeStandard;
+﻿using BarcodeStandard;
 using DFe.Utils;
 using NFe.Classes;
 using NFe.Classes.Servicos.Consulta;
 using QuestPDF.Fluent;
 using QuestPDF.Helpers;
 using QuestPDF.Infrastructure;
+using System.Text;
+using System.Text.RegularExpressions;
 
 namespace NFe.Danfe.QuestPdf.ImpressaoEventoNfe;
 
@@ -651,4 +651,6 @@ public class EventoNfeDocument : IDocument
                 "Ei! Verifique se seu xml da Carta Correção não está correto, pois identificamos uma falha ao tentar carregar ele.");
         }
     }
+
+    DocumentSettings IDocument.GetSettings() => DocumentSettings.Default;
 }

--- a/NFe.Danfe.QuestPdf/ImpressaoNfce/DanfeNfceDocument.cs
+++ b/NFe.Danfe.QuestPdf/ImpressaoNfce/DanfeNfceDocument.cs
@@ -1,5 +1,4 @@
-﻿using System.Text;
-using DFe.Classes.Flags;
+﻿using DFe.Classes.Flags;
 using DFe.Utils;
 using NFe.Classes;
 using NFe.Classes.Informacoes.Destinatario;
@@ -11,6 +10,7 @@ using QuestPDF.Helpers;
 using QuestPDF.Infrastructure;
 using SkiaSharp;
 using SkiaSharp.QrCode.Image;
+using System.Text;
 
 namespace NFe.Danfe.QuestPdf.ImpressaoNfce;
 
@@ -50,6 +50,7 @@ public class DanfeNfceDocument : IDocument
     }
 
     public DocumentMetadata GetMetadata() => DocumentMetadata.Default;
+    DocumentSettings IDocument.GetSettings() => DocumentSettings.Default;
 
     public void Compose(IDocumentContainer container)
     {

--- a/NFe.Danfe.QuestPdf/Models/PeriodoModel.cs
+++ b/NFe.Danfe.QuestPdf/Models/PeriodoModel.cs
@@ -2,6 +2,6 @@
 
 public class PeriodoModel
 {
-    public DateOnly DataInicial { get; set; }
-    public DateOnly DataFinal { get; set; }
+    public DateTime DataInicial { get; set; }
+    public DateTime DataFinal { get; set; }
 }

--- a/NFe.Danfe.QuestPdf/NFe.Danfe.QuestPdf.csproj
+++ b/NFe.Danfe.QuestPdf/NFe.Danfe.QuestPdf.csproj
@@ -1,33 +1,34 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<Nullable>enable</Nullable>
-		<PackageId>Zeus.Net.NFe.Danfe.QuestPdf</PackageId>
-		<Title>Zeus.Net.NFe.Danfe.QuestPdf</Title>
-		<Authors>ZeusAutomacao</Authors>
-		<Company>Zeus Automacao</Company>
-		<Description>Biblioteca para geração de DANFE em PDF usando QuestPDF.</Description>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <PackageId>Zeus.Net.NFe.Danfe.QuestPdf</PackageId>
+    <Title>Zeus.Net.NFe.Danfe.QuestPdf</Title>
+    <Authors>ZeusAutomacao</Authors>
+    <Company>Zeus Automacao</Company>
+    <Description>Biblioteca para geração de DANFE em PDF usando QuestPDF.</Description>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<None Remove="Fontes\Arial.ttf" />
-	</ItemGroup>
+  <ItemGroup>
+    <None Remove="Fontes\Arial.ttf" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<EmbeddedResource Include="Fontes\Arial.ttf">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</EmbeddedResource>
-	</ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Fontes\Arial.ttf">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </EmbeddedResource>
+  </ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="BarcodeLib" Version="3.1.4" />
-		<PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="7.3.0.2" />
-		<PackageReference Include="QuestPDF" Version="2024.7.3" />
-		<PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.8" />
-		<PackageReference Include="SkiaSharp.QrCode" Version="0.7.0" />
-		<PackageReference Include="Zeus.Net.NFe.NFCe" Version="2025.3.28.1516" />
-	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="BarcodeLib" Version="3.1.4" />
+    <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="7.3.0.2" />
+    <PackageReference Include="QuestPDF" Version="2024.7.3" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.8" />
+    <PackageReference Include="SkiaSharp.QrCode" Version="0.7.0" />
+    <PackageReference Include="Zeus.Net.NFe.NFCe" Version="2025.3.28.1516" />
+  </ItemGroup>
 
 </Project>

--- a/NFe.Danfe.QuestPdf/NFe.Danfe.QuestPdf.csproj
+++ b/NFe.Danfe.QuestPdf/NFe.Danfe.QuestPdf.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>

--- a/NFe.Danfe.QuestPdf/ParaContadores/RelatorioFiscalEmissoesNfceDocument.cs
+++ b/NFe.Danfe.QuestPdf/ParaContadores/RelatorioFiscalEmissoesNfceDocument.cs
@@ -16,6 +16,7 @@ public class RelatorioFiscalEmissoesNfceDocument : IDocument
     }
 
     public DocumentMetadata GetMetadata() => DocumentMetadata.Default;
+    DocumentSettings IDocument.GetSettings() => DocumentSettings.Default;
 
     public void Compose(IDocumentContainer container)
     {

--- a/NFe.Danfe.QuestPdf/ParaContadores/RelatorioFiscalEmissoesNfeDocument.cs
+++ b/NFe.Danfe.QuestPdf/ParaContadores/RelatorioFiscalEmissoesNfeDocument.cs
@@ -16,6 +16,7 @@ public class RelatorioFiscalEmissoesNfeDocument : IDocument
     }
 
     public DocumentMetadata GetMetadata() => DocumentMetadata.Default;
+    DocumentSettings IDocument.GetSettings() => DocumentSettings.Default;
 
     public void Compose(IDocumentContainer container)
     {


### PR DESCRIPTION
[[…Zeus.Net.NFe.Danfe.QuestPdf](https://github.com/ZeusAutomacao/DFe.NET/issues/1640)](https://github.com/ZeusAutomacao/DFe.NET/issues/1640)

**Descrição:**  
Adicionar suporte ao net standard 2.0 nos pacotes Zeus.Net.NFe.Danfe.QuestPdf e Zeus.Net.NFe.Danfe.PdfClown, para que possa ser usado em sistemas legados (.net framework). Atualmente, só tem suporte ao .net6+

**Benefícios:**  
- Ampliaria o suporte da biblioteca para sistemas legados, usando .NET Framework
- Deixaria padronizado o suporte em relação aos demais

**Requisitos:**  
- Alterar o TargetFramework dos projetos NFe.Danfe.PdfClown e NFe.Danfe.QuestPdf para netstandard2.0.