### PR TITLE
Ajuste na formatação de decimais do DANFE HTML

### DIFF
--- a/NFe.Danfe.Html/CrossCutting/Utils.cs
+++ b/NFe.Danfe.Html/CrossCutting/Utils.cs
@@ -237,7 +237,7 @@ namespace NFe.Danfe.Html.CrossCutting
                 var str = FormatarNumero(value);
                 str = str.Replace(".", ",");
                 double.TryParse(str, out var result);
-                return result.ToString("N", CultureInfo.GetCultureInfo("pt-br"));
+                return result.ToString("N2", CultureInfo.GetCultureInfo("pt-br"));
             }
             catch (Exception)
             {


### PR DESCRIPTION
## Descrição das Mudanças Alteração da lógica de formatação de números na classe Utils.cs do projeto NFe.Danfe.Html. A mudança substitui o formato numérico padrão ("N") por um formato fixo de duas casas decimais ("N2").

## Motivação Atualmente, alguns valores decimais estavam sendo renderizados com número de casas variável, o que afetava a padronização visual do documento auxiliar (DANFE). Com esta alteração, garantimos a conformidade visual de 2 casas decimais para os campos formatados por esta função.
