### PR TITLE
fix: tratar vTotTrib nullable em DanfeNfceDocument e atualizar versao…

### DIFF
--- a/NFe.Danfe.QuestPdf/ImpressaoNfce/DanfeNfceDocument.cs
+++ b/NFe.Danfe.QuestPdf/ImpressaoNfce/DanfeNfceDocument.cs
@@ -278,7 +278,7 @@ public class DanfeNfceDocument : IDocument
 
                     r.RelativeItem().AlignRight().Column(c =>
                     {
-                        c.Item().Text($"R$ {_nfe.infNFe.total.ICMSTot.vTotTrib:N2}").FontSize(_tamanhoFontePadrao);
+                        c.Item().Text($"R$ {_nfe.infNFe.total.ICMSTot.vTotTrib ?? 0:N2}").FontSize(_tamanhoFontePadrao);
                     });
                 });
 

--- a/NFe.Danfe.QuestPdf/NFe.Danfe.QuestPdf.csproj
+++ b/NFe.Danfe.QuestPdf/NFe.Danfe.QuestPdf.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="QuestPDF" Version="2024.7.3" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.8" />
     <PackageReference Include="SkiaSharp.QrCode" Version="0.7.0" />
-    <PackageReference Include="Zeus.Net.NFe.NFCe" Version="2025.3.28.1516" />
+    <PackageReference Include="Zeus.Net.NFe.NFCe" Version="2026.4.10.1536" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Descrição

O commit `8046f3d1` ("Tornar vTotTrib (W16a) nullable para se adequar ao manual") alterou o tipo de `ICMSTot.vTotTrib` de `decimal` para `decimal?` em `NFe.Classes`.

O `DanfeNativoNfce.cs` foi corrigido nesse mesmo commit (adicionou `?? 0`), porém `DanfeNfceDocument.cs` (linha 281) **não foi atualizado** para tratar o nullable.

Além disso, o `.csproj` do projeto `NFe.Danfe.QuestPdf` ainda referencia `Zeus.Net.NFe.NFCe` na versão **`2025.3.28.1516`** (anterior à alteração do tipo), fazendo com que o pacote NuGet seja compilado contra a versão antiga de `NFe.Classes` (onde `vTotTrib` era `decimal`). Em runtime, o assembly encontra a versão atualizada (com `decimal?`), causando o `MissingMethodException` devido à incompatibilidade de assinatura do getter.

## Alterações

1. `DanfeNfceDocument.cs` — tratar `vTotTrib` nullable: `vTotTrib` → `vTotTrib ?? 0`
2. `NFe.Danfe.QuestPdf.csproj` — atualizar PackageReference de `Zeus.Net.NFe.NFCe` de `2025.3.28.1516` para `2026.4.10.1536`

Closes #1691