### PR TITLE
bugfix - inserido o ordenamento dos campos do XML do gIBS (UF e Mun) e gCBS

### DIFF
--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Compartilhado/InformacoesIbsCbs/InformacoesCbs/gCBS.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Compartilhado/InformacoesIbsCbs/InformacoesCbs/gCBS.cs
@@ -31,44 +31,51 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 
+using System.Xml.Serialization;
+
 namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Compartilhado.InformacoesIbsCbs.InformacoesCbs
 {
-    public class gCBS
-    {
-        private decimal _pCbs;
-        private decimal _vCbs;
+  public class gCBS
+  {
+    private decimal _pCbs;
+    private decimal _vCbs;
 
-        /// <summary>
-        ///     UB56 - Alíquota da CBS
-        /// </summary>
-        public decimal pCBS
-        {
-            get => _pCbs.Arredondar(4);
-            set => _pCbs = value.Arredondar(4);
-        }
-        
-        /// <summary>
-        ///     UB67 - Valor da CBS
-        /// </summary>
-        public decimal vCBS
-        {
-            get => _vCbs.Arredondar(2);
-            set => _vCbs = value.Arredondar(2);
-        }
-        
-        /// <summary>
-        ///     UB59 - Grupo de Informações do Diferimento
-        /// </summary>
-        public gDif gDif { get; set; }
-        
-        /// <summary>
-        ///     UB62 - Grupo de Informações da devolução de tributos
-        /// </summary>
-        public gDevTrib gDevTrib { get; set; }
-        
-        /// <summary>
-        ///     UB64 - Grupo de informações da redução da alíquota
-        /// </summary>
-        public gRed gRed { get; set; }
+    /// <summary>
+    ///     UB56 - Alíquota da CBS
+    /// </summary>
+    [XmlElement(Order = 1)]
+    public decimal pCBS
+    {
+      get => _pCbs.Arredondar(4);
+      set => _pCbs = value.Arredondar(4);
     }
+
+    /// <summary>
+    ///     UB67 - Valor da CBS
+    /// </summary>
+    [XmlElement(Order = 5)]
+    public decimal vCBS
+    {
+      get => _vCbs.Arredondar(2);
+      set => _vCbs = value.Arredondar(2);
+    }
+
+    /// <summary>
+    ///     UB59 - Grupo de Informações do Diferimento
+    /// </summary>
+    [XmlElement(Order = 2)]
+    public gDif gDif { get; set; }
+
+    /// <summary>
+    ///     UB62 - Grupo de Informações da devolução de tributos
+    /// </summary>
+    [XmlElement(Order = 3)]
+    public gDevTrib gDevTrib { get; set; }
+
+    /// <summary>
+    ///     UB64 - Grupo de informações da redução da alíquota
+    /// </summary>
+    [XmlElement(Order = 4)]
+    public gRed gRed { get; set; }
+  }
 }

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Compartilhado/InformacoesIbsCbs/InformacoesIbs/gIBSMun.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Compartilhado/InformacoesIbsCbs/InformacoesIbs/gIBSMun.cs
@@ -31,44 +31,51 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 
+using System.Xml.Serialization;
+
 namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Compartilhado.InformacoesIbsCbs.InformacoesIbs
 {
-    public class gIBSMun
-    {
-        private decimal _pIbsMun;
-        private decimal _vIbsMun;
+  public class gIBSMun
+  {
+    private decimal _pIbsMun;
+    private decimal _vIbsMun;
 
-        /// <summary>
-        ///     UB37 - Alíquota do IBS de competência do Município
-        /// </summary>
-        public decimal pIBSMun
-        {
-            get => _pIbsMun.Arredondar(4);
-            set => _pIbsMun = value.Arredondar(4);
-        }
-        
-        /// <summary>
-        ///     UB54 - Valor do IBS de competência do Município
-        /// </summary>
-        public decimal vIBSMun
-        {
-            get => _vIbsMun.Arredondar(2);
-            set => _vIbsMun = value.Arredondar(2);
-        }
-        
-        /// <summary>
-        ///     UB40 - Grupo de Informações do Diferimento
-        /// </summary>
-        public gDif gDif { get; set; }
-        
-        /// <summary>
-        ///     UB43 - Grupo de Informações da devolução de tributos
-        /// </summary>
-        public gDevTrib gDevTrib { get; set; }
-        
-        /// <summary>
-        ///     UB45 - Grupo de informações da redução da alíquota
-        /// </summary>
-        public gRed gRed { get; set; }
+    /// <summary>
+    ///     UB37 - Alíquota do IBS de competência do Município
+    /// </summary>
+    [XmlElement(Order = 1)]
+    public decimal pIBSMun
+    {
+      get => _pIbsMun.Arredondar(4);
+      set => _pIbsMun = value.Arredondar(4);
     }
+
+    /// <summary>
+    ///     UB54 - Valor do IBS de competência do Município
+    /// </summary>
+    [XmlElement(Order = 5)]
+    public decimal vIBSMun
+    {
+      get => _vIbsMun.Arredondar(2);
+      set => _vIbsMun = value.Arredondar(2);
+    }
+
+    /// <summary>
+    ///     UB40 - Grupo de Informações do Diferimento
+    /// </summary>
+    [XmlElement(Order = 2)]
+    public gDif gDif { get; set; }
+
+    /// <summary>
+    ///     UB43 - Grupo de Informações da devolução de tributos
+    /// </summary>
+    [XmlElement(Order = 3)]
+    public gDevTrib gDevTrib { get; set; }
+
+    /// <summary>
+    ///     UB45 - Grupo de informações da redução da alíquota
+    /// </summary>
+    [XmlElement(Order = 4)]
+    public gRed gRed { get; set; }
+  }
 }

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Compartilhado/InformacoesIbsCbs/InformacoesIbs/gIBSUF.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Compartilhado/InformacoesIbsCbs/InformacoesIbs/gIBSUF.cs
@@ -31,44 +31,52 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 
+using System.Xml.Serialization;
+
 namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Compartilhado.InformacoesIbsCbs.InformacoesIbs
 {
-    public class gIBSUF
+  public class gIBSUF
+  {
+    private decimal _pIbsUf;
+    private decimal _vIbsUf;
+
+    /// <summary>
+    ///     UB18 - Alíquota do IBS de competência das UF
+    /// </summary>
+
+    [XmlElement(Order = 1)]
+    public decimal pIBSUF
     {
-        private decimal _pIbsUf;
-        private decimal _vIbsUf;
-        
-        /// <summary>
-        ///     UB18 - Alíquota do IBS de competência das UF
-        /// </summary>
-        public decimal pIBSUF
-        {
-            get => _pIbsUf.Arredondar(4);
-            set => _pIbsUf = value.Arredondar(4);
-        }
-        
-        /// <summary>
-        ///     UB21 - Grupo de Informações do Diferimento
-        /// </summary>
-        public gDif gDif { get; set; }
-        
-        /// <summary>
-        ///     UB24 - Grupo de Informações da devolução de tributos
-        /// </summary>
-        public gDevTrib gDevTrib { get; set; }
-        
-        /// <summary>
-        ///     UB26 - Grupo de informações da redução da alíquota
-        /// </summary>
-        public gRed gRed { get; set; }
-        
-        /// <summary>
-        ///     UB35 - Valor do IBS de competência da UF
-        /// </summary>
-        public decimal vIBSUF
-        {
-            get => _vIbsUf.Arredondar(2);
-            set => _vIbsUf = value.Arredondar(2);
-        }
+      get => _pIbsUf.Arredondar(4);
+      set => _pIbsUf = value.Arredondar(4);
     }
+
+    /// <summary>
+    ///     UB21 - Grupo de Informações do Diferimento
+    /// </summary>
+    [XmlElement(Order = 2)]
+    public gDif gDif { get; set; }
+
+    /// <summary>
+    ///     UB24 - Grupo de Informações da devolução de tributos
+    /// </summary>
+    [XmlElement(Order = 3)]
+    public gDevTrib gDevTrib { get; set; }
+
+    /// <summary>
+    ///     UB26 - Grupo de informações da redução da alíquota
+    /// </summary>
+    [XmlElement(Order = 4)]
+    public gRed gRed { get; set; }
+
+    /// <summary>
+    ///     UB35 - Valor do IBS de competência da UF
+    /// </summary>
+    [XmlElement(Order = 5)]
+    public decimal vIBSUF
+    {
+      get => _vIbsUf.Arredondar(2);
+      set => _vIbsUf = value.Arredondar(2);
+    }
+  }
 }


### PR DESCRIPTION
- Ordenamento dos campos do gIBSUF
- Ordenamento dos campos do gIBSMun
- Ordenamento dos campos do gCBS

A falta de ordenamento destes objetos estava causando falha de schema.