### PR TITLE
IBS e CBS, CTe reforma tributaria

### DIFF
--- a/CTe.Classes/Informacoes/Impostos/CBS.cs
+++ b/CTe.Classes/Informacoes/Impostos/CBS.cs
@@ -1,4 +1,4 @@
-﻿/********************************************************************************/
+/********************************************************************************/
 /* Projeto: Biblioteca ZeusNFe                                                  */
 /* Biblioteca C# para emissão de Nota Fiscal Eletrônica - NFe e Nota Fiscal de  */
 /* Consumidor Eletrônica - NFC-e (http://www.nfe.fazenda.gov.br)                */
@@ -31,35 +31,50 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 
+using CTe.Classes.Informacoes.Impostos.Tipos;
 using DFe.Classes;
 
 namespace CTe.Classes.Informacoes.Impostos
 {
-    public class imp
+    /// <summary>
+    /// Grupo da CBS (Contribuição sobre Bens e Serviços)
+    /// </summary>
+    public class CBS
     {
-        public Tributacao.ICMS ICMS { get; set; }
+        private decimal _vBcCbs;
+        private decimal _pCbs;
+        private decimal _vCbs;
 
-        private decimal? _vTotTrib;
+        /// <summary>
+        /// Código de Situação Tributária da CBS
+        /// </summary>
+        public CstIbsCbs CSTCBS { get; set; }
 
-        public decimal? vTotTrib
+        /// <summary>
+        /// Valor da Base de Cálculo da CBS
+        /// </summary>
+        public decimal vBCCBS
         {
-            get { return _vTotTrib.Arredondar(2); }
-            set { _vTotTrib = value.Arredondar(2); }
+            get { return _vBcCbs.Arredondar(2); }
+            set { _vBcCbs = value.Arredondar(2); }
         }
 
-        public bool vTotTribSpecified
+        /// <summary>
+        /// Alíquota da CBS
+        /// </summary>
+        public decimal pCBS
         {
-            get { return vTotTrib.HasValue; }
+            get { return _pCbs.Arredondar(2); }
+            set { _pCbs = value.Arredondar(2); }
         }
 
-        public string infAdFisco { get; set; }
-
-        public ICMSUFFim ICMSUFFim { get; set; }
-
-        public infTribFed infTribFed { get; set; }
-
-        public IBS IBS { get; set; }
-
-        public CBS CBS { get; set; }
+        /// <summary>
+        /// Valor da CBS
+        /// </summary>
+        public decimal vCBS
+        {
+            get { return _vCbs.Arredondar(2); }
+            set { _vCbs = value.Arredondar(2); }
+        }
     }
 }

--- a/CTe.Classes/Informacoes/Impostos/IBS.cs
+++ b/CTe.Classes/Informacoes/Impostos/IBS.cs
@@ -1,4 +1,4 @@
-﻿/********************************************************************************/
+/********************************************************************************/
 /* Projeto: Biblioteca ZeusNFe                                                  */
 /* Biblioteca C# para emissão de Nota Fiscal Eletrônica - NFe e Nota Fiscal de  */
 /* Consumidor Eletrônica - NFC-e (http://www.nfe.fazenda.gov.br)                */
@@ -31,35 +31,50 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 
+using CTe.Classes.Informacoes.Impostos.Tipos;
 using DFe.Classes;
 
 namespace CTe.Classes.Informacoes.Impostos
 {
-    public class imp
+    /// <summary>
+    /// Grupo do IBS (Imposto sobre Bens e Serviços)
+    /// </summary>
+    public class IBS
     {
-        public Tributacao.ICMS ICMS { get; set; }
+        private decimal _vBcIbs;
+        private decimal _pIbs;
+        private decimal _vIbs;
 
-        private decimal? _vTotTrib;
+        /// <summary>
+        /// Código de Situação Tributária do IBS
+        /// </summary>
+        public CstIbsCbs CSTIBS { get; set; }
 
-        public decimal? vTotTrib
+        /// <summary>
+        /// Valor da Base de Cálculo do IBS
+        /// </summary>
+        public decimal vBCIBS
         {
-            get { return _vTotTrib.Arredondar(2); }
-            set { _vTotTrib = value.Arredondar(2); }
+            get { return _vBcIbs.Arredondar(2); }
+            set { _vBcIbs = value.Arredondar(2); }
         }
 
-        public bool vTotTribSpecified
+        /// <summary>
+        /// Alíquota do IBS
+        /// </summary>
+        public decimal pIBS
         {
-            get { return vTotTrib.HasValue; }
+            get { return _pIbs.Arredondar(2); }
+            set { _pIbs = value.Arredondar(2); }
         }
 
-        public string infAdFisco { get; set; }
-
-        public ICMSUFFim ICMSUFFim { get; set; }
-
-        public infTribFed infTribFed { get; set; }
-
-        public IBS IBS { get; set; }
-
-        public CBS CBS { get; set; }
+        /// <summary>
+        /// Valor do IBS
+        /// </summary>
+        public decimal vIBS
+        {
+            get { return _vIbs.Arredondar(2); }
+            set { _vIbs = value.Arredondar(2); }
+        }
     }
 }

--- a/CTe.Classes/Informacoes/Impostos/IBSCBS.cs
+++ b/CTe.Classes/Informacoes/Impostos/IBSCBS.cs
@@ -1,4 +1,4 @@
-﻿/********************************************************************************/
+/********************************************************************************/
 /* Projeto: Biblioteca ZeusNFe                                                  */
 /* Biblioteca C# para emissão de Nota Fiscal Eletrônica - NFe e Nota Fiscal de  */
 /* Consumidor Eletrônica - NFC-e (http://www.nfe.fazenda.gov.br)                */
@@ -31,49 +31,29 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 
-using DFe.Classes;
+using CTe.Classes.Informacoes.Impostos.InformacoesIbsCbs;
+using CTe.Classes.Informacoes.Impostos.Tipos;
 
 namespace CTe.Classes.Informacoes.Impostos
 {
-    public class imp
+    /// <summary>
+    /// Grupo do IBS e CBS
+    /// </summary>
+    public class IBSCBS
     {
-        public Tributacao.ICMS ICMS { get; set; }
-
-        private decimal? _vTotTrib;
-
-        public decimal? vTotTrib
-        {
-            get { return _vTotTrib.Arredondar(2); }
-            set { _vTotTrib = value.Arredondar(2); }
-        }
-
-        public bool vTotTribSpecified
-        {
-            get { return vTotTrib.HasValue; }
-        }
-
-        public string infAdFisco { get; set; }
-
-        public ICMSUFFim ICMSUFFim { get; set; }
-
-        public infTribFed infTribFed { get; set; }
-
-        public IBSCBS IBSCBS { get; set; }
-
-        private decimal? _vTotDFe;
+        /// <summary>
+        /// Código de Situação Tributária do IBS e CBS
+        /// </summary>
+        public CstIbsCbs CST { get; set; }
 
         /// <summary>
-        /// Valor Total do DFe
+        /// Código de Classificação Tributária do IBS e CBS
         /// </summary>
-        public decimal? vTotDFe
-        {
-            get { return _vTotDFe.Arredondar(2); }
-            set { _vTotDFe = value.Arredondar(2); }
-        }
+        public string cClassTrib { get; set; }
 
-        public bool vTotDFeSpecified
-        {
-            get { return vTotDFe.HasValue; }
-        }
+        /// <summary>
+        /// Grupo de Informações do IBS e da CBS
+        /// </summary>
+        public gIBSCBS gIBSCBS { get; set; }
     }
 }

--- a/CTe.Classes/Informacoes/Impostos/ICMSUFFim.cs
+++ b/CTe.Classes/Informacoes/Impostos/ICMSUFFim.cs
@@ -45,6 +45,8 @@ namespace CTe.Classes.Informacoes.Impostos
         private decimal _vFcpufFim;
         private decimal _vIcmsufFim;
         private decimal _vIcmsufIni;
+        private decimal? _vIcmsRel;
+        private decimal? _pIcmsRel;
 
         public decimal vBCUFFim
         {
@@ -78,10 +80,19 @@ namespace CTe.Classes.Informacoes.Impostos
 
         public bool pICMSInterPartSpecified
         {
-            get
-            {
-                return this._pIcmsInterPart.HasValue;
-            }
+            get { return this._pIcmsInterPart.HasValue; }
+        }
+
+
+        public decimal? pICMSRel
+        {
+            get { return _pIcmsRel.Arredondar(2); }
+            set { _pIcmsRel = value.Arredondar(2); }
+        }
+
+        public bool pICMSRelSpecified
+        {
+            get { return _pIcmsRel.HasValue; }
         }
 
         public decimal vFCPUFFim
@@ -100,6 +111,17 @@ namespace CTe.Classes.Informacoes.Impostos
         {
             get { return _vIcmsufIni.Arredondar(2); }
             set { _vIcmsufIni = value.Arredondar(2); }
+        }
+
+        public decimal? vICMSRel
+        {
+            get { return _vIcmsRel.Arredondar(2); }
+            set { _vIcmsRel = value.Arredondar(2); }
+        }
+
+        public bool vICMSRelSpecified
+        {
+            get { return _vIcmsRel.HasValue; }
         }
     }
 }

--- a/CTe.Classes/Informacoes/Impostos/InformacoesIbsCbs/InformacoesCbs/gCBS.cs
+++ b/CTe.Classes/Informacoes/Impostos/InformacoesIbsCbs/InformacoesCbs/gCBS.cs
@@ -1,4 +1,4 @@
-﻿/********************************************************************************/
+/********************************************************************************/
 /* Projeto: Biblioteca ZeusNFe                                                  */
 /* Biblioteca C# para emissão de Nota Fiscal Eletrônica - NFe e Nota Fiscal de  */
 /* Consumidor Eletrônica - NFC-e (http://www.nfe.fazenda.gov.br)                */
@@ -31,49 +31,50 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 
+using CTe.Classes.Informacoes.Impostos.InformacoesIbsCbs;
 using DFe.Classes;
 
-namespace CTe.Classes.Informacoes.Impostos
+namespace CTe.Classes.Informacoes.Impostos.InformacoesIbsCbs.InformacoesCbs
 {
-    public class imp
+    /// <summary>
+    /// Grupo de Informações da CBS
+    /// </summary>
+    public class gCBS
     {
-        public Tributacao.ICMS ICMS { get; set; }
-
-        private decimal? _vTotTrib;
-
-        public decimal? vTotTrib
-        {
-            get { return _vTotTrib.Arredondar(2); }
-            set { _vTotTrib = value.Arredondar(2); }
-        }
-
-        public bool vTotTribSpecified
-        {
-            get { return vTotTrib.HasValue; }
-        }
-
-        public string infAdFisco { get; set; }
-
-        public ICMSUFFim ICMSUFFim { get; set; }
-
-        public infTribFed infTribFed { get; set; }
-
-        public IBSCBS IBSCBS { get; set; }
-
-        private decimal? _vTotDFe;
+        private decimal _pCbs;
+        private decimal _vCbs;
 
         /// <summary>
-        /// Valor Total do DFe
+        /// Alíquota da CBS (em percentual)
         /// </summary>
-        public decimal? vTotDFe
+        public decimal pCBS
         {
-            get { return _vTotDFe.Arredondar(2); }
-            set { _vTotDFe = value.Arredondar(2); }
+            get { return _pCbs.Arredondar(2); }
+            set { _pCbs = value.Arredondar(2); }
         }
 
-        public bool vTotDFeSpecified
+        /// <summary>
+        /// Grupo de Informações do Diferimento
+        /// </summary>
+        public gDif gDif { get; set; }
+
+        /// <summary>
+        /// Grupo de Informações da Devolução de Tributos
+        /// </summary>
+        public gDevTrib gDevTrib { get; set; }
+
+        /// <summary>
+        /// Grupo de Informações da Redução da Alíquota
+        /// </summary>
+        public gRed gRed { get; set; }
+
+        /// <summary>
+        /// Valor da CBS
+        /// </summary>
+        public decimal vCBS
         {
-            get { return vTotDFe.HasValue; }
+            get { return _vCbs.Arredondar(2); }
+            set { _vCbs = value.Arredondar(2); }
         }
     }
 }

--- a/CTe.Classes/Informacoes/Impostos/InformacoesIbsCbs/InformacoesIbs/gIBSMun.cs
+++ b/CTe.Classes/Informacoes/Impostos/InformacoesIbsCbs/InformacoesIbs/gIBSMun.cs
@@ -1,4 +1,4 @@
-﻿/********************************************************************************/
+/********************************************************************************/
 /* Projeto: Biblioteca ZeusNFe                                                  */
 /* Biblioteca C# para emissão de Nota Fiscal Eletrônica - NFe e Nota Fiscal de  */
 /* Consumidor Eletrônica - NFC-e (http://www.nfe.fazenda.gov.br)                */
@@ -31,49 +31,50 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 
+using CTe.Classes.Informacoes.Impostos.InformacoesIbsCbs;
 using DFe.Classes;
 
-namespace CTe.Classes.Informacoes.Impostos
+namespace CTe.Classes.Informacoes.Impostos.InformacoesIbsCbs.InformacoesIbs
 {
-    public class imp
+    /// <summary>
+    /// Grupo de Informações do IBS para o município
+    /// </summary>
+    public class gIBSMun
     {
-        public Tributacao.ICMS ICMS { get; set; }
-
-        private decimal? _vTotTrib;
-
-        public decimal? vTotTrib
-        {
-            get { return _vTotTrib.Arredondar(2); }
-            set { _vTotTrib = value.Arredondar(2); }
-        }
-
-        public bool vTotTribSpecified
-        {
-            get { return vTotTrib.HasValue; }
-        }
-
-        public string infAdFisco { get; set; }
-
-        public ICMSUFFim ICMSUFFim { get; set; }
-
-        public infTribFed infTribFed { get; set; }
-
-        public IBSCBS IBSCBS { get; set; }
-
-        private decimal? _vTotDFe;
+        private decimal _pIbsMun;
+        private decimal _vIbsMun;
 
         /// <summary>
-        /// Valor Total do DFe
+        /// Alíquota do IBS de competência do Município (em percentual)
         /// </summary>
-        public decimal? vTotDFe
+        public decimal pIBSMun
         {
-            get { return _vTotDFe.Arredondar(2); }
-            set { _vTotDFe = value.Arredondar(2); }
+            get { return _pIbsMun.Arredondar(2); }
+            set { _pIbsMun = value.Arredondar(2); }
         }
 
-        public bool vTotDFeSpecified
+        /// <summary>
+        /// Grupo de Informações do Diferimento
+        /// </summary>
+        public gDif gDif { get; set; }
+
+        /// <summary>
+        /// Grupo de Informações da Devolução de Tributos
+        /// </summary>
+        public gDevTrib gDevTrib { get; set; }
+
+        /// <summary>
+        /// Grupo de Informações da Redução da Alíquota
+        /// </summary>
+        public gRed gRed { get; set; }
+
+        /// <summary>
+        /// Valor do IBS de competência do Município
+        /// </summary>
+        public decimal vIBSMun
         {
-            get { return vTotDFe.HasValue; }
+            get { return _vIbsMun.Arredondar(2); }
+            set { _vIbsMun = value.Arredondar(2); }
         }
     }
 }

--- a/CTe.Classes/Informacoes/Impostos/InformacoesIbsCbs/InformacoesIbs/gIBSUF.cs
+++ b/CTe.Classes/Informacoes/Impostos/InformacoesIbsCbs/InformacoesIbs/gIBSUF.cs
@@ -31,50 +31,50 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 
-using CTe.Classes.Informacoes.Impostos.Tipos;
+using CTe.Classes.Informacoes.Impostos.InformacoesIbsCbs;
 using DFe.Classes;
 
-namespace CTe.Classes.Informacoes.Impostos
+namespace CTe.Classes.Informacoes.Impostos.InformacoesIbsCbs.InformacoesIbs
 {
     /// <summary>
-    /// Grupo da CBS (Contribuição sobre Bens e Serviços)
+    /// Grupo de Informações do IBS para a UF
     /// </summary>
-    public class CBS
+    public class gIBSUF
     {
-        private decimal _vBcCbs;
-        private decimal _pCbs;
-        private decimal _vCbs;
+        private decimal _pIbsUf;
+        private decimal _vIbsUf;
 
         /// <summary>
-        /// Código de Situação Tributária da CBS
+        /// Alíquota do IBS de competência das UF (em percentual)
         /// </summary>
-        public CstIbsCbs CSTCBS { get; set; }
-
-        /// <summary>
-        /// Valor da Base de Cálculo da CBS
-        /// </summary>
-        public decimal vBCCBS
+        public decimal pIBSUF
         {
-            get { return _vBcCbs.Arredondar(2); }
-            set { _vBcCbs = value.Arredondar(2); }
+            get { return _pIbsUf.Arredondar(2); }
+            set { _pIbsUf = value.Arredondar(2); }
         }
 
         /// <summary>
-        /// Alíquota da CBS
+        /// Grupo de Informações do Diferimento
         /// </summary>
-        public decimal pCBS
-        {
-            get { return _pCbs.Arredondar(2); }
-            set { _pCbs = value.Arredondar(2); }
-        }
+        public gDif gDif { get; set; }
 
         /// <summary>
-        /// Valor da CBS
+        /// Grupo de Informações da Devolução de Tributos
         /// </summary>
-        public decimal vCBS
+        public gDevTrib gDevTrib { get; set; }
+
+        /// <summary>
+        /// Grupo de Informações da Redução da Alíquota
+        /// </summary>
+        public gRed gRed { get; set; }
+
+        /// <summary>
+        /// Valor do IBS de competência da UF
+        /// </summary>
+        public decimal vIBSUF
         {
-            get { return _vCbs.Arredondar(2); }
-            set { _vCbs = value.Arredondar(2); }
+            get { return _vIbsUf.Arredondar(2); }
+            set { _vIbsUf = value.Arredondar(2); }
         }
     }
 }

--- a/CTe.Classes/Informacoes/Impostos/InformacoesIbsCbs/gCBSCredPres.cs
+++ b/CTe.Classes/Informacoes/Impostos/InformacoesIbsCbs/gCBSCredPres.cs
@@ -1,4 +1,4 @@
-﻿/********************************************************************************/
+/********************************************************************************/
 /* Projeto: Biblioteca ZeusNFe                                                  */
 /* Biblioteca C# para emissão de Nota Fiscal Eletrônica - NFe e Nota Fiscal de  */
 /* Consumidor Eletrônica - NFC-e (http://www.nfe.fazenda.gov.br)                */
@@ -33,47 +33,47 @@
 
 using DFe.Classes;
 
-namespace CTe.Classes.Informacoes.Impostos
+namespace CTe.Classes.Informacoes.Impostos.InformacoesIbsCbs
 {
-    public class imp
+    /// <summary>
+    /// Grupo de Crédito Presumido da CBS
+    /// </summary>
+    public class gCBSCredPres
     {
-        public Tributacao.ICMS ICMS { get; set; }
-
-        private decimal? _vTotTrib;
-
-        public decimal? vTotTrib
-        {
-            get { return _vTotTrib.Arredondar(2); }
-            set { _vTotTrib = value.Arredondar(2); }
-        }
-
-        public bool vTotTribSpecified
-        {
-            get { return vTotTrib.HasValue; }
-        }
-
-        public string infAdFisco { get; set; }
-
-        public ICMSUFFim ICMSUFFim { get; set; }
-
-        public infTribFed infTribFed { get; set; }
-
-        public IBSCBS IBSCBS { get; set; }
-
-        private decimal? _vTotDFe;
+        private decimal _pCredPres;
+        private decimal _vCredPres;
+        private decimal _vCredPresCondSus;
 
         /// <summary>
-        /// Valor Total do DFe
+        /// Código de Crédito Presumido
         /// </summary>
-        public decimal? vTotDFe
+        public string cCredPres { get; set; }
+
+        /// <summary>
+        /// Percentual de Crédito Presumido (em percentual)
+        /// </summary>
+        public decimal pCredPres
         {
-            get { return _vTotDFe.Arredondar(2); }
-            set { _vTotDFe = value.Arredondar(2); }
+            get { return _pCredPres.Arredondar(2); }
+            set { _pCredPres = value.Arredondar(2); }
         }
 
-        public bool vTotDFeSpecified
+        /// <summary>
+        /// Valor de Crédito Presumido
+        /// </summary>
+        public decimal vCredPres
         {
-            get { return vTotDFe.HasValue; }
+            get { return _vCredPres.Arredondar(2); }
+            set { _vCredPres = value.Arredondar(2); }
+        }
+
+        /// <summary>
+        /// Valor de Crédito Presumido Condicionado ou Suspenso
+        /// </summary>
+        public decimal vCredPresCondSus
+        {
+            get { return _vCredPresCondSus.Arredondar(2); }
+            set { _vCredPresCondSus = value.Arredondar(2); }
         }
     }
 }

--- a/CTe.Classes/Informacoes/Impostos/InformacoesIbsCbs/gDevTrib.cs
+++ b/CTe.Classes/Informacoes/Impostos/InformacoesIbsCbs/gDevTrib.cs
@@ -1,4 +1,4 @@
-﻿/********************************************************************************/
+/********************************************************************************/
 /* Projeto: Biblioteca ZeusNFe                                                  */
 /* Biblioteca C# para emissão de Nota Fiscal Eletrônica - NFe e Nota Fiscal de  */
 /* Consumidor Eletrônica - NFC-e (http://www.nfe.fazenda.gov.br)                */
@@ -33,47 +33,22 @@
 
 using DFe.Classes;
 
-namespace CTe.Classes.Informacoes.Impostos
+namespace CTe.Classes.Informacoes.Impostos.InformacoesIbsCbs
 {
-    public class imp
+    /// <summary>
+    /// Grupo de Informações da Devolução de Tributos
+    /// </summary>
+    public class gDevTrib
     {
-        public Tributacao.ICMS ICMS { get; set; }
-
-        private decimal? _vTotTrib;
-
-        public decimal? vTotTrib
-        {
-            get { return _vTotTrib.Arredondar(2); }
-            set { _vTotTrib = value.Arredondar(2); }
-        }
-
-        public bool vTotTribSpecified
-        {
-            get { return vTotTrib.HasValue; }
-        }
-
-        public string infAdFisco { get; set; }
-
-        public ICMSUFFim ICMSUFFim { get; set; }
-
-        public infTribFed infTribFed { get; set; }
-
-        public IBSCBS IBSCBS { get; set; }
-
-        private decimal? _vTotDFe;
+        private decimal _vDevTrib;
 
         /// <summary>
-        /// Valor Total do DFe
+        /// Valor da devolução de tributos
         /// </summary>
-        public decimal? vTotDFe
+        public decimal vDevTrib
         {
-            get { return _vTotDFe.Arredondar(2); }
-            set { _vTotDFe = value.Arredondar(2); }
-        }
-
-        public bool vTotDFeSpecified
-        {
-            get { return vTotDFe.HasValue; }
+            get { return _vDevTrib.Arredondar(2); }
+            set { _vDevTrib = value.Arredondar(2); }
         }
     }
 }

--- a/CTe.Classes/Informacoes/Impostos/InformacoesIbsCbs/gDif.cs
+++ b/CTe.Classes/Informacoes/Impostos/InformacoesIbsCbs/gDif.cs
@@ -1,4 +1,4 @@
-﻿/********************************************************************************/
+/********************************************************************************/
 /* Projeto: Biblioteca ZeusNFe                                                  */
 /* Biblioteca C# para emissão de Nota Fiscal Eletrônica - NFe e Nota Fiscal de  */
 /* Consumidor Eletrônica - NFC-e (http://www.nfe.fazenda.gov.br)                */
@@ -33,47 +33,32 @@
 
 using DFe.Classes;
 
-namespace CTe.Classes.Informacoes.Impostos
+namespace CTe.Classes.Informacoes.Impostos.InformacoesIbsCbs
 {
-    public class imp
+    /// <summary>
+    /// Grupo de Informações do Diferimento
+    /// </summary>
+    public class gDif
     {
-        public Tributacao.ICMS ICMS { get; set; }
-
-        private decimal? _vTotTrib;
-
-        public decimal? vTotTrib
-        {
-            get { return _vTotTrib.Arredondar(2); }
-            set { _vTotTrib = value.Arredondar(2); }
-        }
-
-        public bool vTotTribSpecified
-        {
-            get { return vTotTrib.HasValue; }
-        }
-
-        public string infAdFisco { get; set; }
-
-        public ICMSUFFim ICMSUFFim { get; set; }
-
-        public infTribFed infTribFed { get; set; }
-
-        public IBSCBS IBSCBS { get; set; }
-
-        private decimal? _vTotDFe;
+        private decimal _pDif;
+        private decimal _vDif;
 
         /// <summary>
-        /// Valor Total do DFe
+        /// Percentual de diferimento (em percentual)
         /// </summary>
-        public decimal? vTotDFe
+        public decimal pDif
         {
-            get { return _vTotDFe.Arredondar(2); }
-            set { _vTotDFe = value.Arredondar(2); }
+            get { return _pDif.Arredondar(2); }
+            set { _pDif = value.Arredondar(2); }
         }
 
-        public bool vTotDFeSpecified
+        /// <summary>
+        /// Valor diferido
+        /// </summary>
+        public decimal vDif
         {
-            get { return vTotDFe.HasValue; }
+            get { return _vDif.Arredondar(2); }
+            set { _vDif = value.Arredondar(2); }
         }
     }
 }

--- a/CTe.Classes/Informacoes/Impostos/InformacoesIbsCbs/gIBSCBS.cs
+++ b/CTe.Classes/Informacoes/Impostos/InformacoesIbsCbs/gIBSCBS.cs
@@ -1,4 +1,4 @@
-﻿/********************************************************************************/
+/********************************************************************************/
 /* Projeto: Biblioteca ZeusNFe                                                  */
 /* Biblioteca C# para emissão de Nota Fiscal Eletrônica - NFe e Nota Fiscal de  */
 /* Consumidor Eletrônica - NFC-e (http://www.nfe.fazenda.gov.br)                */
@@ -31,49 +31,71 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 
+using CTe.Classes.Informacoes.Impostos.InformacoesIbsCbs.InformacoesCbs;
+using CTe.Classes.Informacoes.Impostos.InformacoesIbsCbs.InformacoesIbs;
 using DFe.Classes;
 
-namespace CTe.Classes.Informacoes.Impostos
+namespace CTe.Classes.Informacoes.Impostos.InformacoesIbsCbs
 {
-    public class imp
+    /// <summary>
+    /// Grupo de Informações do IBS e da CBS
+    /// </summary>
+    public class gIBSCBS
     {
-        public Tributacao.ICMS ICMS { get; set; }
-
-        private decimal? _vTotTrib;
-
-        public decimal? vTotTrib
-        {
-            get { return _vTotTrib.Arredondar(2); }
-            set { _vTotTrib = value.Arredondar(2); }
-        }
-
-        public bool vTotTribSpecified
-        {
-            get { return vTotTrib.HasValue; }
-        }
-
-        public string infAdFisco { get; set; }
-
-        public ICMSUFFim ICMSUFFim { get; set; }
-
-        public infTribFed infTribFed { get; set; }
-
-        public IBSCBS IBSCBS { get; set; }
-
-        private decimal? _vTotDFe;
+        private decimal _vBc;
+        private decimal _vIbs;
 
         /// <summary>
-        /// Valor Total do DFe
+        /// Base de cálculo do IBS e CBS
         /// </summary>
-        public decimal? vTotDFe
+        public decimal vBC
         {
-            get { return _vTotDFe.Arredondar(2); }
-            set { _vTotDFe = value.Arredondar(2); }
+            get { return _vBc.Arredondar(2); }
+            set { _vBc = value.Arredondar(2); }
         }
 
-        public bool vTotDFeSpecified
+        /// <summary>
+        /// Grupo de Informações do IBS para a UF
+        /// </summary>
+        public gIBSUF gIBSUF { get; set; }
+
+        /// <summary>
+        /// Grupo de Informações do IBS para o município
+        /// </summary>
+        public gIBSMun gIBSMun { get; set; }
+
+        /// <summary>
+        /// Valor do IBS
+        /// </summary>
+        public decimal vIBS
         {
-            get { return vTotDFe.HasValue; }
+            get { return _vIbs.Arredondar(2); }
+            set { _vIbs = value.Arredondar(2); }
         }
+
+        /// <summary>
+        /// Grupo de Informações da CBS
+        /// </summary>
+        public gCBS gCBS { get; set; }
+
+        /// <summary>
+        /// Grupo de Informações da Tributação Regular
+        /// </summary>
+        public gTribRegular gTribRegular { get; set; }
+
+        /// <summary>
+        /// Grupo de Crédito Presumido do IBS
+        /// </summary>
+        public gIBSCredPres gIBSCredPres { get; set; }
+
+        /// <summary>
+        /// Grupo de Crédito Presumido da CBS
+        /// </summary>
+        public gCBSCredPres gCBSCredPres { get; set; }
+
+        /// <summary>
+        /// Grupo de Informações da Composição do Valor do IBS e da CBS em Compras Governamentais
+        /// </summary>
+        public gTribCompraGov gTribCompraGov { get; set; }
     }
 }

--- a/CTe.Classes/Informacoes/Impostos/InformacoesIbsCbs/gIBSCredPres.cs
+++ b/CTe.Classes/Informacoes/Impostos/InformacoesIbsCbs/gIBSCredPres.cs
@@ -1,4 +1,4 @@
-﻿/********************************************************************************/
+/********************************************************************************/
 /* Projeto: Biblioteca ZeusNFe                                                  */
 /* Biblioteca C# para emissão de Nota Fiscal Eletrônica - NFe e Nota Fiscal de  */
 /* Consumidor Eletrônica - NFC-e (http://www.nfe.fazenda.gov.br)                */
@@ -33,47 +33,47 @@
 
 using DFe.Classes;
 
-namespace CTe.Classes.Informacoes.Impostos
+namespace CTe.Classes.Informacoes.Impostos.InformacoesIbsCbs
 {
-    public class imp
+    /// <summary>
+    /// Grupo de Crédito Presumido do IBS
+    /// </summary>
+    public class gIBSCredPres
     {
-        public Tributacao.ICMS ICMS { get; set; }
-
-        private decimal? _vTotTrib;
-
-        public decimal? vTotTrib
-        {
-            get { return _vTotTrib.Arredondar(2); }
-            set { _vTotTrib = value.Arredondar(2); }
-        }
-
-        public bool vTotTribSpecified
-        {
-            get { return vTotTrib.HasValue; }
-        }
-
-        public string infAdFisco { get; set; }
-
-        public ICMSUFFim ICMSUFFim { get; set; }
-
-        public infTribFed infTribFed { get; set; }
-
-        public IBSCBS IBSCBS { get; set; }
-
-        private decimal? _vTotDFe;
+        private decimal _pCredPres;
+        private decimal _vCredPres;
+        private decimal _vCredPresCondSus;
 
         /// <summary>
-        /// Valor Total do DFe
+        /// Código de Crédito Presumido
         /// </summary>
-        public decimal? vTotDFe
+        public string cCredPres { get; set; }
+
+        /// <summary>
+        /// Percentual de Crédito Presumido (em percentual)
+        /// </summary>
+        public decimal pCredPres
         {
-            get { return _vTotDFe.Arredondar(2); }
-            set { _vTotDFe = value.Arredondar(2); }
+            get { return _pCredPres.Arredondar(2); }
+            set { _pCredPres = value.Arredondar(2); }
         }
 
-        public bool vTotDFeSpecified
+        /// <summary>
+        /// Valor de Crédito Presumido
+        /// </summary>
+        public decimal vCredPres
         {
-            get { return vTotDFe.HasValue; }
+            get { return _vCredPres.Arredondar(2); }
+            set { _vCredPres = value.Arredondar(2); }
+        }
+
+        /// <summary>
+        /// Valor de Crédito Presumido Condicionado ou Suspenso
+        /// </summary>
+        public decimal vCredPresCondSus
+        {
+            get { return _vCredPresCondSus.Arredondar(2); }
+            set { _vCredPresCondSus = value.Arredondar(2); }
         }
     }
 }

--- a/CTe.Classes/Informacoes/Impostos/InformacoesIbsCbs/gRed.cs
+++ b/CTe.Classes/Informacoes/Impostos/InformacoesIbsCbs/gRed.cs
@@ -1,4 +1,4 @@
-﻿/********************************************************************************/
+/********************************************************************************/
 /* Projeto: Biblioteca ZeusNFe                                                  */
 /* Biblioteca C# para emissão de Nota Fiscal Eletrônica - NFe e Nota Fiscal de  */
 /* Consumidor Eletrônica - NFC-e (http://www.nfe.fazenda.gov.br)                */
@@ -33,47 +33,32 @@
 
 using DFe.Classes;
 
-namespace CTe.Classes.Informacoes.Impostos
+namespace CTe.Classes.Informacoes.Impostos.InformacoesIbsCbs
 {
-    public class imp
+    /// <summary>
+    /// Grupo de Informações da Redução da Alíquota
+    /// </summary>
+    public class gRed
     {
-        public Tributacao.ICMS ICMS { get; set; }
-
-        private decimal? _vTotTrib;
-
-        public decimal? vTotTrib
-        {
-            get { return _vTotTrib.Arredondar(2); }
-            set { _vTotTrib = value.Arredondar(2); }
-        }
-
-        public bool vTotTribSpecified
-        {
-            get { return vTotTrib.HasValue; }
-        }
-
-        public string infAdFisco { get; set; }
-
-        public ICMSUFFim ICMSUFFim { get; set; }
-
-        public infTribFed infTribFed { get; set; }
-
-        public IBSCBS IBSCBS { get; set; }
-
-        private decimal? _vTotDFe;
+        private decimal _pRedAliq;
+        private decimal _pAliqEfet;
 
         /// <summary>
-        /// Valor Total do DFe
+        /// Percentual de redução da alíquota (em percentual)
         /// </summary>
-        public decimal? vTotDFe
+        public decimal pRedAliq
         {
-            get { return _vTotDFe.Arredondar(2); }
-            set { _vTotDFe = value.Arredondar(2); }
+            get { return _pRedAliq.Arredondar(2); }
+            set { _pRedAliq = value.Arredondar(2); }
         }
 
-        public bool vTotDFeSpecified
+        /// <summary>
+        /// Percentual da alíquota efetiva (em percentual)
+        /// </summary>
+        public decimal pAliqEfet
         {
-            get { return vTotDFe.HasValue; }
+            get { return _pAliqEfet.Arredondar(2); }
+            set { _pAliqEfet = value.Arredondar(2); }
         }
     }
 }

--- a/CTe.Classes/Informacoes/Impostos/InformacoesIbsCbs/gTribCompraGov.cs
+++ b/CTe.Classes/Informacoes/Impostos/InformacoesIbsCbs/gTribCompraGov.cs
@@ -31,50 +31,74 @@
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
 
-using CTe.Classes.Informacoes.Impostos.Tipos;
 using DFe.Classes;
 
-namespace CTe.Classes.Informacoes.Impostos
+namespace CTe.Classes.Informacoes.Impostos.InformacoesIbsCbs
 {
     /// <summary>
-    /// Grupo do IBS (Imposto sobre Bens e Serviços)
+    /// Grupo de Informações da Composição do Valor do IBS e da CBS em Compras Governamentais
     /// </summary>
-    public class IBS
+    public class gTribCompraGov
     {
-        private decimal _vBcIbs;
-        private decimal _pIbs;
-        private decimal _vIbs;
+        private decimal _pAliqIBSUF;
+        private decimal _vTribIBSUF;
+        private decimal _pAliqIBSMun;
+        private decimal _vTribIBSMun;
+        private decimal _pAliqCBS;
+        private decimal _vTribCBS;
 
         /// <summary>
-        /// Código de Situação Tributária do IBS
+        /// Alíquota do IBS UF nas compras governamentais (em percentual)
         /// </summary>
-        public CstIbsCbs CSTIBS { get; set; }
-
-        /// <summary>
-        /// Valor da Base de Cálculo do IBS
-        /// </summary>
-        public decimal vBCIBS
+        public decimal pAliqIBSUF
         {
-            get { return _vBcIbs.Arredondar(2); }
-            set { _vBcIbs = value.Arredondar(2); }
+            get { return _pAliqIBSUF.Arredondar(2); }
+            set { _pAliqIBSUF = value.Arredondar(2); }
         }
 
         /// <summary>
-        /// Alíquota do IBS
+        /// Valor do tributo do IBS UF nas compras governamentais
         /// </summary>
-        public decimal pIBS
+        public decimal vTribIBSUF
         {
-            get { return _pIbs.Arredondar(2); }
-            set { _pIbs = value.Arredondar(2); }
+            get { return _vTribIBSUF.Arredondar(2); }
+            set { _vTribIBSUF = value.Arredondar(2); }
         }
 
         /// <summary>
-        /// Valor do IBS
+        /// Alíquota do IBS Município nas compras governamentais (em percentual)
         /// </summary>
-        public decimal vIBS
+        public decimal pAliqIBSMun
         {
-            get { return _vIbs.Arredondar(2); }
-            set { _vIbs = value.Arredondar(2); }
+            get { return _pAliqIBSMun.Arredondar(2); }
+            set { _pAliqIBSMun = value.Arredondar(2); }
+        }
+
+        /// <summary>
+        /// Valor do tributo do IBS Município nas compras governamentais
+        /// </summary>
+        public decimal vTribIBSMun
+        {
+            get { return _vTribIBSMun.Arredondar(2); }
+            set { _vTribIBSMun = value.Arredondar(2); }
+        }
+
+        /// <summary>
+        /// Alíquota da CBS nas compras governamentais (em percentual)
+        /// </summary>
+        public decimal pAliqCBS
+        {
+            get { return _pAliqCBS.Arredondar(2); }
+            set { _pAliqCBS = value.Arredondar(2); }
+        }
+
+        /// <summary>
+        /// Valor do tributo da CBS nas compras governamentais
+        /// </summary>
+        public decimal vTribCBS
+        {
+            get { return _vTribCBS.Arredondar(2); }
+            set { _vTribCBS = value.Arredondar(2); }
         }
     }
 }

--- a/CTe.Classes/Informacoes/Impostos/InformacoesIbsCbs/gTribRegular.cs
+++ b/CTe.Classes/Informacoes/Impostos/InformacoesIbsCbs/gTribRegular.cs
@@ -1,4 +1,4 @@
-﻿/********************************************************************************/
+/********************************************************************************/
 /* Projeto: Biblioteca ZeusNFe                                                  */
 /* Biblioteca C# para emissão de Nota Fiscal Eletrônica - NFe e Nota Fiscal de  */
 /* Consumidor Eletrônica - NFC-e (http://www.nfe.fazenda.gov.br)                */
@@ -33,47 +33,82 @@
 
 using DFe.Classes;
 
-namespace CTe.Classes.Informacoes.Impostos
+namespace CTe.Classes.Informacoes.Impostos.InformacoesIbsCbs
 {
-    public class imp
+    /// <summary>
+    /// Grupo de Informações da Tributação Regular
+    /// </summary>
+    public class gTribRegular
     {
-        public Tributacao.ICMS ICMS { get; set; }
-
-        private decimal? _vTotTrib;
-
-        public decimal? vTotTrib
-        {
-            get { return _vTotTrib.Arredondar(2); }
-            set { _vTotTrib = value.Arredondar(2); }
-        }
-
-        public bool vTotTribSpecified
-        {
-            get { return vTotTrib.HasValue; }
-        }
-
-        public string infAdFisco { get; set; }
-
-        public ICMSUFFim ICMSUFFim { get; set; }
-
-        public infTribFed infTribFed { get; set; }
-
-        public IBSCBS IBSCBS { get; set; }
-
-        private decimal? _vTotDFe;
+        private decimal _pAliqEfetRegIBSUF;
+        private decimal _vTribRegIBSUF;
+        private decimal _pAliqEfetRegIBSMun;
+        private decimal _vTribRegIBSMun;
+        private decimal _pAliqEfetRegCBS;
+        private decimal _vTribRegCBS;
 
         /// <summary>
-        /// Valor Total do DFe
+        /// Código de Situação Tributária da Tributação Regular
         /// </summary>
-        public decimal? vTotDFe
+        public string CSTReg { get; set; }
+
+        /// <summary>
+        /// Código de Classificação Tributária da Tributação Regular
+        /// </summary>
+        public string cClassTribReg { get; set; }
+
+        /// <summary>
+        /// Percentual da alíquota efetiva da Tributação Regular do IBS UF (em percentual)
+        /// </summary>
+        public decimal pAliqEfetRegIBSUF
         {
-            get { return _vTotDFe.Arredondar(2); }
-            set { _vTotDFe = value.Arredondar(2); }
+            get { return _pAliqEfetRegIBSUF.Arredondar(2); }
+            set { _pAliqEfetRegIBSUF = value.Arredondar(2); }
         }
 
-        public bool vTotDFeSpecified
+        /// <summary>
+        /// Valor da Tributação Regular do IBS UF
+        /// </summary>
+        public decimal vTribRegIBSUF
         {
-            get { return vTotDFe.HasValue; }
+            get { return _vTribRegIBSUF.Arredondar(2); }
+            set { _vTribRegIBSUF = value.Arredondar(2); }
+        }
+
+        /// <summary>
+        /// Percentual da alíquota efetiva da Tributação Regular do IBS Município (em percentual)
+        /// </summary>
+        public decimal pAliqEfetRegIBSMun
+        {
+            get { return _pAliqEfetRegIBSMun.Arredondar(2); }
+            set { _pAliqEfetRegIBSMun = value.Arredondar(2); }
+        }
+
+        /// <summary>
+        /// Valor da Tributação Regular do IBS Município
+        /// </summary>
+        public decimal vTribRegIBSMun
+        {
+            get { return _vTribRegIBSMun.Arredondar(2); }
+            set { _vTribRegIBSMun = value.Arredondar(2); }
+        }
+
+        /// <summary>
+        /// Percentual da alíquota efetiva da Tributação Regular da CBS (em percentual)
+        /// </summary>
+        public decimal pAliqEfetRegCBS
+        {
+            get { return _pAliqEfetRegCBS.Arredondar(2); }
+            set { _pAliqEfetRegCBS = value.Arredondar(2); }
+        }
+
+        /// <summary>
+        /// Valor da Tributação Regular da CBS
+        /// </summary>
+        public decimal vTribRegCBS
+        {
+            get { return _vTribRegCBS.Arredondar(2); }
+            set { _vTribRegCBS = value.Arredondar(2); }
         }
     }
 }

--- a/CTe.Classes/Informacoes/Impostos/Tipos/CstIbsCbs.cs
+++ b/CTe.Classes/Informacoes/Impostos/Tipos/CstIbsCbs.cs
@@ -1,0 +1,170 @@
+/********************************************************************************/
+/* Projeto: Biblioteca ZeusNFe                                                  */
+/* Biblioteca C# para emissão de Nota Fiscal Eletrônica - NFe e Nota Fiscal de  */
+/* Consumidor Eletrônica - NFC-e (http://www.nfe.fazenda.gov.br)                */
+/*                                                                              */
+/* Direitos Autorais Reservados (c) 2014 Adenilton Batista da Silva             */
+/*                                       Zeusdev Tecnologia LTDA ME             */
+/*                                                                              */
+/*  Você pode obter a última versão desse arquivo no GitHub                     */
+/* localizado em https://github.com/adeniltonbs/Zeus.Net.NFe.NFCe               */
+/*                                                                              */
+/*                                                                              */
+/*  Esta biblioteca é software livre; você pode redistribuí-la e/ou modificá-la */
+/* sob os termos da Licença Pública Geral Menor do GNU conforme publicada pela  */
+/* Free Software Foundation; tanto a versão 2.1 da Licença, ou (a seu critério) */
+/* qualquer versão posterior.                                                   */
+/*                                                                              */
+/*  Esta biblioteca é distribuída na expectativa de que seja útil, porém, SEM   */
+/* NENHUMA GARANTIA; nem mesmo a garantia implícita de COMERCIABILIDADE OU      */
+/* ADEQUAÇÃO A UMA FINALIDADE ESPECÍFICA. Consulte a Licença Pública Geral Menor*/
+/* do GNU para mais detalhes. (Arquivo LICENÇA.TXT ou LICENSE.TXT)              */
+/*                                                                              */
+/*  Você deve ter recebido uma cópia da Licença Pública Geral Menor do GNU junto*/
+/* com esta biblioteca; se não, escreva para a Free Software Foundation, Inc.,  */
+/* no endereço 59 Temple Street, Suite 330, Boston, MA 02111-1307 USA.          */
+/* Você também pode obter uma copia da licença em:                              */
+/* http://www.opensource.org/licenses/lgpl-license.php                          */
+/*                                                                              */
+/* Zeusdev Tecnologia LTDA ME - adenilton@zeusautomacao.com.br                  */
+/* http://www.zeusautomacao.com.br/                                             */
+/* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
+/********************************************************************************/
+
+using System.ComponentModel;
+using System.Xml.Serialization;
+
+namespace CTe.Classes.Informacoes.Impostos.Tipos
+{
+    /// <summary>
+    /// Código de Situação Tributária do IBS/CBS
+    /// </summary>
+    public enum CstIbsCbs
+    {
+        /// <summary>
+        /// 00 - Tributação integral
+        /// </summary>
+        [XmlEnum("00")]
+        [Description("Tributação integral")]
+        Cst00 = 0,
+
+        /// <summary>
+        /// 01 - Tributação com alíquotas uniformes
+        /// </summary>
+        [XmlEnum("01")]
+        [Description("Tributação com alíquotas uniformes")]
+        Cst01 = 1,
+
+        /// <summary>
+        /// 02 - Tributação com alíquotas uniformes reduzidas
+        /// </summary>
+        [XmlEnum("02")]
+        [Description("Tributação com alíquotas uniformes reduzidas")]
+        Cst02 = 2,
+
+        /// <summary>
+        /// 20 - Alíquota reduzida
+        /// </summary>
+        [XmlEnum("20")]
+        [Description("Alíquota reduzida")]
+        Cst20 = 20,
+
+        /// <summary>
+        /// 22 - Alíquota fixa
+        /// </summary>
+        [XmlEnum("22")]
+        [Description("Alíquota fixa")]
+        Cst22 = 22,
+
+        /// <summary>
+        /// 23 - Alíquota fixa rateada
+        /// </summary>
+        [XmlEnum("23")]
+        [Description("Alíquota fixa rateada")]
+        Cst23 = 23,
+
+        /// <summary>
+        /// 24 - Redução de Base de Cálculo
+        /// </summary>
+        [XmlEnum("24")]
+        [Description("Redução de Base de Cálculo")]
+        Cst24 = 24,
+
+        /// <summary>
+        /// 40 - Isenção
+        /// </summary>
+        [XmlEnum("40")]
+        [Description("Isenção")]
+        Cst40 = 40,
+
+        /// <summary>
+        /// 41 - Imunidade / Não incidência
+        /// </summary>
+        [XmlEnum("41")]
+        [Description("Imunidade / Não incidência")]
+        Cst41 = 41,
+
+        /// <summary>
+        /// 51 - Diferimento
+        /// </summary>
+        [XmlEnum("51")]
+        [Description("Diferimento")]
+        Cst51 = 51,
+
+        /// <summary>
+        /// 52 - Diferimento com redução de alíquota
+        /// </summary>
+        [XmlEnum("52")]
+        [Description("Diferimento com redução de alíquota")]
+        Cst52 = 52,
+
+        /// <summary>
+        /// 55 - Suspensão
+        /// </summary>
+        [XmlEnum("55")]
+        [Description("Suspensão")]
+        Cst55 = 55,
+
+        /// <summary>
+        /// 62 - Tributação monofásica
+        /// </summary>
+        [XmlEnum("62")]
+        [Description("Tributação monofásica")]
+        Cst62 = 62,
+
+        /// <summary>
+        /// 80 - Transferência de crédito
+        /// </summary>
+        [XmlEnum("80")]
+        [Description("Transferência de crédito")]
+        Cst80 = 80,
+
+        /// <summary>
+        /// 81 - Ajuste de IBS em ZFM
+        /// </summary>
+        [XmlEnum("81")]
+        [Description("Ajuste de IBS em ZFM")]
+        Cst81 = 81,
+
+        /// <summary>
+        /// 82 - Ajustes
+        /// </summary>
+        [XmlEnum("82")]
+        [Description("Ajustes")]
+        Cst82 = 82,
+
+        /// <summary>
+        /// 83 - Tributação em declaração de regime específico
+        /// </summary>
+        [XmlEnum("83")]
+        [Description("Tributação em declaração de regime específico")]
+        Cst83 = 83,
+
+        /// <summary>
+        /// 84 - Exclusão da Base de Cálculo
+        /// </summary>
+        [XmlEnum("84")]
+        [Description("Exclusão da Base de Cálculo")]
+        Cst84 = 84
+    }
+}

--- a/CTe.Classes/Informacoes/Impostos/Tipos/CstIbsCbs.cs
+++ b/CTe.Classes/Informacoes/Impostos/Tipos/CstIbsCbs.cs
@@ -38,133 +38,57 @@ namespace CTe.Classes.Informacoes.Impostos.Tipos
 {
     /// <summary>
     /// Código de Situação Tributária do IBS/CBS
+    /// Conforme NT 2025.001 v1.07
     /// </summary>
     public enum CstIbsCbs
     {
         /// <summary>
-        /// 00 - Tributação integral
+        /// 200 - Tributação integral
         /// </summary>
-        [XmlEnum("00")]
+        [XmlEnum("200")]
         [Description("Tributação integral")]
-        Cst00 = 0,
+        Cst200 = 200,
 
         /// <summary>
-        /// 01 - Tributação com alíquotas uniformes
+        /// 210 - Tributação com alíquota uniforme
         /// </summary>
-        [XmlEnum("01")]
-        [Description("Tributação com alíquotas uniformes")]
-        Cst01 = 1,
+        [XmlEnum("210")]
+        [Description("Tributação com alíquota uniforme")]
+        Cst210 = 210,
 
         /// <summary>
-        /// 02 - Tributação com alíquotas uniformes reduzidas
+        /// 220 - Tributação com alíquota uniforme reduzida
         /// </summary>
-        [XmlEnum("02")]
-        [Description("Tributação com alíquotas uniformes reduzidas")]
-        Cst02 = 2,
+        [XmlEnum("220")]
+        [Description("Tributação com alíquota uniforme reduzida")]
+        Cst220 = 220,
 
         /// <summary>
-        /// 20 - Alíquota reduzida
+        /// 300 - Alíquota reduzida
         /// </summary>
-        [XmlEnum("20")]
+        [XmlEnum("300")]
         [Description("Alíquota reduzida")]
-        Cst20 = 20,
+        Cst300 = 300,
 
         /// <summary>
-        /// 22 - Alíquota fixa
+        /// 400 - Isenção
         /// </summary>
-        [XmlEnum("22")]
-        [Description("Alíquota fixa")]
-        Cst22 = 22,
-
-        /// <summary>
-        /// 23 - Alíquota fixa rateada
-        /// </summary>
-        [XmlEnum("23")]
-        [Description("Alíquota fixa rateada")]
-        Cst23 = 23,
-
-        /// <summary>
-        /// 24 - Redução de Base de Cálculo
-        /// </summary>
-        [XmlEnum("24")]
-        [Description("Redução de Base de Cálculo")]
-        Cst24 = 24,
-
-        /// <summary>
-        /// 40 - Isenção
-        /// </summary>
-        [XmlEnum("40")]
+        [XmlEnum("400")]
         [Description("Isenção")]
-        Cst40 = 40,
+        Cst400 = 400,
 
         /// <summary>
-        /// 41 - Imunidade / Não incidência
+        /// 410 - Imunidade / Não incidência
         /// </summary>
-        [XmlEnum("41")]
+        [XmlEnum("410")]
         [Description("Imunidade / Não incidência")]
-        Cst41 = 41,
+        Cst410 = 410,
 
         /// <summary>
-        /// 51 - Diferimento
+        /// 500 - Suspensão / Diferimento
         /// </summary>
-        [XmlEnum("51")]
-        [Description("Diferimento")]
-        Cst51 = 51,
-
-        /// <summary>
-        /// 52 - Diferimento com redução de alíquota
-        /// </summary>
-        [XmlEnum("52")]
-        [Description("Diferimento com redução de alíquota")]
-        Cst52 = 52,
-
-        /// <summary>
-        /// 55 - Suspensão
-        /// </summary>
-        [XmlEnum("55")]
-        [Description("Suspensão")]
-        Cst55 = 55,
-
-        /// <summary>
-        /// 62 - Tributação monofásica
-        /// </summary>
-        [XmlEnum("62")]
-        [Description("Tributação monofásica")]
-        Cst62 = 62,
-
-        /// <summary>
-        /// 80 - Transferência de crédito
-        /// </summary>
-        [XmlEnum("80")]
-        [Description("Transferência de crédito")]
-        Cst80 = 80,
-
-        /// <summary>
-        /// 81 - Ajuste de IBS em ZFM
-        /// </summary>
-        [XmlEnum("81")]
-        [Description("Ajuste de IBS em ZFM")]
-        Cst81 = 81,
-
-        /// <summary>
-        /// 82 - Ajustes
-        /// </summary>
-        [XmlEnum("82")]
-        [Description("Ajustes")]
-        Cst82 = 82,
-
-        /// <summary>
-        /// 83 - Tributação em declaração de regime específico
-        /// </summary>
-        [XmlEnum("83")]
-        [Description("Tributação em declaração de regime específico")]
-        Cst83 = 83,
-
-        /// <summary>
-        /// 84 - Exclusão da Base de Cálculo
-        /// </summary>
-        [XmlEnum("84")]
-        [Description("Exclusão da Base de Cálculo")]
-        Cst84 = 84
+        [XmlEnum("500")]
+        [Description("Suspensão / Diferimento")]
+        Cst500 = 500
     }
 }

--- a/CTe.Classes/Informacoes/Impostos/Tipos/CstIbsCbs.cs
+++ b/CTe.Classes/Informacoes/Impostos/Tipos/CstIbsCbs.cs
@@ -43,52 +43,24 @@ namespace CTe.Classes.Informacoes.Impostos.Tipos
     public enum CstIbsCbs
     {
         /// <summary>
-        /// 200 - Tributação integral
+        /// 000 - Tributação integral
+        /// </summary>
+        [XmlEnum("000")]
+        [Description("Tributação integral")]
+        Cst000 = 0,
+
+        /// <summary>
+        /// 200 - Alíquota zero
         /// </summary>
         [XmlEnum("200")]
-        [Description("Tributação integral")]
+        [Description("Alíquota zero")]
         Cst200 = 200,
 
         /// <summary>
-        /// 210 - Tributação com alíquota uniforme
-        /// </summary>
-        [XmlEnum("210")]
-        [Description("Tributação com alíquota uniforme")]
-        Cst210 = 210,
-
-        /// <summary>
-        /// 220 - Tributação com alíquota uniforme reduzida
-        /// </summary>
-        [XmlEnum("220")]
-        [Description("Tributação com alíquota uniforme reduzida")]
-        Cst220 = 220,
-
-        /// <summary>
-        /// 300 - Alíquota reduzida
-        /// </summary>
-        [XmlEnum("300")]
-        [Description("Alíquota reduzida")]
-        Cst300 = 300,
-
-        /// <summary>
-        /// 400 - Isenção
-        /// </summary>
-        [XmlEnum("400")]
-        [Description("Isenção")]
-        Cst400 = 400,
-
-        /// <summary>
-        /// 410 - Imunidade / Não incidência
+        /// 410 - Imunidade e não incidência
         /// </summary>
         [XmlEnum("410")]
-        [Description("Imunidade / Não incidência")]
-        Cst410 = 410,
-
-        /// <summary>
-        /// 500 - Suspensão / Diferimento
-        /// </summary>
-        [XmlEnum("500")]
-        [Description("Suspensão / Diferimento")]
-        Cst500 = 500
+        [Description("Imunidade e não incidência")]
+        Cst410 = 410
     }
 }

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Compartilhado/InformacoesIbsCbs/InformacoesCbs/gCBS.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Compartilhado/InformacoesIbsCbs/InformacoesCbs/gCBS.cs
@@ -30,6 +30,7 @@
 /* http://www.zeusautomacao.com.br/                                             */
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
+using System.Xml.Serialization;
 
 namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Compartilhado.InformacoesIbsCbs.InformacoesCbs
 {
@@ -40,7 +41,8 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Compartilhado.InformacoesIb
 
         /// <summary>
         ///     UB56 - Alíquota da CBS (em percentual)
-        /// </summary>
+        /// </summary>~
+        [XmlElement(Order = 1)]
         public decimal pCBS
         {
             get => _pCbs.Arredondar(4);
@@ -50,21 +52,25 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Compartilhado.InformacoesIb
         /// <summary>
         ///     UB59 - Grupo de Informações do Diferimento
         /// </summary>
+        [XmlElement(Order = 2)]
         public gDif gDif { get; set; }
         
         /// <summary>
         ///     UB62 - Grupo de Informações da devolução de tributos
         /// </summary>
+        [XmlElement(Order = 3)]
         public gDevTrib gDevTrib { get; set; }
         
         /// <summary>
         ///     UB64 - Grupo de informações da redução da alíquota
         /// </summary>
+        [XmlElement(Order = 4)]
         public gRed gRed { get; set; }
         
         /// <summary>
         ///     UB67 - Valor da CBS
         /// </summary>
+        [XmlElement(Order = 5)]
         public decimal vCBS
         {
             get => _vCbs.Arredondar(2);

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Compartilhado/InformacoesIbsCbs/InformacoesIbs/gIBSMun.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Compartilhado/InformacoesIbsCbs/InformacoesIbs/gIBSMun.cs
@@ -30,6 +30,7 @@
 /* http://www.zeusautomacao.com.br/                                             */
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
+using System.Xml.Serialization;
 
 namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Compartilhado.InformacoesIbsCbs.InformacoesIbs
 {
@@ -41,6 +42,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Compartilhado.InformacoesIb
         /// <summary>
         ///     UB37 - Alíquota do IBS de competência do Município (em percentual)
         /// </summary>
+        [XmlElement(Order = 1)]
         public decimal pIBSMun
         {
             get => _pIbsMun.Arredondar(4);
@@ -50,21 +52,25 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Compartilhado.InformacoesIb
         /// <summary>
         ///     UB40 - Grupo de Informações do Diferimento
         /// </summary>
+        [XmlElement(Order = 2)]
         public gDif gDif { get; set; }
         
         /// <summary>
         ///     UB43 - Grupo de Informações da devolução de tributos
         /// </summary>
+        [XmlElement(Order = 3)]
         public gDevTrib gDevTrib { get; set; }
         
         /// <summary>
         ///     UB45 - Grupo de informações da redução da alíquota
         /// </summary>
+        [XmlElement(Order = 4)]
         public gRed gRed { get; set; }
         
         /// <summary>
         ///     UB54 - Valor do IBS de competência do Município
         /// </summary>
+        [XmlElement(Order = 5)]
         public decimal vIBSMun
         {
             get => _vIbsMun.Arredondar(2);

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Compartilhado/InformacoesIbsCbs/InformacoesIbs/gIBSUF.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Compartilhado/InformacoesIbsCbs/InformacoesIbs/gIBSUF.cs
@@ -30,6 +30,7 @@
 /* http://www.zeusautomacao.com.br/                                             */
 /* Rua Comendador Francisco josé da Cunha, 111 - Itabaiana - SE - 49500-000     */
 /********************************************************************************/
+using System.Xml.Serialization;
 
 namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Compartilhado.InformacoesIbsCbs.InformacoesIbs
 {
@@ -41,6 +42,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Compartilhado.InformacoesIb
         /// <summary>
         ///     UB18 - Alíquota do IBS de competência das UF (em percentual)
         /// </summary>
+        [XmlElement(Order = 1)]
         public decimal pIBSUF
         {
             get => _pIbsUf.Arredondar(4);
@@ -50,21 +52,25 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Compartilhado.InformacoesIb
         /// <summary>
         ///     UB21 - Grupo de Informações do Diferimento
         /// </summary>
+        [XmlElement(Order = 2)]
         public gDif gDif { get; set; }
         
         /// <summary>
         ///     UB24 - Grupo de Informações da devolução de tributos
         /// </summary>
+        [XmlElement(Order = 3)]
         public gDevTrib gDevTrib { get; set; }
         
         /// <summary>
         ///     UB26 - Grupo de informações da redução da alíquota
         /// </summary>
+        [XmlElement(Order = 4)]
         public gRed gRed { get; set; }
         
         /// <summary>
         ///     UB35 - Valor do IBS de competência da UF
         /// </summary>
+        [XmlElement(Order = 5)]
         public decimal vIBSUF
         {
             get => _vIbsUf.Arredondar(2);


### PR DESCRIPTION
De acordo com a NT da CTe e exemplos de XML que obtive precisaria desses campos para realizar a leitura dos valores 
Foi feito modificações adicionando campos conforme a 
Nota Técnica CTe - Nota_Técnica_2025_001 - RTC_v1.08a - Publicada em 18/08/2025
E tem um xml que usei para o desenvolvimento 
[Uploading teste.xml…]()

