### PR TITLE
fix(NFe.Danfe.Html): atualizar dependências e corrigir a instância de DanfeNFe

### DIFF
--- a/NFe.Danfe.App.Teste.Html/NFe.Danfe.App.Teste.Html.csproj
+++ b/NFe.Danfe.App.Teste.Html/NFe.Danfe.App.Teste.Html.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Zeus.Net.NFe.NFCe" Version="2024.1.15.1723" />
+    <PackageReference Include="Zeus.Net.NFe.NFCe" Version="2025.12.22.2042" />
   </ItemGroup>
 
   <ItemGroup>

--- a/NFe.Danfe.Html/Dominio/DanfeNFe.cs
+++ b/NFe.Danfe.Html/Dominio/DanfeNFe.cs
@@ -354,7 +354,7 @@ namespace NFe.Danfe.Html.Dominio
             Imposto = new Imposto(nfe.infNFe.total.ICMSTot.vBC, nfe.infNFe.total.ICMSTot.vICMS, nfe.infNFe.total.ICMSTot.vBCST,
                     nfe.infNFe.total.ICMSTot.vST, nfe.infNFe.total.ICMSTot.vProd, nfe.infNFe.total.ICMSTot.vFrete,
                     nfe.infNFe.total.ICMSTot.vSeg, nfe.infNFe.total.ICMSTot.vDesc, nfe.infNFe.total.ICMSTot.vOutro,
-                    nfe.infNFe.total.ICMSTot.vIPI, nfe.infNFe.total.ICMSTot.vNF,nfe.infNFe.total.ICMSTot.vTotTrib,
+                    nfe.infNFe.total.ICMSTot.vIPI, nfe.infNFe.total.ICMSTot.vNF,nfe.infNFe.total.ICMSTot.vTotTrib ?? 0,
                     nfe.infNFe.total.ICMSTot.vPIS, nfe.infNFe.total.ICMSTot.vCOFINS, nfe.infNFe.total.ICMSTot.vICMSUFRemet,
                     nfe.infNFe.total.ICMSTot.vICMSUFDest);
             

--- a/NFe.Danfe.Html/NFe.Danfe.Html.csproj
+++ b/NFe.Danfe.Html/NFe.Danfe.Html.csproj
@@ -11,7 +11,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="NetBarcode" Version="1.7.0" />
-		<PackageReference Include="Zeus.Net.NFe.NFCe" Version="2024.1.15.1723" />
+		<PackageReference Include="Zeus.Net.NFe.NFCe" Version="2025.12.22.2042" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Após a atualização do pacote **Zeus.Net.NFe.NFCe** para a versão **2025.12.22.2042**, o componente **NFe.Danfe.Html** passou a apresentar erro ao instanciar a classe de impostos na classe `DanfeNFe`.

O problema ocorre porque a propriedade `vTotTrib` passou a permitir valor *nullable*, impactando diretamente a criação da instância do imposto.

Para corrigir o problema, foram realizados os seguintes ajustes:

- Atualização da dependência **Zeus.Net.NFe.NFCe** para a versão **2025.12.22.2042**;
- Ajuste na instância de `Imposto` na classe `DanfeNFe`, tratando corretamente o cenário em que `vTotTrib` pode ser `null`.
