### PR TITLE
Fix/danfe quest pdf contingencia

### DIFF
--- a/NFe.Danfe.AppTeste.QuestPdf/MainWindow.xaml.cs
+++ b/NFe.Danfe.AppTeste.QuestPdf/MainWindow.xaml.cs
@@ -32,7 +32,6 @@
 /********************************************************************************/
 
 using Microsoft.Win32;
-using NFe.Classes;
 using NFe.Danfe.QuestPdf.ImpressaoNfce;
 using QuestPDF.Fluent;
 using QuestPDF.Infrastructure;
@@ -156,8 +155,7 @@ namespace NFe.Danfe.AppTeste.QuestPdf
 
         private void GerarDanfeNfce(string caminhoXml, TamanhoImpressao tamanho)
         {
-            var proc = new nfeProc().CarregarDeArquivoXml(caminhoXml);
-            var xml = proc.ObterXmlString();
+            var xml = File.ReadAllText(caminhoXml);
 
             var documento = new DanfeNfceDocument(xml, _logoMarcaBytes);
             documento.TamanhoImpressao(tamanho);

--- a/NFe.Danfe.QuestPdf/ImpressaoNfce/DanfeNfceDocument.cs
+++ b/NFe.Danfe.QuestPdf/ImpressaoNfce/DanfeNfceDocument.cs
@@ -3,6 +3,7 @@ using DFe.Classes.Flags;
 using DFe.Utils;
 using NFe.Classes;
 using NFe.Classes.Informacoes.Destinatario;
+using NFe.Classes.Informacoes.Identificacao.Tipos;
 using NFe.Classes.Informacoes.Pagamento;
 using NFe.Utils;
 using NFe.Utils.InformacoesSuplementares;

--- a/NFe.Danfe.QuestPdf/ImpressaoNfce/DanfeNfceDocument.cs
+++ b/NFe.Danfe.QuestPdf/ImpressaoNfce/DanfeNfceDocument.cs
@@ -349,6 +349,27 @@ public class DanfeNfceDocument : IDocument
 
                 column.Item().LineHorizontal(1);
 
+                if (DeveExibirMensagemContingencia())
+                {
+                    column.Item().Row(r =>
+                    {
+                        r.RelativeItem().AlignCenter().Column(c =>
+                        {
+                            c.Item().AlignCenter().Text("EMITIDA EM CONTINGÊNCIA").FontSize(_tamanhoFontePadrao).ExtraBlack();
+                        });
+                    });
+
+                    column.Item().Row(r =>
+                    {
+                        r.RelativeItem().AlignCenter().Column(c =>
+                        {
+                            c.Item().AlignCenter().Text("Pendente de autorização").FontSize(_tamanhoFontePadrao).ExtraBlack();
+                        });
+                    });
+
+                    column.Item().LineHorizontal(1);
+                }
+
                 column.Item().Row(r =>
                 {
                     r.RelativeItem().AlignCenter().Column(c =>
@@ -372,11 +393,18 @@ public class DanfeNfceDocument : IDocument
                         t.Cell().AlignCenter().Image(ImagemQrCode());
                         t.Cell().AlignLeft().Column(c =>
                         {
-                            c.Item().Text($"Série: {_nfe.infNFe.ide.serie:D3}").FontSize(_tamanhoFontePadrao);
-                            c.Item().Text($"Número: {_nfe.infNFe.ide.nNF:D9}").FontSize(_tamanhoFontePadrao);
-                            c.Item().Text($"Emissão: {_nfeProc.NFe.infNFe.ide.dhEmi:G}").FontSize(_tamanhoFontePadrao);
-                            c.Item().Text($"Protocolo: {_nfeProc.protNFe.infProt.nProt}").FontSize(_tamanhoFontePadrao);
-                            c.Item().Text($"Autorização: {_nfeProc.protNFe.infProt.dhRecbto:G}").FontSize(_tamanhoFontePadrao);
+                            if (_nfe?.infNFe?.ide != null)
+                            {
+                                c.Item().Text($"Série: {_nfe.infNFe.ide.serie:D3}").FontSize(_tamanhoFontePadrao);
+                                c.Item().Text($"Número: {_nfe.infNFe.ide.nNF:D9}").FontSize(_tamanhoFontePadrao);
+                                c.Item().Text($"Emissão: {_nfe.infNFe.ide.dhEmi:G}").FontSize(_tamanhoFontePadrao);
+                            }
+
+                            if (DeveExibirDadosProtocolo())
+                            {
+                                c.Item().Text($"Protocolo: {_nfeProc!.protNFe!.infProt.nProt}").FontSize(_tamanhoFontePadrao);
+                                c.Item().Text($"Autorização: {_nfeProc!.protNFe!.infProt.dhRecbto:G}").FontSize(_tamanhoFontePadrao);
+                            }
                         });
                     });
                 });
@@ -531,6 +559,8 @@ public class DanfeNfceDocument : IDocument
     {
         try
         {
+            _nfeProc = null;
+            _nfe = null;
             _nfeProc = FuncoesXml.XmlStringParaClasse<nfeProc>(xml);
             _nfe = _nfeProc.NFe;
         }
@@ -540,6 +570,7 @@ public class DanfeNfceDocument : IDocument
             {
                 NFe.Classes.NFe nfe = FuncoesXml.XmlStringParaClasse<NFe.Classes.NFe>(xml);
                 _nfe = nfe;
+                _nfeProc = null;
             }
             catch (Exception)
             {
@@ -547,6 +578,16 @@ public class DanfeNfceDocument : IDocument
                     "Ei! Verifique se seu xml está correto, pois identificamos uma falha ao tentar carregar ele.");
             }
         }
+    }
+
+    private bool DeveExibirMensagemContingencia()
+    {
+        return _nfe?.infNFe?.ide?.tpEmis == TipoEmissao.teOffLine && _nfeProc == null;
+    }
+
+    private bool DeveExibirDadosProtocolo()
+    {
+        return _nfeProc?.protNFe?.infProt != null && !DeveExibirMensagemContingencia();
     }
 
     private string ObtemDescricao(FormaPagamento? formaPagamento)


### PR DESCRIPTION
Fiz 2 pequenos ajustes:

- Tratamento para não ocorrer erro ao tentar imprimir um xml de nfce gerado em contingência e sem nfeproc.
- Inclusão de texto para indicar que o XML foi gerado em contingência.

<img width="456" height="800" alt="image" src="https://github.com/user-attachments/assets/ff3c85ba-e01b-4b1a-9884-18d64b03cc08" />
