### PR TITLE
fix: correção de versionamento de eventos em rotina assíncrona.

### DIFF
--- a/CTe.Servicos/Eventos/ServicoController.cs
+++ b/CTe.Servicos/Eventos/ServicoController.cs
@@ -113,8 +113,20 @@ namespace CTe.Servicos.Eventos
 
             evento.SalvarXmlEmDisco(configServico);
 
-            var webService = WsdlFactory.CriaWsdlCteEvento(configServico);
-            var retornoXml = await webService.cteRecepcaoEventoAsync(evento.CriaXmlRequestWs());
+            XmlNode retornoXml = null;
+
+            if (evento.versao == versao.ve200 || evento.versao == versao.ve300)
+            {
+                var webService = WsdlFactory.CriaWsdlCteEvento(configServico);
+                retornoXml = await webService.cteRecepcaoEventoAsync(evento.CriaXmlRequestWs());
+            }
+
+            if (evento.versao == versao.ve400)
+            {
+                var webService = WsdlFactory.CriaWsdlCteEventoV4(configServico);
+                retornoXml = await webService.cteRecepcaoEventoAsync(evento.CriaXmlRequestWs());
+            }
+            
 
             var retorno = retEventoCTe.LoadXml(retornoXml.OuterXml, evento);
             retorno.SalvarXmlEmDisco(configServico);


### PR DESCRIPTION
Ao criar eventos do CTe em rotina assíncrona o tipo de evento criado não é versionado corretamente, causando erros na SEFAZ SP em rotina assíncrona, onde a URN enviada é definida como 'CTeDistribuicaoDFe/cteDistDFeInteresse' em versão 4.0, onde na verdade deveria ser 'CTeRecepcaoEventoV4/cteRecepcaoEvento'.

Ver arquivo CteRecepcaoEvento.cs, linha 62, comparado com CteRecepcaoEventoV4, linha 52.

