### PR TITLE
feat: atualiza schemas e implementa suporte ao CNPJ alfanumérico NT 2026.004.v.1.01

### DIFF
--- a/NFe.AppTeste/Schemas/leiauteConsSitNFe_v4.00.xsd
+++ b/NFe.AppTeste/Schemas/leiauteConsSitNFe_v4.00.xsd
@@ -315,7 +315,7 @@
 						</xs:annotation>
 						<xs:simpleType>
 							<xs:restriction base="xs:ID">
-								<xs:pattern value="ID[0-9]{52}"/>
+								<xs:pattern value="ID[0-9]{12}[0-9A-Z]{12}[0-9]{28}"/>
 							</xs:restriction>
 						</xs:simpleType>
 					</xs:attribute>

--- a/NFe.AppTeste/Schemas/leiauteEvento_v1.00.xsd
+++ b/NFe.AppTeste/Schemas/leiauteEvento_v1.00.xsd
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/nfe" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsig-core-schema_v1.01.xsd"/>
 	<xs:include schemaLocation="tiposBasico_v1.03.xsd"/>
@@ -91,6 +91,40 @@
 								<xs:anyAttribute processContents="skip"/>
 							</xs:complexType>
 						</xs:element>
+						<xs:element name="infPAA" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Grupo de Informação do Provedor de Assinatura e Autorização</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="CNPJPAA" type="TCnpj">
+										<xs:annotation>
+											<xs:documentation>CNPJ do Provedor de Assinatura e Autorização</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="PAASignature">
+										<xs:annotation>
+											<xs:documentation>Assinatura RSA do Emitente para DFe gerados por PAA</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="SignatureValue" type="xs:base64Binary">
+													<xs:annotation>
+														<xs:documentation>Assinatura digital padrão RSA</xs:documentation>
+														<xs:documentation>Converter o atributo Id do DFe para array de bytes e assinar com a chave privada do RSA com algoritmo SHA1 gerando um valor no formato base64.</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="RSAKeyValue" type="TRSAKeyValueType">
+													<xs:annotation>
+														<xs:documentation>Chave Publica no padrão XML RSA Key</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
 					</xs:sequence>
 					<xs:attribute name="Id" use="required">
 						<xs:annotation>
@@ -99,7 +133,7 @@
 						</xs:annotation>
 						<xs:simpleType>
 							<xs:restriction base="xs:ID">
-								<xs:pattern value="ID[0-9]{52}"/>
+								<xs:pattern value="ID[0-9]{12}[0-9A-Z]{12}[0-9]{28}"/>
 							</xs:restriction>
 						</xs:simpleType>
 					</xs:attribute>
@@ -332,48 +366,4 @@
 			<xs:pattern value="1\.00"/>
 		</xs:restriction>
 	</xs:simpleType>
-
-<!-- Comentado pelo fato da definição já constar no tiposBasico_v1.03.xsd
-
-	<xs:simpleType name="TCOrgaoIBGE">
-		<xs:annotation>
-			<xs:documentation>Tipo Código de orgão (UF da tabela do IBGE + 90 RFB)</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:string">
-			<xs:whiteSpace value="preserve"/>
-			<xs:enumeration value="11"/>
-			<xs:enumeration value="12"/>
-			<xs:enumeration value="13"/>
-			<xs:enumeration value="14"/>
-			<xs:enumeration value="15"/>
-			<xs:enumeration value="16"/>
-			<xs:enumeration value="17"/>
-			<xs:enumeration value="21"/>
-			<xs:enumeration value="22"/>
-			<xs:enumeration value="23"/>
-			<xs:enumeration value="24"/>
-			<xs:enumeration value="25"/>
-			<xs:enumeration value="26"/>
-			<xs:enumeration value="27"/>
-			<xs:enumeration value="28"/>
-			<xs:enumeration value="29"/>
-			<xs:enumeration value="31"/>
-			<xs:enumeration value="32"/>
-			<xs:enumeration value="33"/>
-			<xs:enumeration value="35"/>
-			<xs:enumeration value="41"/>
-			<xs:enumeration value="42"/>
-			<xs:enumeration value="43"/>
-			<xs:enumeration value="50"/>
-			<xs:enumeration value="51"/>
-			<xs:enumeration value="52"/>
-			<xs:enumeration value="53"/>
-			<xs:enumeration value="90"/>
-			<xs:enumeration value="91"/>
-			<xs:enumeration value="92"/>
-		</xs:restriction>
-	</xs:simpleType>
-
--->
-
 </xs:schema>

--- a/NFe.AppTeste/Schemas/leiauteInutNFe_v4.00.xsd
+++ b/NFe.AppTeste/Schemas/leiauteInutNFe_v4.00.xsd
@@ -76,7 +76,7 @@
 					<xs:attribute name="Id" use="required">
 						<xs:simpleType>
 							<xs:restriction base="xs:ID">
-								<xs:pattern value="ID[0-9]{41}"/>
+								<xs:pattern value="ID[0-9]{4}[0-9A-Z]{12}[0-9]{25}"/>
 							</xs:restriction>
 						</xs:simpleType>
 					</xs:attribute>

--- a/NFe.AppTeste/Schemas/leiauteNFe_v4.00.xsd
+++ b/NFe.AppTeste/Schemas/leiauteNFe_v4.00.xsd
@@ -209,7 +209,13 @@ Campo preenchido somente quando “indPres = 5 (Operação presencial, fora do e
 									</xs:element>
 									<xs:element name="tpNFDebito" type="TTpNFDebito" minOccurs="0">
 										<xs:annotation>
-											<xs:documentation>Tipo de Nota de Débito</xs:documentation>
+											<xs:documentation>Tipo de Nota de Débito:
+01=Transferência de créditos para Cooperativas; 
+02=Anulação de Crédito por Saídas Imunes/Isentas; 
+03=Débitos de notas fiscais não processadas na apuração; 
+04=Multa e juros; 
+05=Transferência de crédito de sucessão.
+											</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element name="tpNFCredito" type="TTpNFCredito" minOccurs="0">
@@ -268,7 +274,8 @@ Campo preenchido somente quando “indPres = 5 (Operação presencial, fora do e
 1 - emissão de NF-e avulsa pelo Fisco;
 2 - emissão de NF-e avulsa, pelo contribuinte com seu certificado digital, através do site
 do Fisco;
-3- emissão de NF-e pelo contribuinte com aplicativo fornecido pelo Fisco.</xs:documentation>
+3 - emissão de NF-e pelo contribuinte com aplicativo fornecido pelo Fisco;
+4 - emissão de NF-e por Provedor de Assinatura e Autorização - PAA.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element name="verProc">
@@ -501,7 +508,7 @@ Preencher com &quot;2B&quot;, quando se tratar de Cupom Fiscal emitido por máqu
 										</xs:annotation>
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element name="refNFe" type="TChNFe" minOccurs="1" maxOccurs="99">
+												<xs:element name="refNFe" type="TChNFe" maxOccurs="99">
 													<xs:annotation>
 														<xs:documentation>Chave de acesso da NF-e de antecipação de pagamento</xs:documentation>
 													</xs:annotation>
@@ -2555,13 +2562,15 @@ ambiente.</xs:documentation>
 																					</xs:element>
 																					<xs:element name="motDesICMS">
 																						<xs:annotation>
-																							<xs:documentation>Motivo da desoneração do ICMS:3-Uso na agropecuária;9-Outros;12-Fomento agropecuário</xs:documentation>
+																							<xs:documentation>Motivo da desoneração do ICMS:3-Uso na agropecuária;9-Outros; 10=Deficiente Condutor (Convênio ICMS 38/12); 11=Deficiente Não Condutor (Convênio ICMS 38/12);  12-Fomento agropecuário</xs:documentation>
 																						</xs:annotation>
 																						<xs:simpleType>
 																							<xs:restriction base="xs:string">
 																								<xs:whiteSpace value="preserve"/>
 																								<xs:enumeration value="3"/>
 																								<xs:enumeration value="9"/>
+																								<xs:enumeration value="10"/>
+																								<xs:enumeration value="11"/>
 																								<xs:enumeration value="12"/>
 																							</xs:restriction>
 																						</xs:simpleType>
@@ -3395,11 +3404,39 @@ Informar o motivo da desoneração:
 																							<xs:documentation>Percentual de redução da BC</xs:documentation>
 																						</xs:annotation>
 																					</xs:element>
+																					<xs:element name="cBenefRBC" minOccurs="0">
+																						<xs:annotation>
+																							<xs:documentation>Código de Benefício Fiscal na UF aplicado ao item quando houver RBC.</xs:documentation>
+																						</xs:annotation>
+																						<xs:simpleType>
+																							<xs:restriction base="xs:string">
+																								<xs:whiteSpace value="preserve"/>
+																								<xs:pattern value="[!-ÿ]{8}|[!-ÿ]{10}"/>
+																							</xs:restriction>
+																						</xs:simpleType>
+																					</xs:element>
 																					<xs:element name="pICMS" type="TDec_0302a04">
 																						<xs:annotation>
 																							<xs:documentation>Alíquota do ICMS</xs:documentation>
 																						</xs:annotation>
 																					</xs:element>
+																					<xs:sequence minOccurs="0">
+																						<xs:element name="vICMSOp" type="TDec_1302">
+																							<xs:annotation>
+																								<xs:documentation>Valor do ICMS da Operação</xs:documentation>
+																							</xs:annotation>
+																						</xs:element>
+																						<xs:element name="pDif" type="TDec_0302a04Max100">
+																							<xs:annotation>
+																								<xs:documentation>Percentual do diferemento</xs:documentation>
+																							</xs:annotation>
+																						</xs:element>
+																						<xs:element name="vICMSDif" type="TDec_1302">
+																							<xs:annotation>
+																								<xs:documentation>Valor do ICMS da diferido</xs:documentation>
+																							</xs:annotation>
+																						</xs:element>
+																					</xs:sequence>
 																					<xs:element name="vICMS" type="TDec_1302">
 																						<xs:annotation>
 																							<xs:documentation>Valor do ICMS</xs:documentation>
@@ -3419,6 +3456,23 @@ Informar o motivo da desoneração:
 																						<xs:element name="vFCP" type="TDec_1302">
 																							<xs:annotation>
 																								<xs:documentation>Valor do ICMS relativo ao Fundo de Combate à Pobreza (FCP).</xs:documentation>
+																							</xs:annotation>
+																						</xs:element>
+																					</xs:sequence>
+																					<xs:sequence minOccurs="0">
+																						<xs:element name="pFCPDif" type="TDec_0302a04Opc">
+																							<xs:annotation>
+																								<xs:documentation>Percentual do diferimento do ICMS relativo ao Fundo de Combate à Pobreza (FCP).</xs:documentation>
+																							</xs:annotation>
+																						</xs:element>
+																						<xs:element name="vFCPDif" type="TDec_1302">
+																							<xs:annotation>
+																								<xs:documentation>Valor do ICMS relativo ao Fundo de Combate à Pobreza (FCP) diferido.</xs:documentation>
+																							</xs:annotation>
+																						</xs:element>
+																						<xs:element name="vFCPEfet" type="TDec_1302" minOccurs="0">
+																							<xs:annotation>
+																								<xs:documentation>Valor efetivo do ICMS relativo ao Fundo de Combate à Pobreza (FCP).</xs:documentation>
 																							</xs:annotation>
 																						</xs:element>
 																					</xs:sequence>
@@ -3569,12 +3623,14 @@ Operação interestadual para consumidor final com partilha do ICMS  devido na o
 																					<xs:annotation>
 																						<xs:documentation>Tributação pelo ICMS 
 10 - Tributada e com cobrança do ICMS por substituição tributária;
+20 – Redução de base de cálculo
 90 – Outros.</xs:documentation>
 																					</xs:annotation>
 																					<xs:simpleType>
 																						<xs:restriction base="xs:string">
 																							<xs:whiteSpace value="preserve"/>
 																							<xs:enumeration value="10"/>
+																							<xs:enumeration value="20"/>
 																							<xs:enumeration value="90"/>
 																						</xs:restriction>
 																					</xs:simpleType>
@@ -3693,6 +3749,43 @@ Operação interestadual para consumidor final com partilha do ICMS  devido na o
 																						<xs:documentation>Sigla da UF para qual é devido o ICMS ST da operação.</xs:documentation>
 																					</xs:annotation>
 																				</xs:element>
+																				<xs:sequence minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Grupo desoneração</xs:documentation>
+																					</xs:annotation>
+																					<xs:element name="vICMSDeson" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS de desoneração</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="motDesICMS">
+																						<xs:annotation>
+																							<xs:documentation>Motivo da desoneração do ICMS:9-Outros;10=Deficiente Condutor (Convênio ICMS 38/12) 11=Deficiente Não Condutor (Convênio ICMS 38/12)</xs:documentation>
+																						</xs:annotation>
+																						<xs:simpleType>
+																							<xs:restriction base="xs:string">
+																								<xs:whiteSpace value="preserve"/>
+																								<xs:enumeration value="9"/>
+																								<xs:enumeration value="10"/>
+																								<xs:enumeration value="11"/>
+																							</xs:restriction>
+																						</xs:simpleType>
+																					</xs:element>
+																					<xs:element name="indDeduzDeson" minOccurs="0">
+																						<xs:annotation>
+																							<xs:documentation>Indica se o valor do ICMS desonerado (vICMSDeson) deduz do valor do item (vProd):
+0=Valor do ICMS desonerado (vICMSDeson) não deduz do valor do item (vProd) / total da NF-e;
+1=Valor do ICMS desonerado (vICMSDeson) deduz do valor do item (vProd) / total da NF-e.</xs:documentation>
+																						</xs:annotation>
+																						<xs:simpleType>
+																							<xs:restriction base="xs:string">
+																								<xs:whiteSpace value="preserve"/>
+																								<xs:enumeration value="0"/>
+																								<xs:enumeration value="1"/>
+																							</xs:restriction>
+																						</xs:simpleType>
+																					</xs:element>
+																				</xs:sequence>
 																			</xs:sequence>
 																		</xs:complexType>
 																	</xs:element>
@@ -6481,6 +6574,40 @@ tipo de ato concessório:
 								</xs:choice>
 							</xs:complexType>
 						</xs:element>
+						<xs:element name="infPAA" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Grupo de Informação do Provedor de Assinatura e Autorização</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="CNPJPAA" type="TCnpj">
+										<xs:annotation>
+											<xs:documentation>CNPJ do Provedor de Assinatura e Autorização</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="PAASignature">
+										<xs:annotation>
+											<xs:documentation>Assinatura RSA do Emitente para DFe gerados por PAA</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="SignatureValue" type="xs:base64Binary">
+													<xs:annotation>
+														<xs:documentation>Assinatura digital padrão RSA</xs:documentation>
+														<xs:documentation>Converter o atributo Id do DFe para array de bytes e assinar com a chave privada do RSA com algoritmo SHA1 gerando um valor no formato base64.</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="RSAKeyValue" type="TRSAKeyValueType">
+													<xs:annotation>
+														<xs:documentation>Chave Publica no padrão XML RSA Key</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
 					</xs:sequence>
 					<xs:attribute name="versao" type="TVerNFe" use="required">
 						<xs:annotation>
@@ -6493,7 +6620,7 @@ tipo de ato concessório:
 						</xs:annotation>
 						<xs:simpleType>
 							<xs:restriction base="xs:ID">
-								<xs:pattern value="NFe[0-9]{44}"/>
+								<xs:pattern value="NFe[0-9]{6}[0-9A-Z]{12}[0-9]{26}"/>
 							</xs:restriction>
 						</xs:simpleType>
 					</xs:attribute>
@@ -6519,15 +6646,15 @@ tipo de ato concessório:
 									<xs:minLength value="60"/>
 									<xs:maxLength value="1000"/>
 									<!--QRCODE V1-->
-									<xs:pattern value="((HTTPS?|https?)://.*\?chNFe=[0-9]{44}&amp;nVersao=100&amp;tpAmb=[1-2](&amp;cDest=([A-Za-z0-9.:+-/)(]{0}|[A-Za-z0-9.:+-/)(]{5,20})?)?&amp;dhEmi=[A-Fa-f0-9]{50}&amp;vNF=(0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?)&amp;vICMS=(0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?)&amp;digVal=[A-Fa-f0-9]{56}&amp;cIdToken=[0-9]{6}&amp;cHashQRCode=[A-Fa-f0-9]{40})"/>
+									<xs:pattern value="((HTTPS?|https?)://.*\?chNFe=[0-9]{6}[0-9A-Z]{12}[0-9]{26}&amp;nVersao=100&amp;tpAmb=[1-2](&amp;cDest=([A-Za-z0-9.:+-/)(]{0}|[A-Za-z0-9.:+-/)(]{5,20})?)?&amp;dhEmi=[A-Fa-f0-9]{50}&amp;vNF=(0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?)&amp;vICMS=(0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?)&amp;digVal=[A-Fa-f0-9]{56}&amp;cIdToken=[0-9]{6}&amp;cHashQRCode=[A-Fa-f0-9]{40})"/>
 									<!--QRCODE V2 ONLINE-->
-									<xs:pattern value="((HTTPS?|https?)://.*\?p=([0-9]{34}(1|3|4)[0-9]{9})\|[2]\|[1-2]\|(0|[1-9]{1}([0-9]{1,5})?)\|[A-Fa-f0-9]{40})"/>
+									<xs:pattern value="((HTTPS?|https?)://.*\?p=([0-9]{6}[0-9A-Z]{12}[0-9]{16}(1|3|4)[0-9]{9})\|[2]\|[1-2]\|(0|[1-9]{1}([0-9]{1,5})?)\|[A-Fa-f0-9]{40})"/>
 									<!--QRCODE V2 OFFLINE-->
-									<xs:pattern value="((HTTPS?|https?)://.*\?p=([0-9]{34}9[0-9]{9})\|[2]\|[1-2]\|([0]{1}[1-9]{1}|[1-2]{1}[0-9]{1}|[3]{1}[0-1]{1})\|(0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?)\|[A-Fa-f0-9]{56}\|(0|[1-9]{1}([0-9]{1,5})?)\|[A-Fa-f0-9]{40})"/>
+									<xs:pattern value="((HTTPS?|https?)://.*\?p=([0-9]{6}[0-9A-Z]{12}[0-9]{16}9[0-9]{9})\|[2]\|[1-2]\|([0]{1}[1-9]{1}|[1-2]{1}[0-9]{1}|[3]{1}[0-1]{1})\|(0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?)\|[A-Fa-f0-9]{56}\|(0|[1-9]{1}([0-9]{1,5})?)\|[A-Fa-f0-9]{40})"/>
 									<!--QRCODE V3 ONLINE-->
-									<xs:pattern value="((HTTPS?|https?)://.*\?p=([0-9]{34}(1|3|4)[0-9]{9})\|[3]\|[1-2])"/>
+									<xs:pattern value="((HTTPS?|https?)://.*\?p=([0-9]{6}[0-9A-Z]{12}[0-9]{16}(1|3|4)[0-9]{9})\|[3]\|[1-2])"/>
 									<!--QRCODE V3 OFFLINE-->
-									<xs:pattern value="((HTTPS?|https?)://.*\?p=([0-9]{34}(9)[0-9]{9})\|[3]\|[1-2]\|([0]{1}[1-9]{1}|[1-2]{1}[0-9]{1}|[3]{1}[0-1]{1})\|(0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?)\|((1|2|3)?)\|(([0-9]{3,14})?)\|([a-zA-Z0-9+/]+[=]{0,2}))"/>
+									<xs:pattern value="((HTTPS?|https?)://.*\?p=([0-9]{6}[0-9A-Z]{12}[0-9]{16}(9)[0-9]{9})\|[3]\|[1-2]\|([0]{1}[1-9]{1}|[1-2]{1}[0-9]{1}|[3]{1}[0-1]{1})\|(0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?)\|((1|2|3)?)\|(([0-9]{3,14})?)\|([a-zA-Z0-9+/]+[=]{0,2}))"/>
 								</xs:restriction>
 							</xs:simpleType>
 						</xs:element>
@@ -7400,6 +7527,7 @@ alterado para tamanho variavel 1-4. (NT2011/004)</xs:documentation>
 			<xs:enumeration value="1"/>
 			<xs:enumeration value="2"/>
 			<xs:enumeration value="3"/>
+			<xs:enumeration value="4"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="TCListServ">

--- a/NFe.AppTeste/Schemas/nfe_v4.00.xsd
+++ b/NFe.AppTeste/Schemas/nfe_v4.00.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas-softwares@procergs.rs.gov.br (PROCERGS) -->
+<!-- edited with XMLSpy v2025 rel. 2 (x64) (https://www.altova.com) by PROCERGS (Procergs - Centro de Tecnologia da Informação e Comunicação do Estado do Rio Grande do Sul S.A.) -->
 <xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/nfe" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xs:include schemaLocation="leiauteNFe_v4.00.xsd"/>
 	<xs:element name="NFe" type="TNFe">

--- a/NFe.AppTeste/Schemas/tiposBasico_v1.03.xsd
+++ b/NFe.AppTeste/Schemas/tiposBasico_v1.03.xsd
@@ -68,7 +68,7 @@
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:whiteSpace value="preserve"/>
-			<xs:pattern value="[0-9]{44}"/>
+			<xs:pattern value="[0-9]{6}[0-9A-Z]{12}[0-9]{26}"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="TProt">
@@ -95,7 +95,8 @@
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:whiteSpace value="preserve"/>
-			<xs:pattern value="[0-9]{3}"/>
+			<xs:maxLength value="4"/>
+			<xs:pattern value="[0-9]{3,4}"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="TCnpj">
@@ -104,7 +105,7 @@
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:whiteSpace value="preserve"/>
-			<xs:pattern value="[0-9]{14}"/>
+			<xs:pattern value="[0-9A-Z]{12}[0-9]{2}"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="TCnpjVar">
@@ -113,7 +114,7 @@
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:whiteSpace value="preserve"/>
-			<xs:pattern value="[0-9]{3,14}"/>
+			<xs:pattern value="[0-9A-Z]{12}[0-9]{2}"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="TCnpjOpc">
@@ -123,7 +124,7 @@
 		<xs:restriction base="xs:string">
 			<xs:whiteSpace value="preserve"/>
 			<xs:maxLength value="14"/>
-			<xs:pattern value="[0-9]{0}|[0-9]{14}"/>
+			<xs:pattern value="[0-9]{0}|[0-9A-Z]{12}[0-9]{2}"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="TCpf">
@@ -903,4 +904,13 @@ acrescentado:
 			<xs:pattern value="[0-9]\.[0-9]{6}|[1-9][0-9]\.[0-9]{6}|1[0-7][0-9]\.[0-9]{6}|180\.[0-9]{6}|-[0-9]\.[0-9]{6}|-[1-9][0-9]\.[0-9]{6}|-1[0-7][0-9]\.[0-9]{6}|-180\.[0-9]{6}"/>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:complexType name="TRSAKeyValueType">
+		<xs:annotation>
+			<xs:documentation>Tipo que representa uma chave publica padrão RSA</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Modulus" type="xs:base64Binary"/>
+			<xs:element name="Exponent" type="xs:base64Binary"/>
+		</xs:sequence>
+	</xs:complexType>
 </xs:schema>

--- a/NFe.AppTeste/Schemas/tiposBasico_v4.00.xsd
+++ b/NFe.AppTeste/Schemas/tiposBasico_v4.00.xsd
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2025 rel. 2 (x64) (https://www.altova.com) by PROCERGS (Procergs - Centro de Tecnologia da Informação e Comunicação do Estado do Rio Grande do Sul S.A.) -->
 <!-- PL_008  - 30/07/2013- NT 2013/005 -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:nfe="http://www.portalfiscal.inf.br/nfe" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xs:simpleType name="TCodUfIBGE">
@@ -52,7 +53,7 @@
 		<xs:restriction base="xs:string">
 			<xs:whiteSpace value="preserve"/>
 			<xs:maxLength value="44"/>
-			<xs:pattern value="[0-9]{44}"/>
+			<xs:pattern value="[0-9]{6}[0-9A-Z]{12}[0-9]{26}"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="TProt">
@@ -92,7 +93,7 @@
 		<xs:restriction base="xs:string">
 			<xs:whiteSpace value="preserve"/>
 			<xs:maxLength value="14"/>
-			<xs:pattern value="[0-9]{14}"/>
+			<xs:pattern value="[0-9A-Z]{12}[0-9]{2}"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="TCnpjVar">
@@ -102,7 +103,7 @@
 		<xs:restriction base="xs:string">
 			<xs:whiteSpace value="preserve"/>
 			<xs:maxLength value="14"/>
-			<xs:pattern value="[0-9]{3,14}"/>
+			<xs:pattern value="[0-9A-Z]{12}[0-9]{2}"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="TCnpjOpc">
@@ -112,7 +113,7 @@
 		<xs:restriction base="xs:string">
 			<xs:whiteSpace value="preserve"/>
 			<xs:maxLength value="14"/>
-			<xs:pattern value="[0-9]{0}|[0-9]{14}"/>
+			<xs:pattern value="[0-9]{0}|[0-9A-Z]{12}[0-9]{2}"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="TCpf">
@@ -595,4 +596,13 @@
 			<xs:enumeration value="92"/>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:complexType name="TRSAKeyValueType">
+		<xs:annotation>
+			<xs:documentation>Tipo que representa uma chave publica padrão RSA</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Modulus" type="xs:base64Binary"/>
+			<xs:element name="Exponent" type="xs:base64Binary"/>
+		</xs:sequence>
+	</xs:complexType>
 </xs:schema>

--- a/NFe.Classes/Servicos/DistribuicaoDFe/Schemas/infProt.cs
+++ b/NFe.Classes/Servicos/DistribuicaoDFe/Schemas/infProt.cs
@@ -49,7 +49,6 @@ namespace NFe.Classes.Servicos.DistribuicaoDFe.Schemas
 
         public string verAplic { get; set; }
 
-        [XmlElement(DataType = "integer")]
         public string chNFe { get; set; }
 
         [XmlIgnore]

--- a/NFe.Classes/Servicos/DistribuicaoDFe/Schemas/resEvento.cs
+++ b/NFe.Classes/Servicos/DistribuicaoDFe/Schemas/resEvento.cs
@@ -59,7 +59,7 @@ namespace NFe.Classes.Servicos.DistribuicaoDFe.Schemas
         /// <summary>
         /// D04 - CNPJ do Emitente
         /// </summary>
-        public ulong CNPJ { get; set; }
+        public string CNPJ { get; set; }
 
         /// <summary>
         /// D05 - CPF do Emitente
@@ -69,7 +69,6 @@ namespace NFe.Classes.Servicos.DistribuicaoDFe.Schemas
         /// <summary>
         /// D06 - Chave de acesso da NF-e
         /// </summary>
-        [XmlElement(DataType = "integer")]
         public string chNFe { get; set; }
 
         /// <summary>

--- a/NFe.Classes/Servicos/DistribuicaoDFe/Schemas/resNFe.cs
+++ b/NFe.Classes/Servicos/DistribuicaoDFe/Schemas/resNFe.cs
@@ -53,7 +53,6 @@ namespace NFe.Classes.Servicos.DistribuicaoDFe.Schemas
         /// <summary>
         /// C03 - Chave de acesso da NF-e
         /// </summary>
-        [XmlElement(DataType = "integer")]
         public string chNFe { get; set; }
 
         /// <summary>

--- a/NFe.Danfe.Base/NFCe/NFCe.frx
+++ b/NFe.Danfe.Base/NFCe/NFCe.frx
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Report ScriptLanguage="CSharp" ReferencedAssemblies="System.dll&#13;&#10;System.Drawing.dll&#13;&#10;System.Windows.Forms.dll&#13;&#10;System.Data.dll&#13;&#10;System.Xml.dll&#13;&#10;NFe.Classes.dll&#13;&#10;DFe.Utils.dll&#13;&#10;NFe.Utils.dll&#13;&#10;NFe.Danfe.Base.dll&#13;&#10;DFe.Classes.dll" DoublePass="true" ReportInfo.Created="09/01/2015 11:27:10" ReportInfo.Modified="03/21/2024 16:39:08" ReportInfo.CreatorVersion="2017.4.3.0" PrintSettings.CopyNames="Via Consumidor&#13;&#10;Via Consumidor&#13;&#10;Via do Estabelecimento">
+<Report ScriptLanguage="CSharp" ReferencedAssemblies="System.dll&#13;&#10;System.Drawing.dll&#13;&#10;System.Windows.Forms.dll&#13;&#10;System.Data.dll&#13;&#10;System.Xml.dll&#13;&#10;NFe.Classes.dll&#13;&#10;DFe.Utils.dll&#13;&#10;NFe.Utils.dll&#13;&#10;NFe.Danfe.Base.dll&#13;&#10;DFe.Classes.dll" DoublePass="true" ReportInfo.Created="09/01/2015 11:27:10" ReportInfo.Modified="06/23/2026 16:28:01" ReportInfo.CreatorVersion="2017.4.3.0" PrintSettings.CopyNames="Via Consumidor&#13;&#10;Via Consumidor&#13;&#10;Via do Estabelecimento">
   <ScriptText>using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -45,7 +45,7 @@ namespace FastReport
     {
       var cnpj = (string)Report.GetColumnValue(&quot;NFCe.NFe.infNFe.emit.CNPJ&quot;);
       if (!string.IsNullOrEmpty(cnpj))
-        txtEmitCnpj.Text = &quot;CNPJ: &quot; + String.Format(@&quot;{0:00\.000\.000\/0000\-00}&quot;, long.Parse(cnpj));
+        txtEmitCnpj.Text = &quot;CNPJ: &quot; + FormatarCnpj(cnpj);
     }
 
     private void memChaveNfe_BeforePrint(object sender, EventArgs e)
@@ -91,7 +91,7 @@ namespace FastReport
       var cnpj = (String)Report.GetColumnValue(&quot;NFCe.NFe.infNFe.dest.CNPJ&quot;);
       var cpf = (String)Report.GetColumnValue(&quot;NFCe.NFe.infNFe.dest.CPF&quot;);
       var idEstrangeiro = (String)Report.GetColumnValue(&quot;NFCe.NFe.infNFe.dest.idEstrangeiro&quot;);
-      if ( !String.IsNullOrEmpty(cnpj)) documentoDest = &quot;CNPJ: &quot; + String.Format(@&quot;{0:00\.000\.000\/0000\-00}&quot;, long.Parse(cnpj)) + &quot; &quot;;
+      if ( !String.IsNullOrEmpty(cnpj)) documentoDest = &quot;CNPJ: &quot; + FormatarCnpj(cnpj) + &quot; &quot;;
       if ( !String.IsNullOrEmpty(cpf)) documentoDest = &quot;CPF: &quot; + String.Format(@&quot;{0:000\.000\.000\-00}&quot;, long.Parse(cpf)) + &quot; &quot;;
       if ( !String.IsNullOrEmpty(idEstrangeiro)) documentoDest = &quot;Id. Estrangeiro: &quot; + idEstrangeiro + &quot; &quot;;
       return documentoDest;
@@ -386,6 +386,13 @@ namespace FastReport
       if (nfceDetalheVendaNormalCompleto || nfceDetalheVendaContingenciaCompleto)
         txtProdutoDuasLinhasDescricaoProduto.LineHeight = txtProdutoDuasLinhasDescricaoProduto.Height; // Ajuste de espaçamento entre linhas
     }
+    
+    private string FormatarCnpj(string cnpj)
+    {
+      if (string.IsNullOrEmpty(cnpj)) return cnpj;
+      
+      return cnpj.Substring(0,2) + &quot;.&quot; + cnpj.Substring(2,3) + &quot;.&quot; + cnpj.Substring(5,3) + &quot;/&quot; + cnpj.Substring(8,4) + &quot;-&quot; + cnpj.Substring(12,2);
+  }
   }
 }</ScriptText>
   <Dictionary>
@@ -430,7 +437,7 @@ namespace FastReport
             <Column Name="indPagSpecified" DataType="System.Boolean" BindableControl="CheckBox"/>
             <Column Name="indIntermed" DataType="System.Nullable`1[[NFe.Classes.Informacoes.Identificacao.Tipos.IndicadorIntermediador, NFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]"/>
             <Column Name="indIntermedSpecified" DataType="System.Boolean" BindableControl="CheckBox"/>
-          </Column>
+            </Column>
           <Column Name="emit" DataType="NFe.Classes.Informacoes.Emitente.emit, NFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
             <Column Name="CNPJ" DataType="System.String"/>
             <Column Name="CPF" DataType="System.String"/>
@@ -577,9 +584,9 @@ namespace FastReport
               <BusinessObjectDataSource Name="BusinessObjectDataSource14" Alias="rastro" Enabled="false" DataType="System.Collections.Generic.List`1[[NFe.Classes.Informacoes.Detalhe.rastro, NFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]" PropName="rastro"/>
               <Column Name="cBarra" DataType="System.String"/>
               <Column Name="cBarraTrib" DataType="System.String"/>
-              <Column Name="cCredPresumido" DataType="System.String"/>
-              <Column Name="pCredPresumido" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
-              <Column Name="vCredPresumido" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
+                <Column Name="cCredPresumido" DataType="System.String"/>
+                <Column Name="pCredPresumido" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
+                <Column Name="vCredPresumido" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
             </Column>
             <Column Name="imposto" DataType="NFe.Classes.Informacoes.Detalhe.Tributacao.imposto, NFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
               <Column Name="vTotTrib" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
@@ -669,7 +676,7 @@ namespace FastReport
                 <Column Name="indISS" DataType="System.Nullable`1[[NFe.Classes.Informacoes.Detalhe.Tributacao.Municipal.IndicadorISS, NFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]"/>
               </Column>
               <Column Name="ICMSUFDest" Enabled="false" DataType="NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual.ICMSUFDest, NFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"/>
-            </Column>
+                    </Column>
             <Column Name="impostoDevol" DataType="NFe.Classes.Informacoes.Detalhe.impostoDevol, NFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
               <Column Name="pDevol" DataType="System.Decimal"/>
               <Column Name="IPI" DataType="NFe.Classes.Informacoes.Detalhe.IPIDevolvido, NFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
@@ -747,7 +754,7 @@ namespace FastReport
               <Column Name="vBCRetPrev" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
               <Column Name="vRetPrev" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
             </Column>
-          </Column>
+            </Column>
           <Column Name="transp" DataType="NFe.Classes.Informacoes.Transporte.transp, NFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
             <Column Name="modFrete" DataType="System.Nullable`1[[NFe.Classes.Informacoes.Transporte.ModalidadeFrete, NFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]"/>
             <Column Name="transporta" DataType="NFe.Classes.Informacoes.Transporte.transporta, NFe.Classes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">

--- a/NFe.Danfe.Base/NFCe/NFCe.frx
+++ b/NFe.Danfe.Base/NFCe/NFCe.frx
@@ -392,7 +392,7 @@ namespace FastReport
       if (string.IsNullOrEmpty(cnpj)) return cnpj;
       
       return cnpj.Substring(0,2) + &quot;.&quot; + cnpj.Substring(2,3) + &quot;.&quot; + cnpj.Substring(5,3) + &quot;/&quot; + cnpj.Substring(8,4) + &quot;-&quot; + cnpj.Substring(12,2);
-  }
+    }
   }
 }</ScriptText>
   <Dictionary>

--- a/NFe.Danfe.PdfClown/Tools/Formatador.cs
+++ b/NFe.Danfe.PdfClown/Tools/Formatador.cs
@@ -22,7 +22,7 @@ namespace NFe.Danfe.PdfClown.Tools
         public const string FormatoNumeroNF = @"000\.000\.000";
 
         public const string CEP = @"^(\d{5})\-?(\d{3})$";
-        public const string CNPJ = @"^(\d{2})\.?(\d{3})\.?(\d{3})\/?(\d{4})\-?(\d{2})$";
+        public const string CNPJ = @"^([0-9A-Z]{2})\.?([0-9A-Z]{3})\.?([0-9A-Z]{3})\/?([0-9A-Z]{4})\-?([0-9]{2})$";
         public const string CPF = @"^(\d{3})\.?(\d{3})\.?(\d{3})\-?(\d{2})$";
         public const string Telefone = @"^\(?(\d{2})\)?\s*(\d{4,5})\s*\-?\s*(\d{4})$";
 


### PR DESCRIPTION
- Atualizado schemas para o pacote: [Schemas XML NF-e 010d - CNPJ Alfanumérico - NT 2026.004.v.1.01, Eventos e ws de Consulta CCC. (Publicado em 08/06/2026)](https://www.nfe.fazenda.gov.br/portal/exibirArquivo.aspx?conteudo=FOEnx2KAsCk=);
- Ajustado relatórios de NFe/NFCe para suportar CNPJ alfanumérico;
- Ajustados campos de CNPJ que estava com tipo ulong para string;
- Ajustado campos com anotação de XML do tipo int em campos de CNPJ.