### PR TITLE
Implementa NT 2022.002 v1.30a

### DIFF
--- a/DFe.Testes/Impostos/ICMSGeral_Teste.cs
+++ b/DFe.Testes/Impostos/ICMSGeral_Teste.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
+using System.IO;
+using System.Xml.Serialization;
 using DFe.Testes.Impostos.DadosDeTeste;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual;
@@ -113,6 +115,102 @@ namespace DFe.Testes.Impostos
             Assert.AreEqual(Convert.ToDecimal(vBCFCPST), tagICMSGerada.vBCFCPST);
             Assert.AreEqual(Convert.ToDecimal(pFCPST), tagICMSGerada.pFCPST);
             Assert.AreEqual(Convert.ToDecimal(vFCPST), tagICMSGerada.vFCPST);
+        }
+
+        [TestMethod]
+        public void ObterICMSBasico_ICMS90ComDiferimento_Teste()
+        {
+            var icmsGeral = new ICMSGeral()
+            {
+                orig = OrigemMercadoria.OmNacional,
+                CST = Csticms.Cst90,
+                modBC = DeterminacaoBaseIcms.DbiValorOperacao,
+                vBC = 1000,
+                pRedBC = 10,
+                cBenefRBC = "ABC12345",
+                pICMS = 18,
+                vICMSOp = 180,
+                pDif = 50,
+                vICMSDif = 90,
+                vICMS = 90,
+                vBCFCP = 1000,
+                pFCP = 2,
+                vFCP = 20,
+                pFCPDif = 50,
+                vFCPDif = 10,
+                vFCPEfet = 10
+            };
+
+            var tagGerada = icmsGeral.ObterICMSBasico(CRT.RegimeNormal);
+
+            Assert.IsInstanceOfType(tagGerada, typeof(ICMS90));
+            var tagICMSGerada = tagGerada as ICMS90;
+            Assert.AreEqual(Csticms.Cst90, tagICMSGerada.CST);
+            Assert.AreEqual("ABC12345", tagICMSGerada.cBenefRBC);
+            Assert.AreEqual(180m, tagICMSGerada.vICMSOp);
+            Assert.AreEqual(50m, tagICMSGerada.pDif);
+            Assert.AreEqual(90m, tagICMSGerada.vICMSDif);
+            Assert.AreEqual(50m, tagICMSGerada.pFCPDif);
+            Assert.AreEqual(10m, tagICMSGerada.vFCPDif);
+            Assert.AreEqual(10m, tagICMSGerada.vFCPEfet);
+
+            var xml = Serializar(tagICMSGerada, "ICMS90");
+            StringAssert.Contains(xml, "<cBenefRBC>ABC12345</cBenefRBC>");
+            StringAssert.Contains(xml, "<vICMSOp>180.00</vICMSOp>");
+            StringAssert.Contains(xml, "<pDif>50.0000</pDif>");
+            StringAssert.Contains(xml, "<vICMSDif>90.00</vICMSDif>");
+            StringAssert.Contains(xml, "<pFCPDif>50.0000</pFCPDif>");
+            StringAssert.Contains(xml, "<vFCPDif>10.00</vFCPDif>");
+            StringAssert.Contains(xml, "<vFCPEfet>10.00</vFCPEfet>");
+        }
+
+        [TestMethod]
+        public void ObterICMSBasico_ICMSPartCst20ComDesoneracao_Teste()
+        {
+            var icmsGeral = new ICMSGeral()
+            {
+                orig = OrigemMercadoria.OmNacional,
+                CST = Csticms.CstPart20,
+                modBC = DeterminacaoBaseIcms.DbiValorOperacao,
+                vBC = 1000,
+                pRedBC = 10,
+                pICMS = 18,
+                vICMS = 90,
+                modBCST = DeterminacaoBaseIcmsSt.DbisValordaOperacao,
+                vBCST = 1000,
+                pICMSST = 18,
+                vICMSST = 180,
+                pBCOp = 100,
+                UFST = "SP",
+                vICMSDeson = 10,
+                motDesICMS = MotivoDesoneracaoIcms.MdiDeficienteCondutor,
+                indDeduzDeson = DeduzDesoneracaoNoProduto.Deduz
+            };
+
+            var tagGerada = icmsGeral.ObterICMSBasico(CRT.RegimeNormal);
+
+            Assert.IsInstanceOfType(tagGerada, typeof(ICMSPart));
+            var tagICMSGerada = tagGerada as ICMSPart;
+            Assert.AreEqual(Csticms.CstPart20, tagICMSGerada.CST);
+            Assert.AreEqual(10m, tagICMSGerada.vICMSDeson);
+            Assert.AreEqual(MotivoDesoneracaoIcms.MdiDeficienteCondutor, tagICMSGerada.motDesICMS);
+            Assert.AreEqual(DeduzDesoneracaoNoProduto.Deduz, tagICMSGerada.indDeduzDeson);
+
+            var xml = Serializar(tagICMSGerada, "ICMSPart");
+            StringAssert.Contains(xml, "<CST>20</CST>");
+            StringAssert.Contains(xml, "<vICMSDeson>10.00</vICMSDeson>");
+            StringAssert.Contains(xml, "<motDesICMS>10</motDesICMS>");
+            StringAssert.Contains(xml, "<indDeduzDeson>1</indDeduzDeson>");
+        }
+
+        private static string Serializar<T>(T objeto, string raiz)
+        {
+            var serializer = new XmlSerializer(typeof(T), new XmlRootAttribute(raiz));
+            using (var writer = new StringWriter())
+            {
+                serializer.Serialize(writer, objeto);
+                return writer.ToString();
+            }
         }
 
         //TODO: Falta criar os métodos de testes dos demais CSTs do ICMS (CTR = Normal)

--- a/NFe.AppTeste/Schemas/leiauteNFe_v4.00.xsd
+++ b/NFe.AppTeste/Schemas/leiauteNFe_v4.00.xsd
@@ -209,7 +209,13 @@ Campo preenchido somente quando “indPres = 5 (Operação presencial, fora do e
 									</xs:element>
 									<xs:element name="tpNFDebito" type="TTpNFDebito" minOccurs="0">
 										<xs:annotation>
-											<xs:documentation>Tipo de Nota de Débito</xs:documentation>
+											<xs:documentation>Tipo de Nota de Débito:
+01=Transferência de créditos para Cooperativas;
+02=Anulação de Crédito por Saídas Imunes/Isentas;
+03=Débitos de notas fiscais não processadas na apuração;
+04=Multa e juros;
+05=Transferência de crédito de sucessão.
+											</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element name="tpNFCredito" type="TTpNFCredito" minOccurs="0">
@@ -501,7 +507,7 @@ Preencher com &quot;2B&quot;, quando se tratar de Cupom Fiscal emitido por máqu
 										</xs:annotation>
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element name="refNFe" type="TChNFe" minOccurs="1" maxOccurs="99">
+												<xs:element name="refNFe" type="TChNFe" maxOccurs="99">
 													<xs:annotation>
 														<xs:documentation>Chave de acesso da NF-e de antecipação de pagamento</xs:documentation>
 													</xs:annotation>
@@ -2555,13 +2561,15 @@ ambiente.</xs:documentation>
 																					</xs:element>
 																					<xs:element name="motDesICMS">
 																						<xs:annotation>
-																							<xs:documentation>Motivo da desoneração do ICMS:3-Uso na agropecuária;9-Outros;12-Fomento agropecuário</xs:documentation>
+																							<xs:documentation>Motivo da desoneração do ICMS:3-Uso na agropecuária;9-Outros; 10=Deficiente Condutor (Convênio ICMS 38/12); 11=Deficiente Não Condutor (Convênio ICMS 38/12);  12-Fomento agropecuário</xs:documentation>
 																						</xs:annotation>
 																						<xs:simpleType>
 																							<xs:restriction base="xs:string">
 																								<xs:whiteSpace value="preserve"/>
 																								<xs:enumeration value="3"/>
 																								<xs:enumeration value="9"/>
+																								<xs:enumeration value="10"/>
+																								<xs:enumeration value="11"/>
 																								<xs:enumeration value="12"/>
 																							</xs:restriction>
 																						</xs:simpleType>
@@ -3395,11 +3403,39 @@ Informar o motivo da desoneração:
 																							<xs:documentation>Percentual de redução da BC</xs:documentation>
 																						</xs:annotation>
 																					</xs:element>
+																					<xs:element name="cBenefRBC" minOccurs="0">
+																						<xs:annotation>
+																							<xs:documentation>Código de Benefício Fiscal na UF aplicado ao item quando houver RBC.</xs:documentation>
+																						</xs:annotation>
+																						<xs:simpleType>
+																							<xs:restriction base="xs:string">
+																								<xs:whiteSpace value="preserve"/>
+																								<xs:pattern value="[!-ÿ]{8}|[!-ÿ]{10}"/>
+																							</xs:restriction>
+																						</xs:simpleType>
+																					</xs:element>
 																					<xs:element name="pICMS" type="TDec_0302a04">
 																						<xs:annotation>
 																							<xs:documentation>Alíquota do ICMS</xs:documentation>
 																						</xs:annotation>
 																					</xs:element>
+																					<xs:sequence minOccurs="0">
+																						<xs:element name="vICMSOp" type="TDec_1302">
+																							<xs:annotation>
+																								<xs:documentation>Valor do ICMS da Operação</xs:documentation>
+																							</xs:annotation>
+																						</xs:element>
+																						<xs:element name="pDif" type="TDec_0302a04Max100">
+																							<xs:annotation>
+																								<xs:documentation>Percentual do diferemento</xs:documentation>
+																							</xs:annotation>
+																						</xs:element>
+																						<xs:element name="vICMSDif" type="TDec_1302">
+																							<xs:annotation>
+																								<xs:documentation>Valor do ICMS da diferido</xs:documentation>
+																							</xs:annotation>
+																						</xs:element>
+																					</xs:sequence>
 																					<xs:element name="vICMS" type="TDec_1302">
 																						<xs:annotation>
 																							<xs:documentation>Valor do ICMS</xs:documentation>
@@ -3419,6 +3455,23 @@ Informar o motivo da desoneração:
 																						<xs:element name="vFCP" type="TDec_1302">
 																							<xs:annotation>
 																								<xs:documentation>Valor do ICMS relativo ao Fundo de Combate à Pobreza (FCP).</xs:documentation>
+																							</xs:annotation>
+																						</xs:element>
+																					</xs:sequence>
+																					<xs:sequence minOccurs="0">
+																						<xs:element name="pFCPDif" type="TDec_0302a04Opc">
+																							<xs:annotation>
+																								<xs:documentation>Percentual do diferimento do ICMS relativo ao Fundo de Combate à Pobreza (FCP).</xs:documentation>
+																							</xs:annotation>
+																						</xs:element>
+																						<xs:element name="vFCPDif" type="TDec_1302">
+																							<xs:annotation>
+																								<xs:documentation>Valor do ICMS relativo ao Fundo de Combate à Pobreza (FCP) diferido.</xs:documentation>
+																							</xs:annotation>
+																						</xs:element>
+																						<xs:element name="vFCPEfet" type="TDec_1302" minOccurs="0">
+																							<xs:annotation>
+																								<xs:documentation>Valor efetivo do ICMS relativo ao Fundo de Combate à Pobreza (FCP).</xs:documentation>
 																							</xs:annotation>
 																						</xs:element>
 																					</xs:sequence>
@@ -3569,12 +3622,14 @@ Operação interestadual para consumidor final com partilha do ICMS  devido na o
 																					<xs:annotation>
 																						<xs:documentation>Tributação pelo ICMS 
 10 - Tributada e com cobrança do ICMS por substituição tributária;
+20 – Redução de base de cálculo
 90 – Outros.</xs:documentation>
 																					</xs:annotation>
 																					<xs:simpleType>
 																						<xs:restriction base="xs:string">
 																							<xs:whiteSpace value="preserve"/>
 																							<xs:enumeration value="10"/>
+																							<xs:enumeration value="20"/>
 																							<xs:enumeration value="90"/>
 																						</xs:restriction>
 																					</xs:simpleType>
@@ -3693,6 +3748,43 @@ Operação interestadual para consumidor final com partilha do ICMS  devido na o
 																						<xs:documentation>Sigla da UF para qual é devido o ICMS ST da operação.</xs:documentation>
 																					</xs:annotation>
 																				</xs:element>
+																				<xs:sequence minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Grupo desoneração</xs:documentation>
+																					</xs:annotation>
+																					<xs:element name="vICMSDeson" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS de desoneração</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="motDesICMS">
+																						<xs:annotation>
+																							<xs:documentation>Motivo da desoneração do ICMS:9-Outros;10=Deficiente Condutor (Convênio ICMS 38/12) 11=Deficiente Não Condutor (Convênio ICMS 38/12)</xs:documentation>
+																						</xs:annotation>
+																						<xs:simpleType>
+																							<xs:restriction base="xs:string">
+																								<xs:whiteSpace value="preserve"/>
+																								<xs:enumeration value="9"/>
+																								<xs:enumeration value="10"/>
+																								<xs:enumeration value="11"/>
+																							</xs:restriction>
+																						</xs:simpleType>
+																					</xs:element>
+																					<xs:element name="indDeduzDeson" minOccurs="0">
+																						<xs:annotation>
+																							<xs:documentation>Indica se o valor do ICMS desonerado (vICMSDeson) deduz do valor do item (vProd):
+0=Valor do ICMS desonerado (vICMSDeson) não deduz do valor do item (vProd) / total da NF-e;
+1=Valor do ICMS desonerado (vICMSDeson) deduz do valor do item (vProd) / total da NF-e.</xs:documentation>
+																						</xs:annotation>
+																						<xs:simpleType>
+																							<xs:restriction base="xs:string">
+																								<xs:whiteSpace value="preserve"/>
+																								<xs:enumeration value="0"/>
+																								<xs:enumeration value="1"/>
+																							</xs:restriction>
+																						</xs:simpleType>
+																					</xs:element>
+																				</xs:sequence>
 																			</xs:sequence>
 																		</xs:complexType>
 																	</xs:element>
@@ -6518,16 +6610,16 @@ tipo de ato concessório:
 									<xs:whiteSpace value="preserve"/>
 									<xs:minLength value="60"/>
 									<xs:maxLength value="1000"/>
-									<!--QRCODE V1-->
 									<xs:pattern value="((HTTPS?|https?)://.*\?chNFe=[0-9]{44}&amp;nVersao=100&amp;tpAmb=[1-2](&amp;cDest=([A-Za-z0-9.:+-/)(]{0}|[A-Za-z0-9.:+-/)(]{5,20})?)?&amp;dhEmi=[A-Fa-f0-9]{50}&amp;vNF=(0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?)&amp;vICMS=(0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?)&amp;digVal=[A-Fa-f0-9]{56}&amp;cIdToken=[0-9]{6}&amp;cHashQRCode=[A-Fa-f0-9]{40})"/>
-									<!--QRCODE V2 ONLINE-->
 									<xs:pattern value="((HTTPS?|https?)://.*\?p=([0-9]{34}(1|3|4)[0-9]{9})\|[2]\|[1-2]\|(0|[1-9]{1}([0-9]{1,5})?)\|[A-Fa-f0-9]{40})"/>
-									<!--QRCODE V2 OFFLINE-->
 									<xs:pattern value="((HTTPS?|https?)://.*\?p=([0-9]{34}9[0-9]{9})\|[2]\|[1-2]\|([0]{1}[1-9]{1}|[1-2]{1}[0-9]{1}|[3]{1}[0-1]{1})\|(0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?)\|[A-Fa-f0-9]{56}\|(0|[1-9]{1}([0-9]{1,5})?)\|[A-Fa-f0-9]{40})"/>
-									<!--QRCODE V3 ONLINE-->
 									<xs:pattern value="((HTTPS?|https?)://.*\?p=([0-9]{34}(1|3|4)[0-9]{9})\|[3]\|[1-2])"/>
-									<!--QRCODE V3 OFFLINE-->
 									<xs:pattern value="((HTTPS?|https?)://.*\?p=([0-9]{34}(9)[0-9]{9})\|[3]\|[1-2]\|([0]{1}[1-9]{1}|[1-2]{1}[0-9]{1}|[3]{1}[0-1]{1})\|(0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?)\|((1|2|3)?)\|(([0-9]{3,14})?)\|([a-zA-Z0-9+/]+[=]{0,2}))"/>
+									<!--QRCODE V1-->
+									<!--QRCODE V2 ONLINE-->
+									<!--QRCODE V2 OFFLINE-->
+									<!--QRCODE V3 ONLINE-->
+									<!--QRCODE V3 OFFLINE-->
 								</xs:restriction>
 							</xs:simpleType>
 						</xs:element>

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS90.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS90.cs
@@ -40,6 +40,9 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         private decimal? _vBc;
         private decimal? _pRedBc;
         private decimal? _pIcms;
+        private decimal? _vIcmsOp;
+        private decimal? _pDif;
+        private decimal? _vIcmsDif;
         private decimal? _vIcms;
         private decimal? _pMvast;
         private decimal? _pRedBcst;
@@ -50,6 +53,9 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         private decimal? _vBcfcp;
         private decimal? _pFcp;
         private decimal? _vFcp;
+        private decimal? _pFCPDif;
+        private decimal? _vFCPDif;
+        private decimal? _vFCPEfet;
         private decimal? _vBcfcpst;
         private decimal? _pFcpst;
         private decimal? _vFcpst;
@@ -94,9 +100,15 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         }
 
         /// <summary>
-        ///     N16 - Alíquota do imposto
+        ///     N14a - Código de Benefício Fiscal na UF aplicado ao item quando houver RBC.
         /// </summary>
         [XmlElement(Order = 6)]
+        public string cBenefRBC { get; set; }
+
+        /// <summary>
+        ///     N16 - Alíquota do imposto
+        /// </summary>
+        [XmlElement(Order = 7)]
         public decimal? pICMS
         {
             get { return _pIcms.Arredondar(4); }
@@ -104,9 +116,39 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         }
 
         /// <summary>
+        ///     N16b - Valor do ICMS da Operação
+        /// </summary>
+        [XmlElement(Order = 8)]
+        public decimal? vICMSOp
+        {
+            get { return _vIcmsOp.Arredondar(2); }
+            set { _vIcmsOp = value.Arredondar(2); }
+        }
+
+        /// <summary>
+        ///     N16c - Percentual do diferimento
+        /// </summary>
+        [XmlElement(Order = 9)]
+        public decimal? pDif
+        {
+            get { return _pDif.Arredondar(4); }
+            set { _pDif = value.Arredondar(4); }
+        }
+
+        /// <summary>
+        ///     N16d - Valor do ICMS diferido
+        /// </summary>
+        [XmlElement(Order = 10)]
+        public decimal? vICMSDif
+        {
+            get { return _vIcmsDif.Arredondar(2); }
+            set { _vIcmsDif = value.Arredondar(2); }
+        }
+
+        /// <summary>
         ///     N17 - Valor do ICMS
         /// </summary>
-        [XmlElement(Order = 7)]
+        [XmlElement(Order = 11)]
         public decimal? vICMS
         {
             get { return _vIcms.Arredondar(2); }
@@ -117,7 +159,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// N17a - Valor da Base de Cálculo do FCP
         /// Versão 4.00
         /// </summary>
-        [XmlElement(Order = 8)]
+        [XmlElement(Order = 12)]
         public decimal? vBCFCP
         {
             get { return _vBcfcp.Arredondar(2); }
@@ -133,7 +175,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// N17b - Percentual do Fundo de Combate à Pobreza (FCP)
         /// Versão 4.00
         /// </summary>
-        [XmlElement(Order = 9)]
+        [XmlElement(Order = 13)]
         public decimal? pFCP
         {
             get { return _pFcp.Arredondar(4); }
@@ -149,7 +191,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// N17c - Valor do Fundo de Combate à Pobreza (FCP)
         /// Versão 4.00
         /// </summary>
-        [XmlElement(Order = 10)]
+        [XmlElement(Order = 14)]
         public decimal? vFCP
         {
             get { return _vFcp.Arredondar(2); }
@@ -162,15 +204,48 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         }
 
         /// <summary>
+        /// N17d - Percentual do diferimento do ICMS relativo ao Fundo de Combate à Pobreza (FCP)
+        /// Versão 4.00
+        /// </summary>
+        [XmlElement(Order = 15)]
+        public decimal? pFCPDif
+        {
+            get { return _pFCPDif.Arredondar(4); }
+            set { _pFCPDif = value.Arredondar(4); }
+        }
+
+        /// <summary>
+        /// N17e - Valor do ICMS relativo ao Fundo de Combate à Pobreza (FCP) diferido
+        /// Versão 4.00
+        /// </summary>
+        [XmlElement(Order = 16)]
+        public decimal? vFCPDif
+        {
+            get { return _vFCPDif.Arredondar(2); }
+            set { _vFCPDif = value.Arredondar(2); }
+        }
+
+        /// <summary>
+        /// N17f - Valor efetivo do ICMS relativo ao Fundo de Combate à Pobreza (FCP)
+        /// Versão 4.00
+        /// </summary>
+        [XmlElement(Order = 17)]
+        public decimal? vFCPEfet
+        {
+            get { return _vFCPEfet.Arredondar(2); }
+            set { _vFCPEfet = value.Arredondar(2); }
+        }
+
+        /// <summary>
         ///     N18 - Modalidade de determinação da BC do ICMS ST
         /// </summary>
-        [XmlElement(Order = 11)]
+        [XmlElement(Order = 18)]
         public DeterminacaoBaseIcmsSt? modBCST { get; set; }
 
         /// <summary>
         ///     N19 - Percentual da margem de valor Adicionado do ICMS ST
         /// </summary>
-        [XmlElement(Order = 12)]
+        [XmlElement(Order = 19)]
         public decimal? pMVAST
         {
             get { return _pMvast.Arredondar(4); }
@@ -180,7 +255,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N20 - Percentual da Redução de BC do ICMS ST
         /// </summary>
-        [XmlElement(Order = 13)]
+        [XmlElement(Order = 20)]
         public decimal? pRedBCST
         {
             get { return _pRedBcst.Arredondar(4); }
@@ -190,7 +265,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N21 - Valor da BC do ICMS ST
         /// </summary>
-        [XmlElement(Order = 14)]
+        [XmlElement(Order = 21)]
         public decimal? vBCST
         {
             get { return _vBcst.Arredondar(2); }
@@ -200,7 +275,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N22 - Alíquota do imposto do ICMS ST
         /// </summary>
-        [XmlElement(Order = 15)]
+        [XmlElement(Order = 22)]
         public decimal? pICMSST
         {
             get { return _pIcmsst.Arredondar(4); }
@@ -210,7 +285,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N23 - Valor do ICMS ST
         /// </summary>
-        [XmlElement(Order = 16)]
+        [XmlElement(Order = 23)]
         public decimal? vICMSST
         {
             get { return _vIcmsst.Arredondar(2); }
@@ -221,7 +296,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// N23a - Valor da Base de Cálculo do FCP retido por Substituição Tributária
         /// Versão 4.00
         /// </summary>
-        [XmlElement(Order = 17)]
+        [XmlElement(Order = 24)]
         public decimal? vBCFCPST
         {
             get { return _vBcfcpst.Arredondar(2); }
@@ -237,7 +312,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// N23b - Percentual do FCP retido por Substituição Tributária
         /// Versão 4.00
         /// </summary>
-        [XmlElement(Order = 18)]
+        [XmlElement(Order = 25)]
         public decimal? pFCPST
         {
             get { return _pFcpst.Arredondar(4); }
@@ -253,7 +328,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// N23d - Valor do FCP retido por Substituição Tributária
         /// Versão 4.00
         /// </summary>
-        [XmlElement(Order = 19)]
+        [XmlElement(Order = 26)]
         public decimal? vFCPST
         {
             get { return _vFcpst.Arredondar(2); }
@@ -268,7 +343,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N27a - Valor do ICMS desonerado
         /// </summary>
-        [XmlElement(Order = 20)]
+        [XmlElement(Order = 27)]
         public decimal? vICMSDeson
         {
             get { return _vIcmsDeson.Arredondar(2); }
@@ -278,21 +353,21 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N28 - Motivo da desoneração do ICMS
         /// </summary>
-        [XmlElement(Order = 21)]
+        [XmlElement(Order = 28)]
         public MotivoDesoneracaoIcms? motDesICMS { get; set; }
         
         /// <summary>
         /// N28b - Indica se o valor do ICMS desonerado (vICMSDeson) deduz 
         /// do valor do item (vProd). (NT 2023.004) 
         /// </summary>
-        [XmlElement(Order = 22)]
+        [XmlElement(Order = 29)]
         public DeduzDesoneracaoNoProduto? indDeduzDeson { get; set; }
 
         /// <summary>
         /// N33a - Valor do ICMS- ST desonerado
         /// Versão 4.00
         /// </summary>
-        [XmlElement(Order = 23)]
+        [XmlElement(Order = 30)]
         public decimal? vICMSSTDeson
         {
             get { return _vICMSSTDeson.Arredondar(2); }
@@ -308,7 +383,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// N33b - Motivo da desoneração do ICMS- ST 
         /// Versão 4.00
         /// </summary>
-        [XmlElement(Order = 24)]
+        [XmlElement(Order = 31)]
         public MotivoDesoneracaoIcmsSt? motDesICMSST { get; set; }
 
         public bool ShouldSerializemotDesICMSST()
@@ -336,9 +411,39 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
             return pICMS.HasValue;
         }
 
+        public bool ShouldSerializevICMSOp()
+        {
+            return vICMSOp.HasValue;
+        }
+
+        public bool ShouldSerializepDif()
+        {
+            return pDif.HasValue;
+        }
+
+        public bool ShouldSerializevICMSDif()
+        {
+            return vICMSDif.HasValue;
+        }
+
         public bool ShouldSerializevICMS()
         {
             return vICMS.HasValue;
+        }
+
+        public bool ShouldSerializepFCPDif()
+        {
+            return pFCPDif.HasValue;
+        }
+
+        public bool ShouldSerializevFCPDif()
+        {
+            return vFCPDif.HasValue;
+        }
+
+        public bool ShouldSerializevFCPEfet()
+        {
+            return vFCPEfet.HasValue;
         }
 
         public bool ShouldSerializemodBCST()

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMSPart.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMSPart.cs
@@ -50,6 +50,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         private decimal? _pFCPST;
         private decimal? _vFCPST;
         private decimal _pBcOp;
+        private decimal? _vIcmsDeson;
 
         /// <summary>
         ///     N11 - Origem da Mercadoria
@@ -211,6 +212,29 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         [XmlElement(Order = 18)]
         public string UFST { get; set; }
 
+        /// <summary>
+        ///     N28a - Valor do ICMS desonerado
+        /// </summary>
+        [XmlElement(Order = 19)]
+        public decimal? vICMSDeson
+        {
+            get { return _vIcmsDeson.Arredondar(2); }
+            set { _vIcmsDeson = value.Arredondar(2); }
+        }
+
+        /// <summary>
+        ///     N28 - Motivo da desoneração do ICMS
+        /// </summary>
+        [XmlElement(Order = 20)]
+        public MotivoDesoneracaoIcms? motDesICMS { get; set; }
+
+        /// <summary>
+        /// N28b - Indica se o valor do ICMS desonerado (vICMSDeson) deduz
+        /// do valor do item (vProd). (NT 2023.004)
+        /// </summary>
+        [XmlElement(Order = 21)]
+        public DeduzDesoneracaoNoProduto? indDeduzDeson { get; set; }
+
         public bool ShouldSerializepRedBC()
         {
             return pRedBC.HasValue;
@@ -239,6 +263,21 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         public bool ShouldSerializevFCPST()
         {
             return vFCPST.HasValue;
+        }
+
+        public bool ShouldSerializevICMSDeson()
+        {
+            return vICMSDeson.HasValue;
+        }
+
+        public bool ShouldSerializemotDesICMS()
+        {
+            return motDesICMS.HasValue;
+        }
+
+        public bool ShouldSerializeindDeduzDeson()
+        {
+            return indDeduzDeson.HasValue;
         }
 
     }

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/Tipos/ICMSTipos.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/Tipos/ICMSTipos.cs
@@ -181,6 +181,13 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual.Tipos
         Cst20,
 
         /// <summary>
+        /// 20 - Com redução de base de cálculo
+        /// </summary>
+        [Description("Com redução de base de cálculo")]
+        [XmlEnum("20")]
+        CstPart20,
+
+        /// <summary>
         /// 30 - Isenta ou não tributada e com cobrança do ICMS por substituição tributária
         /// </summary>
         [Description("Isenta ou não tributada e com cobrança do ICMS por substituição tributária")]

--- a/NFe.Utils/Conversao.cs
+++ b/NFe.Utils/Conversao.cs
@@ -200,6 +200,7 @@ namespace NFe.Utils
                 case Csticms.CstPart10:
                     return "10";
                 case Csticms.Cst20:
+                case Csticms.CstPart20:
                     return "20";
                 case Csticms.Cst15:
                     return "15";                    

--- a/NFe.Utils/Tributacao/Estadual/ICMSGeral.cs
+++ b/NFe.Utils/Tributacao/Estadual/ICMSGeral.cs
@@ -129,6 +129,7 @@ namespace NFe.Utils.Tributacao.Estadual
                             icmsBasico = new ICMS15();
                             break;
                         case Csticms.CstPart10:
+                        case Csticms.CstPart20:
                         case Csticms.CstPart90:
                             icmsBasico = new ICMSPart();
                             break;
@@ -241,6 +242,11 @@ namespace NFe.Utils.Tributacao.Estadual
         ///     Percentual de redução da BC
         /// </summary>
         public decimal pRedBC { get; set; }
+
+        /// <summary>
+        ///     Código de Benefício Fiscal na UF aplicado ao item quando houver RBC.
+        /// </summary>
+        public string cBenefRBC { get; set; }
 
         /// <summary>
         ///     Valor do ICMS desonerado
@@ -366,6 +372,21 @@ namespace NFe.Utils.Tributacao.Estadual
         ///     Valor do Fundo de Combate à Pobreza (FCP) retido por Substituição Tributária
         /// </summary>
         public decimal? vFCPST { get; set; }
+
+        /// <summary>
+        ///     Percentual do diferimento do ICMS relativo ao Fundo de Combate à Pobreza (FCP)
+        /// </summary>
+        public decimal? pFCPDif { get; set; }
+
+        /// <summary>
+        ///     Valor do ICMS relativo ao Fundo de Combate à Pobreza (FCP) diferido
+        /// </summary>
+        public decimal? vFCPDif { get; set; }
+
+        /// <summary>
+        ///     Valor efetivo do ICMS relativo ao Fundo de Combate à Pobreza (FCP)
+        /// </summary>
+        public decimal? vFCPEfet { get; set; }
 
         #endregion
 


### PR DESCRIPTION
## O que foi feito

Implementa as alteracoes da Nota Tecnica 2022.002 v1.30a / Pacote de Liberacao PL_010c para NF-e/NFC-e.

- Atualiza o schema `leiauteNFe_v4.00.xsd` conforme pacote oficial.
- Adiciona os campos de diferimento, FCP diferido/efetivo e `cBenefRBC` no `ICMS90`.
- Adiciona suporte ao CST 20 no `ICMSPart`, incluindo campos de desoneracao.
- Atualiza `ICMSGeral` e `Conversao` para montar/serializar os novos cenarios.
- Adiciona testes cobrindo ICMS90 com diferimento e ICMSPart CST 20 com desoneracao.

