### PR TITLE
chore: atualização dos schemas da NFe/NFCe

### DIFF
--- a/NFe.AppTeste/Schemas/leiauteNFe_v4.00.xsd
+++ b/NFe.AppTeste/Schemas/leiauteNFe_v4.00.xsd
@@ -1,23 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- edited with XMLSpy v2025 rel. 2 (x64) (https://www.altova.com) by PROCERGS (Procergs - Centro de Tecnologia da Informação e Comunicação do Estado do Rio Grande do Sul S.A.) -->
-<!-- PL_009  alterações de esquema decorrentes da - NT2016.002 v1.20 - 31/05/2017 13:14hs-->
-<!-- PL_008g  alterações de esquema decorrentes da - NT2015.002  - 15/07/2015 -->
-<!-- PL_008h  alterações de esquema decorrentes da - NT2015.003 - 17/09/2015 -->
-<!-- PL_008i -->
-<!-- PL_009-v4  alterações de esquema decorrentes da - NT2016.002 - 10/2017 -->
-<!-- PL_009-v4a  alterações de esquema decorrentes da - NT2017.001 - 10/2017 -->
-<!-- PL_009-v4a  alterações de esquema decorrentes da - NT2016.002 v1.60 - 06/2018 -->
-<!-- PL_009-v4a.1  correções de esquema decorrentes da - NT2016.002 v1.60 - 06/2018 -->
-<!-- PL_009-v4a.2  adequação do campo placa para novo padrão do Mercosul - 06/2018 -->
-<!-- PL_009-v4a.3  adequação da lista TCListServ - 10/2018 -->
-<!-- PL_009-v4a.4  implementado alterações da NT 2018.005 -->
-<!-- PL_009-v4b  implementado alterações da NT 2020.006 -->
-<!-- PL_009-v5a  implementado alterações da NT  -->
-<!-- PL_009k_NT2023_001_v100 implementado alterações da NT 2023.001  -->
-<!-- PL_009l_NT2023_002_v100 - Alteração de Schema para evitar caracteres inválidos  -->
-<!-- PL_009m_NT2019_001_v155 - Inclusão de campos para Crédito Presumido e Redução da base de cálculo -->
-<!-- PL_009m_NT2023_004_v101 - Informações de Pagamentos e Outros -->
-<!-- PL_009p_NT2024_003_v103 - Produtos agropecuários -->
 <xs:schema xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:editix="http://www.portalfiscal.inf.br/nfe" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsig-core-schema_v1.01.xsd"/>
 	<xs:include schemaLocation="tiposBasico_v4.00.xsd"/>
@@ -73,10 +55,7 @@
 									</xs:element>
 									<xs:element name="serie" type="TSerie">
 										<xs:annotation>
-											<xs:documentation>Série do Documento Fiscal
-série normal 0-889
-Avulsa Fisco 890-899
-SCAN 900-999</xs:documentation>
+											<xs:documentation>Série do Documento Fiscal</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element name="nNF" type="TNF">
@@ -6654,7 +6633,7 @@ tipo de ato concessório:
 									<!--QRCODE V3 ONLINE-->
 									<xs:pattern value="((HTTPS?|https?)://.*\?p=([0-9]{6}[0-9A-Z]{12}[0-9]{16}(1|3|4)[0-9]{9})\|[3]\|[1-2])"/>
 									<!--QRCODE V3 OFFLINE-->
-									<xs:pattern value="((HTTPS?|https?)://.*\?p=([0-9]{6}[0-9A-Z]{12}[0-9]{16}(9)[0-9]{9})\|[3]\|[1-2]\|([0]{1}[1-9]{1}|[1-2]{1}[0-9]{1}|[3]{1}[0-1]{1})\|(0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?)\|((1|2|3)?)\|(([0-9]{3,14})?)\|([a-zA-Z0-9+/]+[=]{0,2}))"/>
+									<xs:pattern value="((HTTPS?|https?)://.*\?p=([0-9]{6}[0-9A-Z]{12}[0-9]{16}(9)[0-9]{9})\|[3]\|[1-2]\|([0]{1}[1-9]{1}|[1-2]{1}[0-9]{1}|[3]{1}[0-1]{1})\|(0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?)\|((1|2|3)?)\|(([0-9A-Z]{12}[0-9]{2})?)\|([a-zA-Z0-9+/]+[=]{0,2}))"/>
 								</xs:restriction>
 							</xs:simpleType>
 						</xs:element>

--- a/NFe.AppTeste/Schemas/tiposBasico_v1.03.xsd
+++ b/NFe.AppTeste/Schemas/tiposBasico_v1.03.xsd
@@ -1,13 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- PL_006u - 21/07/14 - Inclusão do tipo Básico TPlaca // v2.0-->
-<!-- PL_006u - 06/05/14 - Alterações Fuso-Horario // v2.0-->
-<!-- PL_006h - 13/05/11 - correções da NT 2011/004  // v2.0-->
-<!-- PL_006f - 29/05/10 - correcao do tipo TDec_1504 para limitar a quantidade de decimais para 4  // v2.0-->
-<!-- PL_006f - 09/05/10 - eliminação da possibilidade informar a Inscrição produtor rural na IEDest  // v2.0-->
-<!-- PL_006d - 04/10/09 - alterada a ordem do pattern do TIE - adequacao libxml  // v2.0-->
-<!-- PL_006d - 20/08/09 - acrescentado o tipo númerico com 10 casas decimais,15 casas inteiras e hora  // v2.0-->
-<!-- PL_005d - 11/08/09 - alteração no enumeration do tpais para nova tabela de paises do BACEN-->
-<!-- PL_005b - 24/10/08 - acrescentado a tabela do tpais   e outras alterações para eliminar os brancos no início e fim do campo   -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:nfe="http://www.portalfiscal.inf.br/nfe" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xs:simpleType name="TCodUfIBGE">
 		<xs:annotation>
@@ -110,7 +101,7 @@
 	</xs:simpleType>
 	<xs:simpleType name="TCnpjVar">
 		<xs:annotation>
-			<xs:documentation>Tipo Número do CNPJ tmanho varíavel (3-14)</xs:documentation>
+			<xs:documentation>Tipo Número do CNPJ</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:whiteSpace value="preserve"/>

--- a/NFe.AppTeste/Schemas/tiposBasico_v4.00.xsd
+++ b/NFe.AppTeste/Schemas/tiposBasico_v4.00.xsd
@@ -98,7 +98,7 @@
 	</xs:simpleType>
 	<xs:simpleType name="TCnpjVar">
 		<xs:annotation>
-			<xs:documentation>Tipo Número do CNPJ tmanho varíavel (3-14)</xs:documentation>
+			<xs:documentation>Tipo Número do CNPJ</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:whiteSpace value="preserve"/>


### PR DESCRIPTION
Atualizado schemas da NFe para versão do pacote [Schemas XML NF-e - 010d_v1.02- CNPJ Alfanumérico- NT 2026.004.v.1.01 - (Publicado em 26/06/2026)](https://www.nfe.fazenda.gov.br/portal/exibirArquivo.aspx?conteudo=2Ekw%200S6sY8=)