### PR TITLE
feat: considera caracteres alfanuméricos ao calcular digito verificado da chave de acesso

### DIFF
--- a/DFe.Utils/ChaveFiscal.cs
+++ b/DFe.Utils/ChaveFiscal.cs
@@ -95,8 +95,8 @@ namespace DFe.Utils
             //percorrendo cada caractere da chave da direita para esquerda para fazer os cálculos com o peso
             for (var i = chave.Length - 1; i != -1; i--)
             {
-                var ch = Convert.ToInt32(chave[i].ToString());
-                soma += ch*peso;
+                var valorCaractere = ObterValorDoCaractere(chave[i]);
+                soma += valorCaractere * peso;
                 //sempre que for 9 voltamos o peso a 2
                 if (peso < 9)
                     peso += 1;
@@ -113,6 +113,18 @@ namespace DFe.Utils
                 dv = 11 - mod;
 
             return dv.ToString();
+        }
+
+        /// <summary>
+        /// Obtem o valor de um caractere
+        /// </summary>
+        /// <param name="caractere"></param>
+        /// <returns></returns>
+        private static int ObterValorDoCaractere(char caractere)
+        {
+            const int zeroASCII = 48;
+            var valor = caractere - zeroASCII;
+            return valor;
         }
 
         /// <summary>

--- a/DFe.Utils/ChaveFiscal.cs
+++ b/DFe.Utils/ChaveFiscal.cs
@@ -120,7 +120,7 @@ namespace DFe.Utils
         /// </summary>
         /// <param name="caractere"></param>
         /// <returns></returns>
-        private static int ObterValorDoCaractere(char caractere)
+        internal static int ObterValorDoCaractere(char caractere)
         {
             const int zeroASCII = 48;
             var valor = caractere - zeroASCII;

--- a/DFe.Utils/Properties/AssemblyInfo.cs
+++ b/DFe.Utils/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("NFe.Utils.Testes")]

--- a/NFe.Classes/Informacoes/Emitente/emit.cs
+++ b/NFe.Classes/Informacoes/Emitente/emit.cs
@@ -52,7 +52,7 @@ namespace NFe.Classes.Informacoes.Emitente
             {
                 if (string.IsNullOrEmpty(value)) return;
                 if (string.IsNullOrEmpty(_cpf))
-                    _cnpj = Regex.Match(value, @"\d+").Value;
+                    _cnpj = Regex.Match(value, @"[0-9A-Z]+").Value;
 
                 else
                 {

--- a/NFe.Utils.Testes/ChaveFiscalTesteUnitario.cs
+++ b/NFe.Utils.Testes/ChaveFiscalTesteUnitario.cs
@@ -11,7 +11,7 @@ public class ChaveFiscalTesteUnitario
 {
     [Theory(DisplayName = "Dado cnpj alfanumérico, quando obter chave fiscal, então não deve lançar exceção.")]
     [InlineData("T6J3XFX0IVDD47")]
-    [InlineData("t6j3xfx0ivdd47")]
+    [InlineData("W2MNK0KZ000190")]
     public void DadoCnpjAlfanumericoQuandoObterChaveFiscalEntaoNaoDeveLancarExcecao(string cnpj)
     {
         // Arrange

--- a/NFe.Utils.Testes/ChaveFiscalTesteUnitario.cs
+++ b/NFe.Utils.Testes/ChaveFiscalTesteUnitario.cs
@@ -1,0 +1,43 @@
+using System;
+using DFe.Utils;
+using DFe.Classes.Entidades;
+using DFe.Classes.Flags;
+using NFe.Utils.Testes.Dados;
+using Xunit;
+
+namespace NFe.Utils.Testes;
+
+public class ChaveFiscalTesteUnitario
+{
+    [Theory(DisplayName = "Dado cnpj alfanumérico, quando obter chave fiscal, então não deve lançar exceção.")]
+    [InlineData("T6J3XFX0IVDD47")]
+    [InlineData("t6j3xfx0ivdd47")]
+    public void DadoCnpjAlfanumericoQuandoObterChaveFiscalEntaoNaoDeveLancarExcecao(string cnpj)
+    {
+        // Arrange
+        var estado = Estado.SE;
+        var data = DateTime.Now;
+        var modelo = ModeloDocumento.NFe;
+        var serie = 100;
+        var numero = 12345;
+        var tipoEmissao = 1;
+        var cNf = 12345678;
+
+        // Act
+        var excecaoCapturada = Record.Exception(() => ChaveFiscal.ObterChave(estado, data, cnpj, modelo, serie, numero, tipoEmissao, cNf));
+
+        // Assert
+        Assert.Null(excecaoCapturada);
+    }
+
+    [Theory(DisplayName = "Dado caractere, quando obter valor do caractere, então deve retornar o valor esperado.")]
+    [MemberData(nameof(ChaveFiscalDadosDeTeste.ObterCaracteresEValores), MemberType = typeof(ChaveFiscalDadosDeTeste))]
+    public void DadoCaractereQuandoObterValorEntaoDeveRetornarValorEsperado(char caractere, int valorEsperado)
+    {
+        // Act
+        var valorObtido = ChaveFiscal.ObterValorDoCaractere(caractere);
+        
+        // Assert
+        Assert.Equal(valorEsperado, valorObtido);
+    }
+}

--- a/NFe.Utils.Testes/Dados/ChaveFiscalDadosDeTeste.cs
+++ b/NFe.Utils.Testes/Dados/ChaveFiscalDadosDeTeste.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+
+namespace NFe.Utils.Testes.Dados;
+
+public static class ChaveFiscalDadosDeTeste
+{
+    public static IEnumerable<object[]> ObterCaracteresEValores()
+    {
+        yield return new object[] { '0', 0 };
+        yield return new object[] { '1', 1 };
+        yield return new object[] { '2', 2 };
+        yield return new object[] { '3', 3 };
+        yield return new object[] { '4', 4 };
+        yield return new object[] { '5', 5 };
+        yield return new object[] { '6', 6 };
+        yield return new object[] { '7', 7 };
+        yield return new object[] { '8', 8 };
+        yield return new object[] { '9', 9 };
+
+        yield return new object[] { 'A', 17 };
+        yield return new object[] { 'B', 18 };
+        yield return new object[] { 'C', 19 };
+        yield return new object[] { 'D', 20 };
+        yield return new object[] { 'E', 21 };
+        yield return new object[] { 'F', 22 };
+        yield return new object[] { 'G', 23 };
+        yield return new object[] { 'H', 24 };
+        yield return new object[] { 'I', 25 };
+        yield return new object[] { 'J', 26 };
+        yield return new object[] { 'K', 27 };
+        yield return new object[] { 'L', 28 };
+        yield return new object[] { 'M', 29 };
+        yield return new object[] { 'N', 30 };
+        yield return new object[] { 'O', 31 };
+        yield return new object[] { 'P', 32 };
+        yield return new object[] { 'Q', 33 };
+        yield return new object[] { 'R', 34 };
+        yield return new object[] { 'S', 35 };
+        yield return new object[] { 'T', 36 };
+        yield return new object[] { 'U', 37 };
+        yield return new object[] { 'V', 38 };
+        yield return new object[] { 'W', 39 };
+        yield return new object[] { 'X', 40 };
+        yield return new object[] { 'Y', 41 };
+        yield return new object[] { 'Z', 42 };
+    }
+}

--- a/NFe.Utils.Testes/NFe.Utils.Testes.csproj
+++ b/NFe.Utils.Testes/NFe.Utils.Testes.csproj
@@ -19,6 +19,7 @@
 	<ItemGroup>
 		<ProjectReference Include="..\DadosDeTestes\DadosDeTestes.csproj" />
 		<ProjectReference Include="..\DFe.Classes\DFe.Classes.csproj" />
+		<ProjectReference Include="..\DFe.Utils\DFe.Utils.csproj" />
 		<ProjectReference Include="..\NFe.Classes\NFe.Classes.csproj" />
 		<ProjectReference Include="..\NFe.Utils\NFe.Utils.csproj" />
 	</ItemGroup>


### PR DESCRIPTION
As alterações realizadas no arquivo ChaveFiscal.cs têm como objetivo adaptar o cálculo do dígito verificador (DV) da chave fiscal para suportar CNPJs alfanuméricos. Anteriormente, o cálculo utilizava Convert.ToInt32() e aceitava apenas caracteres numéricos; agora, foi introduzido o método ObterValorDoCaracter, que converte qualquer caractere para seu valor numérico via subtração pelo código ASCII de '0' (48), tornando o processamento compatível com letras e números.