### PR TITLE
Adicionados novos campos definidos pela NT 2025.001 v1.03

### DIFF
--- a/MDFe.Classes/Flags/MDFeTpCarga.cs
+++ b/MDFe.Classes/Flags/MDFeTpCarga.cs
@@ -36,5 +36,8 @@ namespace MDFe.Classes.Flags
 
         [XmlEnum("11")]
         PerigosaCargaGeral = 11,
+        
+        [XmlEnum("12")]
+        GranelPressurizada = 12
     }
 }

--- a/MDFe.Classes/Flags/MDFeTpComp.cs
+++ b/MDFe.Classes/Flags/MDFeTpComp.cs
@@ -12,6 +12,9 @@ namespace MDFe.Classes.Flags
 
         [XmlEnum("03")]
         DespesasBancariasEMeiosDePagamentoOutras = 03,
+        
+        [XmlEnum("04")]
+        Frete = 04,
 
         [XmlEnum("99")]
         Outros = 99

--- a/MDFe.Classes/Informacoes/MDFeAquav.cs
+++ b/MDFe.Classes/Informacoes/MDFeAquav.cs
@@ -110,11 +110,18 @@ namespace MDFe.Classes.Informacoes
         public List<MDFeInfEmbComb> InfEmbCombs { get; set; }
 
         /// <summary>
-        /// 1 - Informações das Undades de Carga vazias
+        /// 1 - Informações das Unidades de Carga vazias
         /// </summary>
         [XmlElement(ElementName = "infUnidCargaVazia")]
         public List<MDFeInfUnidCargaVazia> InfUnidCargaVazias { get; set; }
 
+        /// <summary>
+        /// 1 - Informações das Unidades de Transporte vazias
+        /// </summary>
         public List<infUnidTranspVazia> infUnidTranspVazia { get; set; }
-    }
+        
+        /// <summary>
+        /// 1 - Maritime Mobile Service Identify
+        /// </summary>
+        public string MMSI { get; set; }     }
 }

--- a/MDFe.Classes/Informacoes/MDFeTpValePed.cs
+++ b/MDFe.Classes/Informacoes/MDFeTpValePed.cs
@@ -44,6 +44,9 @@ namespace MDFe.Classes.Informacoes
         Cupom = 02,
 
         [XmlEnum("03")]
-        Cartao = 03
+        Cartao = 03,
+
+        [XmlEnum("04")]
+        LeituraDePlaca = 04
     }
 }


### PR DESCRIPTION
Ajustes referentes a NT 2025.001 v1.03 do MDFe.

Alterações:

- MDFeTpCarga: Adicionada opção Granel Pressurizada;
- MDFeTpComp: Adicionada opção Frete;
- MDFeTpValePed: Adicionada opção Leitura de Placa;
- MDFeAquav: Adicionado campo MMSI.

Obs: As modificações dos Schemas introduzidos nessa NT serão enviados em um novo PR.